### PR TITLE
Fix typo in documentation for Flipper.register

### DIFF
--- a/lib/flipper.rb
+++ b/lib/flipper.rb
@@ -16,7 +16,7 @@ module Flipper
   #
   # Examples
   #
-  #   Flipper.registry(:admins) { |thing|
+  #   Flipper.register(:admins) { |thing|
   #     thing.respond_to?(:admin?) && thing.admin?
   #   }
   #


### PR DESCRIPTION
Simple typo fix. Nothing big.
