### PR TITLE
add link to flipper-activerecord

### DIFF
--- a/README.md
+++ b/README.md
@@ -186,6 +186,7 @@ I plan on supporting [in-memory](https://github.com/jnunemaker/flipper/blob/mast
 * [mongo adapter](https://github.com/jnunemaker/flipper-mongo)
 * [redis adapter](https://github.com/jnunemaker/flipper-redis)
 * [cassanity adapter](https://github.com/jnunemaker/flipper-cassanity)
+* [activerecord adapter](https://github.com/bgentry/flipper-activerecord)
 
 The basic API for an adapter is this:
 


### PR DESCRIPTION
I made an ActiveRecord adapter for Flipper: https://github.com/bgentry/flipper-activerecord

At the moment, it specifically targets Rails 4.2 or higher (due to the use of foreign keys).

This PR adds a link to it in the Flipper readme.