### PR TITLE
Add a method to check in clean way if group exists

### DIFF
--- a/lib/flipper.rb
+++ b/lib/flipper.rb
@@ -37,6 +37,13 @@ module Flipper
     groups.clear
   end
 
+  # Public: Check if a group exists
+  #
+  # Returns boolean
+  def self.group_exists?(name)
+    self.groups.key?(name)
+  end
+
   # Internal: Fetches a group by name.
   #
   # name - The Symbol name of the group.

--- a/lib/flipper/registry.rb
+++ b/lib/flipper/registry.rb
@@ -45,11 +45,17 @@ module Flipper
 
     def get(key)
       key = key.to_sym
-
       @mutex.synchronize {
         @source.fetch(key) {
           raise KeyNotFound.new(key)
         }
+      }
+    end
+
+    def key?(key)
+      key = key.to_sym
+      @mutex.synchronize {
+        @source.has_key?(key)
       }
     end
 

--- a/spec/flipper/registry_spec.rb
+++ b/spec/flipper/registry_spec.rb
@@ -52,6 +52,20 @@ describe Flipper::Registry do
     end
   end
 
+  describe "#key?" do
+    before do
+      source[:admins] = "admins"
+    end
+
+    it "returns true if the key exists" do
+      subject.key?(:admins).should eq true
+    end
+
+    it "returns false if the key does not exists" do
+      subject.key?(:unknown_key).should eq false
+    end
+  end
+
   describe "#each" do
     before do
       source[:admins] = 'admins'

--- a/spec/flipper_spec.rb
+++ b/spec/flipper_spec.rb
@@ -8,6 +8,19 @@ describe Flipper do
     end
   end
 
+  describe ".group_exists" do
+    it "returns true if the group is already created" do
+      group = Flipper.register('admins') { |actor| actor.admin? }
+      Flipper.group_exists?(:admins).should eq(true)
+    end
+
+    it "returns false when the group is not yet registered" do
+      registry = Flipper::Registry.new
+      Flipper.groups = registry
+      Flipper.group_exists?(:non_existing).should eq(false)
+    end
+  end
+
   describe ".groups" do
     it "returns a registry instance" do
       Flipper.groups.should be_instance_of(Flipper::Registry)


### PR DESCRIPTION
**What does this PR do?**
It adds a clean interface for checking if a group exists. That way you can have code like this:

``` ruby
unless Flipper.group_exists?(:admins)
  group = Flipper.register('admins') { |actor| actor.admin? }
end
```

**Why is this PR needed?**
I didn't like the looks of having to put a resque block around `Flipper.register` to see if a group already existed. So this PR is not _needed_ put it would be nice to have it in.
