### PR TITLE
Use the instrumented block's payload, not the original payload

### DIFF
--- a/lib/flipper/feature.rb
+++ b/lib/flipper/feature.rb
@@ -354,7 +354,7 @@ module Flipper
         :thing => thing,
       }
 
-      @instrumenter.instrument(InstrumentationName, payload) {
+      @instrumenter.instrument(InstrumentationName, payload) { |payload|
         payload[:result] = yield(payload) if block_given?
       }
     end
@@ -368,7 +368,7 @@ module Flipper
         :thing => thing,
       }
 
-      @instrumenter.instrument(GateInstrumentationName, payload) {
+      @instrumenter.instrument(GateInstrumentationName, payload) { |payload|
         payload[:result] = yield(payload) if block_given?
       }
     end

--- a/lib/flipper/instrumenters/memory.rb
+++ b/lib/flipper/instrumenters/memory.rb
@@ -12,6 +12,11 @@ module Flipper
       end
 
       def instrument(name, payload = {})
+        # Copy the payload to guard against later modifications to it, and to
+        # ensure that all instrumentation code uses the payload passed to the
+        # block rather than the one passed to #instrument.
+        payload = payload.dup
+
         result = if block_given?
           yield payload
         else


### PR DESCRIPTION
Some instrumentation services don't pass the original payload straight through to the block (e.g., they might copy it and add their own information to it). With those instrumenters it's important to use the payload passed to the block rather than the original payload or information added by the block might get lost.

/cc @jnunemaker @rsanheim 