### PR TITLE
Make Adapters::Memory#clear conform to expectations

### DIFF
--- a/lib/flipper/adapters/memory.rb
+++ b/lib/flipper/adapters/memory.rb
@@ -40,6 +40,7 @@ module Flipper
         feature.gates.each do |gate|
           delete key(feature, gate)
         end
+        true
       end
 
       # Public


### PR DESCRIPTION
An adapter's `#clear` method is supposed to return true according to the specs.

/cc @rsanheim