### PR TITLE
Speed up Subscriber#strip_trailing_question_mark

### DIFF
--- a/lib/flipper/instrumentation/subscriber.rb
+++ b/lib/flipper/instrumentation/subscriber.rb
@@ -95,7 +95,7 @@ module Flipper
 
       # Private
       def strip_trailing_question_mark(operation)
-        operation.to_s.gsub(/\?$/, '')
+        operation.to_s.chomp('?')
       end
     end
   end


### PR DESCRIPTION
I noticed this method while profiling `Feature#enabled?`. Turns out we can speed it up without hurting readability by using `chomp` instead of `gsub`.

    $ cat bench.rb
    require 'benchmark'

    Benchmark.bm do |x|
      x.report("gsub ") { 100000.times { %w[enabled enabled?].each { |str| str.to_s.gsub(/\?$/, '') } } }
      x.report("chomp") { 100000.times { %w[enabled enabled?].each { |str| str.to_s.chomp('?') } } }
    end
    $ ruby bench.rb
           user     system      total        real
    gsub   0.270000   0.010000   0.280000 (  0.273812)
    chomp  0.070000   0.000000   0.070000 (  0.071246)

I tried a lot of other variations (`\z` instead of `$`, `gsub!`, `sub`, `sub!`, `slice`, `slice!`, `chomp!`) and this was the fastest.

I doubt this will have a big effect on Flipper's performance overall, but there doesn't seem to be much downside here.

/cc @jnunemaker @rsanheim