### PR TITLE
Define Flipper::Instrumentation::LogSubscriber#logger

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -6,7 +6,7 @@ gem 'metriks', :require => false
 gem 'statsd-ruby', :require => false
 gem 'rspec'
 gem 'rack-test'
-gem 'activesupport', '< 4.0.0', :require => false
+gem 'activesupport', :require => false
 
 group(:guard) do
   gem 'guard'

--- a/lib/flipper/instrumentation/log_subscriber.rb
+++ b/lib/flipper/instrumentation/log_subscriber.rb
@@ -92,6 +92,10 @@ module Flipper
         name = '%s (%.1fms)' % [description, event.duration]
         debug "  #{color(name, CYAN, true)}  [ #{details} ]"
       end
+
+      def logger
+        self.class.logger
+      end
     end
   end
 


### PR DESCRIPTION
This is a workaround for a Rails bug that by default delegate the logger to ActiveSupport::LogSubscriber.

See https://github.com/jnunemaker/flipper/issues/29#issuecomment-75052342 for more information.

Fixes #29.