### PR TITLE
Remove gate instrumentation

### DIFF
--- a/lib/flipper/feature.rb
+++ b/lib/flipper/feature.rb
@@ -175,7 +175,7 @@ module Flipper
 
     # Private
     def conditional_gates(gate_values)
-      @conditional_gates ||= non_boolean_gates.select { |gate|
+      non_boolean_gates.select { |gate|
         value = gate_values[gate.key]
         gate.enabled?(value)
       }

--- a/lib/flipper/feature.rb
+++ b/lib/flipper/feature.rb
@@ -137,11 +137,11 @@ module Flipper
     # Returns an array of gates
     def gates
       @gates ||= [
-        Gates::Boolean.new(@name, :instrumenter => @instrumenter),
-        Gates::Group.new(@name, :instrumenter => @instrumenter),
-        Gates::Actor.new(@name, :instrumenter => @instrumenter),
-        Gates::PercentageOfActors.new(@name, :instrumenter => @instrumenter),
-        Gates::PercentageOfRandom.new(@name, :instrumenter => @instrumenter),
+        Gates::Boolean.new(@name),
+        Gates::Group.new(@name),
+        Gates::Actor.new(@name),
+        Gates::PercentageOfActors.new(@name),
+        Gates::PercentageOfRandom.new(@name),
       ]
     end
 

--- a/lib/flipper/gate.rb
+++ b/lib/flipper/gate.rb
@@ -1,23 +1,15 @@
 require 'forwardable'
-require 'flipper/instrumenters/noop'
 
 module Flipper
   class Gate
     extend Forwardable
 
-    # Private: The name of instrumentation events.
-    InstrumentationName = "gate_operation.#{InstrumentationNamespace}"
-
     # Private
     attr_reader :feature_name
-
-    # Private: What is used to instrument all the things.
-    attr_reader :instrumenter
 
     # Public
     def initialize(feature_name, options = {})
       @feature_name = feature_name
-      @instrumenter = options.fetch(:instrumenter, Flipper::Instrumenters::Noop)
     end
 
     # Public: The name of the gate. Implemented in subclass.
@@ -76,20 +68,6 @@ module Flipper
         "feature_name=#{feature_name.inspect}",
       ]
       "#<#{self.class.name}:#{object_id} #{attributes.join(', ')}>"
-    end
-
-    # Private
-    def instrument(operation, thing)
-      payload = {
-        :thing => thing,
-        :operation => operation,
-        :gate_name => name,
-        :feature_name => @feature_name,
-      }
-
-      @instrumenter.instrument(InstrumentationName, payload) {
-        payload[:result] = yield(payload) if block_given?
-      }
     end
   end
 end

--- a/lib/flipper/gates/actor.rb
+++ b/lib/flipper/gates/actor.rb
@@ -32,19 +32,17 @@ module Flipper
       #
       # Returns true if gate open for thing, false if not.
       def open?(thing, value)
-        instrument(:open?, thing) { |payload|
-          if thing.nil?
-            false
+        if thing.nil?
+          false
+        else
+          if protects?(thing)
+            actor = wrap(thing)
+            enabled_actor_ids = value
+            enabled_actor_ids.include?(actor.value)
           else
-            if protects?(thing)
-              actor = wrap(thing)
-              enabled_actor_ids = value
-              enabled_actor_ids.include?(actor.value)
-            else
-              false
-            end
+            false
           end
-        }
+        end
       end
 
       def wrap(thing)

--- a/lib/flipper/gates/boolean.rb
+++ b/lib/flipper/gates/boolean.rb
@@ -39,9 +39,7 @@ module Flipper
       # Returns true if explicitly set to true, false if explicitly set to false
       # or nil if not explicitly set.
       def open?(thing, value)
-        instrument(:open?, thing) { |payload|
-          !!TruthMap[value]
-        }
+        !!TruthMap[value]
       end
 
       def protects?(thing)

--- a/lib/flipper/gates/group.rb
+++ b/lib/flipper/gates/group.rb
@@ -32,20 +32,18 @@ module Flipper
       #
       # Returns true if gate open for thing, false if not.
       def open?(thing, value)
-        instrument(:open?, thing) { |payload|
-          if thing.nil?
-            false
-          else
-            value.any? { |name|
-              begin
-                group = Flipper.group(name)
-                group.match?(thing)
-              rescue GroupNotRegistered
-                false
-              end
-            }
-          end
-        }
+        if thing.nil?
+          false
+        else
+          value.any? { |name|
+            begin
+              group = Flipper.group(name)
+              group.match?(thing)
+            rescue GroupNotRegistered
+              false
+            end
+          }
+        end
       end
 
       def protects?(thing)

--- a/lib/flipper/gates/percentage_of_actors.rb
+++ b/lib/flipper/gates/percentage_of_actors.rb
@@ -33,17 +33,15 @@ module Flipper
       #
       # Returns true if gate open for thing, false if not.
       def open?(thing, value)
-        instrument(:open?, thing) { |payload|
-          percentage = value.to_i
+        percentage = value.to_i
 
-          if Types::Actor.wrappable?(thing)
-            actor = Types::Actor.wrap(thing)
-            key = "#{@feature_name}#{actor.value}"
-            Zlib.crc32(key) % 100 < percentage
-          else
-            false
-          end
-        }
+        if Types::Actor.wrappable?(thing)
+          actor = Types::Actor.wrap(thing)
+          key = "#{@feature_name}#{actor.value}"
+          Zlib.crc32(key) % 100 < percentage
+        else
+          false
+        end
       end
 
       def protects?(thing)

--- a/lib/flipper/gates/percentage_of_random.rb
+++ b/lib/flipper/gates/percentage_of_random.rb
@@ -31,11 +31,9 @@ module Flipper
       #
       # Returns true if gate open for thing, false if not.
       def open?(thing, value)
-        instrument(:open?, thing) { |payload|
-          percentage = value.to_i
+        percentage = value.to_i
 
-          rand < (percentage / 100.0)
-        }
+        rand < (percentage / 100.0)
       end
 
       def protects?(thing)

--- a/lib/flipper/instrumentation/log_subscriber.rb
+++ b/lib/flipper/instrumentation/log_subscriber.rb
@@ -65,34 +65,6 @@ module Flipper
         debug "  #{color(name, CYAN, true)}  [ #{details} ]"
       end
 
-      # Logs a gate operation.
-      #
-      # Example Output
-      #
-      #   flipper[:search].enabled?(user)
-      #   # Flipper feature(search) gate(boolean) open false (0.1ms)  [ thing=... ]
-      #   # Flipper feature(search) gate(group) open false (0.1ms)  [ thing=... ]
-      #   # Flipper feature(search) gate(actor) open false (0.1ms)  [ thing=... ]
-      #   # Flipper feature(search) gate(percentage_of_actors) open false (0.1ms)  [ thing=... ]
-      #   # Flipper feature(search) gate(percentage_of_random) open false (0.1ms)  [ thing=... ]
-      #
-      # Returns nothing.
-      def gate_operation(event)
-        return unless logger.debug?
-
-        feature_name = event.payload[:feature_name]
-        gate_name = event.payload[:gate_name]
-        operation = event.payload[:operation]
-        result = event.payload[:result]
-        thing = event.payload[:thing]
-
-        description = "Flipper feature(#{feature_name}) gate(#{gate_name}) #{operation} #{result.inspect}"
-        details = "thing=#{thing.inspect}"
-
-        name = '%s (%.1fms)' % [description, event.duration]
-        debug "  #{color(name, CYAN, true)}  [ #{details} ]"
-      end
-
       def logger
         self.class.logger
       end

--- a/lib/flipper/instrumentation/subscriber.rb
+++ b/lib/flipper/instrumentation/subscriber.rb
@@ -72,28 +72,6 @@ module Flipper
       end
 
       # Private
-      def update_gate_operation_metrics
-        feature_name = @payload[:feature_name]
-        gate_name = @payload[:gate_name]
-        operation = strip_trailing_question_mark(@payload[:operation])
-        result = @payload[:result]
-        thing = @payload[:thing]
-
-        update_timer "flipper.gate_operation.#{gate_name}.#{operation}"
-        update_timer "flipper.feature.#{feature_name}.gate_operation.#{gate_name}.#{operation}"
-
-        if @payload[:operation] == :open?
-          metric_name = if result
-            "flipper.feature.#{feature_name}.gate.#{gate_name}.open"
-          else
-            "flipper.feature.#{feature_name}.gate.#{gate_name}.closed"
-          end
-
-          update_counter metric_name
-        end
-      end
-
-      # Private
       def strip_trailing_question_mark(operation)
         operation.to_s.chomp('?')
       end

--- a/spec/flipper/feature_spec.rb
+++ b/spec/flipper/feature_spec.rb
@@ -48,13 +48,11 @@ describe Flipper::Feature do
   end
 
   describe "#gates" do
-    it "returns array of gates with each gate's instrumenter set" do
-      instrumenter = double('Instrumenter')
-      instance = described_class.new(:search, adapter, :instrumenter => instrumenter)
+    it "returns array of gates" do
+      instance = described_class.new(:search, adapter)
       instance.gates.should be_instance_of(Array)
       instance.gates.each do |gate|
         gate.should be_a(Flipper::Gate)
-        gate.instrumenter.should be(instrumenter)
       end
       instance.gates.size.should be(5)
     end

--- a/spec/flipper/gate_spec.rb
+++ b/spec/flipper/gate_spec.rb
@@ -12,17 +12,6 @@ describe Flipper::Gate do
       gate = described_class.new(feature_name)
       gate.feature_name.should be(feature_name)
     end
-
-    it "defaults instrumenter" do
-      gate = described_class.new(feature_name)
-      gate.instrumenter.should be(Flipper::Instrumenters::Noop)
-    end
-
-    it "allows overriding instrumenter" do
-      instrumenter = double('Instrumentor')
-      gate = described_class.new(feature_name, :instrumenter => instrumenter)
-      gate.instrumenter.should be(instrumenter)
-    end
   end
 
   describe "#inspect" do

--- a/spec/flipper/gates/actor_spec.rb
+++ b/spec/flipper/gates/actor_spec.rb
@@ -9,24 +9,6 @@ describe Flipper::Gates::Actor do
     described_class.new(feature_name, :instrumenter => instrumenter)
   }
 
-  describe "instrumentation" do
-    it "is recorded for open" do
-      thing = Struct.new(:flipper_id).new('22')
-      subject.open?(thing, Set.new)
-
-      event = instrumenter.events.last
-      event.should_not be_nil
-      event.name.should eq('gate_operation.flipper')
-      event.payload.should eq({
-        :thing => thing,
-        :operation => :open?,
-        :result => false,
-        :gate_name => :actor,
-        :feature_name => :search,
-      })
-    end
-  end
-
   describe "#description" do
     context "with actors in set" do
       it "returns text" do

--- a/spec/flipper/gates/boolean_spec.rb
+++ b/spec/flipper/gates/boolean_spec.rb
@@ -98,22 +98,4 @@ describe Flipper::Gates::Boolean do
       end
     end
   end
-
-  describe "instrumentation" do
-    it "is recorded for open" do
-      thing = nil
-      subject.open?(thing, false)
-
-      event = instrumenter.events.last
-      event.should_not be_nil
-      event.name.should eq('gate_operation.flipper')
-      event.payload.should eq({
-        :thing => thing,
-        :operation => :open?,
-        :result => false,
-        :gate_name => :boolean,
-        :feature_name => :search,
-      })
-    end
-  end
 end

--- a/spec/flipper/gates/group_spec.rb
+++ b/spec/flipper/gates/group_spec.rb
@@ -9,24 +9,6 @@ describe Flipper::Gates::Group do
     described_class.new(feature_name, :instrumenter => instrumenter)
   }
 
-  describe "instrumentation" do
-    it "is recorded for open" do
-      thing = Struct.new(:flipper_id).new('22')
-      subject.open?(thing, Set.new)
-
-      event = instrumenter.events.last
-      event.should_not be_nil
-      event.name.should eq('gate_operation.flipper')
-      event.payload.should eq({
-        :thing => thing,
-        :operation => :open?,
-        :result => false,
-        :gate_name => :group,
-        :feature_name => :search,
-      })
-    end
-  end
-
   describe "#description" do
     context "with groups in set" do
       it "returns text" do

--- a/spec/flipper/gates/percentage_of_actors_spec.rb
+++ b/spec/flipper/gates/percentage_of_actors_spec.rb
@@ -9,24 +9,6 @@ describe Flipper::Gates::PercentageOfActors do
     described_class.new(feature_name, :instrumenter => instrumenter)
   }
 
-  describe "instrumentation" do
-    it "is recorded for open" do
-      thing = Struct.new(:flipper_id).new('22')
-      subject.open?(thing, 0)
-
-      event = instrumenter.events.last
-      event.should_not be_nil
-      event.name.should eq('gate_operation.flipper')
-      event.payload.should eq({
-        :thing => thing,
-        :operation => :open?,
-        :result => false,
-        :gate_name => :percentage_of_actors,
-        :feature_name => :search,
-      })
-    end
-  end
-
   describe "#description" do
     context "when enabled" do
       it "returns text" do

--- a/spec/flipper/gates/percentage_of_random_spec.rb
+++ b/spec/flipper/gates/percentage_of_random_spec.rb
@@ -9,26 +9,6 @@ describe Flipper::Gates::PercentageOfRandom do
     described_class.new(feature_name, :instrumenter => instrumenter)
   }
 
-  describe "instrumentation" do
-    it "is recorded for open" do
-      thing = Struct.new(:flipper_id).new('22')
-      subject.open?(thing, 0)
-
-      event = instrumenter.events.last
-      event.should_not be_nil
-      event.name.should eq('gate_operation.flipper')
-
-      event.payload[:thing].should eq(thing)
-      event.payload[:operation].should eq(:open?)
-      event.payload[:gate_name].should eq(:percentage_of_random)
-      event.payload[:feature_name].should eq(:search)
-
-      # random so don't test value
-      event.payload.key?(:result).should eq(true)
-      event.payload[:result].should_not be_nil
-    end
-  end
-
   describe "#description" do
     context "when enabled" do
       it "returns text" do

--- a/spec/flipper/instrumentation/log_subscriber_spec.rb
+++ b/spec/flipper/instrumentation/log_subscriber_spec.rb
@@ -41,11 +41,6 @@ describe Flipper::Instrumentation::LogSubscriber do
       adapter_line.should include('[ result={')
       adapter_line.should include('} ]')
     end
-
-    it "logs gate calls" do
-      gate_line = find_line('Flipper feature(search) gate(boolean) open? false')
-      gate_line.should include('[ thing=nil ]')
-    end
   end
 
   context "feature enabled checks with a thing" do
@@ -59,11 +54,6 @@ describe Flipper::Instrumentation::LogSubscriber do
     it "logs thing for feature" do
       feature_line = find_line('Flipper feature(search) enabled?')
       feature_line.should include(user.inspect)
-    end
-
-    it "logs thing for gate" do
-      gate_line = find_line('Flipper feature(search) gate(boolean) open')
-      gate_line.should include(user.inspect)
     end
   end
 

--- a/spec/flipper/instrumentation/metriks_subscriber_spec.rb
+++ b/spec/flipper/instrumentation/metriks_subscriber_spec.rb
@@ -46,14 +46,4 @@ describe Flipper::Instrumentation::MetriksSubscriber do
     flipper[:stats].disable(user)
     Metriks.timer("flipper.adapter.memory.disable").count.should be(1)
   end
-
-  it "updates gate metrics when calls happen" do
-    flipper[:stats].enable(user)
-    flipper[:stats].enabled?(user)
-
-    Metriks.timer("flipper.gate_operation.boolean.open").count.should be(1)
-    Metriks.timer("flipper.feature.stats.gate_operation.boolean.open").count.should be(1)
-    Metriks.meter("flipper.feature.stats.gate.actor.open").count.should be(1)
-    Metriks.meter("flipper.feature.stats.gate.boolean.closed").count.should be(1)
-  end
 end

--- a/spec/flipper/instrumentation/statsd_subscriber_spec.rb
+++ b/spec/flipper/instrumentation/statsd_subscriber_spec.rb
@@ -63,14 +63,4 @@ describe Flipper::Instrumentation::StatsdSubscriber do
     flipper[:stats].disable(user)
     assert_timer 'flipper.adapter.memory.disable'
   end
-
-  it "updates gate metrics when calls happen" do
-    flipper[:stats].enable(user)
-    flipper[:stats].enabled?(user)
-
-    assert_timer 'flipper.gate_operation.boolean.open'
-    assert_timer 'flipper.feature.stats.gate_operation.boolean.open'
-    assert_counter 'flipper.feature.stats.gate.actor.open'
-    assert_counter 'flipper.feature.stats.gate.boolean.closed'
-  end
 end


### PR DESCRIPTION
This PR removes gate instrumentation. It adds some overhead due to happening per gate with multiple gates per feature and doesn't provide a ton of value currently. We can add something back when we have a better idea of what would be useful. 

cc @aroben @rsanheim 