### PR TITLE
Fix up gemspec

### DIFF
--- a/flipper.gemspec
+++ b/flipper.gemspec
@@ -14,4 +14,5 @@ Gem::Specification.new do |gem|
   gem.name          = "flipper"
   gem.require_paths = ["lib"]
   gem.version       = Flipper::VERSION
+  gem.licenses      = ["MIT"]
 end

--- a/flipper.gemspec
+++ b/flipper.gemspec
@@ -14,5 +14,5 @@ Gem::Specification.new do |gem|
   gem.name          = "flipper"
   gem.require_paths = ["lib"]
   gem.version       = Flipper::VERSION
-  gem.licenses      = ["MIT"]
+  gem.license       = "MIT"
 end

--- a/flipper.gemspec
+++ b/flipper.gemspec
@@ -4,7 +4,6 @@ require File.expand_path('../lib/flipper/version', __FILE__)
 Gem::Specification.new do |gem|
   gem.authors       = ["John Nunemaker"]
   gem.email         = ["nunemaker@gmail.com"]
-  gem.description   = %q{Feature flipper for any adapter}
   gem.summary       = %q{Feature flipper for any adapter}
   gem.homepage      = "http://jnunemaker.github.com/flipper"
 


### PR DESCRIPTION
Clean up some warnings when building the gem:

```
Building flipper.gemspec
WARNING:  licenses is empty, but is recommended.  Use a license abbreviation from:
http://opensource.org/licenses/alphabetical
WARNING:  description and summary are identical
WARNING:  See http://guides.rubygems.org/specification-reference/ for help
```