### PR TITLE
Add thing accessor for Flipper::Types::Actor

### DIFF
--- a/lib/flipper/types/actor.rb
+++ b/lib/flipper/types/actor.rb
@@ -12,6 +12,7 @@ module Flipper
         new(thing)
       end
 
+      attr_reader :thing
       attr_reader :value
 
       def initialize(thing)

--- a/spec/flipper/types/actor_spec.rb
+++ b/spec/flipper/types/actor_spec.rb
@@ -77,6 +77,12 @@ describe Flipper::Types::Actor do
     actor.value.should eq('2')
   end
 
+  it "provides accessor to original thing" do
+    thing = thing_class.new(2)
+    actor = described_class.new(thing)
+    actor.thing.should thing
+  end
+
   it "proxies everything to thing" do
     thing = thing_class.new(10)
     actor = described_class.new(thing)

--- a/spec/flipper/types/actor_spec.rb
+++ b/spec/flipper/types/actor_spec.rb
@@ -80,7 +80,7 @@ describe Flipper::Types::Actor do
   it "provides accessor to original thing" do
     thing = thing_class.new(2)
     actor = described_class.new(thing)
-    actor.thing.should thing
+    actor.thing.should eq(thing)
   end
 
   it "proxies everything to thing" do


### PR DESCRIPTION
Right now when a gate operation happens for an actor (disable/enable), the instrumented `thing` is a `Flipper::Types::Actor` instance. You currently only have access to the `flipper_id` with `Flipper::Types::Actor#value`, but if you'd like to get specific attributes from the raw `thing` that was enabled/disabled for logging or instrumentation purpose you are unable to. You could parse the `flipper_id` and fetch the object from the DB again but that would seem unnecessary if it's already in the `thing` instance just no method available to read it.

Here is an example:

```ruby
ActiveSupport::Notifications.subscribe "feature_operation.flipper" do |name, payload_id, started_at, ended_at, payload|
  feature, operation, gate, thing = payload.values_at(:feature_name, :operation, :gate_name, :thing)
  info = {
    :feature   => feature,
    :operation => operation,
    :gate      => gate
  }

  case thing
  when Flipper::Types::Actor
    case thing.thing
    when User
      p ["User", thing.thing, info]
    end
  when Flipper::Types::Percentage
    p ["Percentage", thing.value, info]
  end
end
```

This will raise an exception because thing isn't an actual method.

/cc @jnunemaker 