### PR TITLE
Link to ActiveRecord 3 adapter.

### DIFF
--- a/README.md
+++ b/README.md
@@ -186,7 +186,8 @@ I plan on supporting [in-memory](https://github.com/jnunemaker/flipper/blob/mast
 * [mongo adapter](https://github.com/jnunemaker/flipper-mongo)
 * [redis adapter](https://github.com/jnunemaker/flipper-redis)
 * [cassanity adapter](https://github.com/jnunemaker/flipper-cassanity)
-* [activerecord adapter](https://github.com/bgentry/flipper-activerecord)
+* [activerecord 4 adapter](https://github.com/bgentry/flipper-activerecord)
+* [activerecord 3 adapter](https://github.com/jproudman/flipper-activerecord)
 
 The basic API for an adapter is this:
 


### PR DESCRIPTION
@bgentry prefers to keep ttps://github.com/bgentry/flipper-activerecord clean for Rails 4 (makes sense), so I've created a fork that works with Rails 3.2. Add link in the docs to that version.