### PR TITLE
Get rid of undefined any? call on a boolean

### DIFF
--- a/lib/flipper/spec/shared_adapter_specs.rb
+++ b/lib/flipper/spec/shared_adapter_specs.rb
@@ -204,7 +204,7 @@ shared_examples_for 'a flipper adapter' do
     subject.enable(feature, actors_gate, flipper.actors(25)).should eq(true)
     subject.enable(feature, random_gate, flipper.random(45)).should eq(true)
 
-    subject.clear(feature).any?.should eq(true)
+    subject.clear(feature).should eq(true)
 
     subject.get(feature).should eq({
       :boolean => nil,
@@ -216,6 +216,6 @@ shared_examples_for 'a flipper adapter' do
   end
 
   it "does not complain clearing a feature that does not exist in adapter" do
-    subject.clear(flipper[:stats]).any?.should eq(true)
+    subject.clear(flipper[:stats]).should eq(true)
   end
 end


### PR DESCRIPTION
Looks like these `any?` calls snuck in on c96f8d02492a49d4e87c73dae8c65a3d1820b10b.

AFAICT, all adapters just return `true` from the `clear()` method, which results in an undefined method exception:

```
     Failure/Error: subject.clear(feature).any?.should eq(true)
     NoMethodError:
       undefined method `any?' for true:TrueClass
```
