### PR TITLE
[features] allow passing of blocks for conditional execution

### DIFF
--- a/lib/flipper/feature.rb
+++ b/lib/flipper/feature.rb
@@ -82,6 +82,7 @@ module Flipper
           false
         else
           payload[:gate_name] = gate.name
+          yield if block_given?
           true
         end
       }

--- a/spec/flipper/feature_spec.rb
+++ b/spec/flipper/feature_spec.rb
@@ -37,6 +37,33 @@ describe Flipper::Feature do
     end
   end
 
+  describe "#enabled?" do
+    it "should call the block when enabled" do
+      feature = described_class.new(:search, adapter)
+      block_executed = false
+      feature.enable
+
+      feature.enabled? do
+        block_executed = true
+      end
+
+      block_executed.should eq(true)
+    end
+
+    it "should not call the block when disabled" do
+      feature = described_class.new(:search, adapter)
+      block_executed = false
+      feature.disable
+
+      feature.enabled? do
+        block_executed = true
+      end
+
+      block_executed.should eq(false)
+    end
+
+  end
+
   describe "#gate_for" do
     context "with percentage of actors" do
       it "returns percentage of actors gate" do


### PR DESCRIPTION
This allows usage like:

``` ruby
Flipper[:search].enabled? do
  # ...
end
```

which is equivalent to the current syntax of:

``` ruby
if Flipper[:search].enabled?
  # ...
end
```
