### PR TITLE
Use truthiness instead of true in group match?

### DIFF
--- a/lib/flipper/types/group.rb
+++ b/lib/flipper/types/group.rb
@@ -9,7 +9,7 @@ module Flipper
       end
 
       def match?(*args)
-        @block.call(*args) == true
+        @block.call(*args)
       end
 
       def value


### PR DESCRIPTION
Modify the block in the Group#match? to be truthy or not rather than
enforcing a strict comparison with true.
