### PR TITLE
Allow an extra parameter to be passed to group blocks

### DIFF
--- a/lib/flipper.rb
+++ b/lib/flipper.rb
@@ -23,14 +23,14 @@ module Flipper
   # Returns a Flipper::Group.
   # Raises Flipper::DuplicateGroup if the group is already registered.
   def self.register(name, &block)
-    group = Types::Group.new(name, &block)
+    group = Group.new(name, &block)
     groups_registry.add(group.name, group)
     group
   rescue Registry::DuplicateKey
     raise DuplicateGroup, "Group #{name.inspect} has already been registered"
   end
 
-  # Public: Returns a Set of registered Types::Group instances.
+  # Public: Returns a Set of registered Group instances.
   def self.groups
     groups_registry.values.to_set
   end
@@ -88,6 +88,7 @@ require 'flipper/dsl'
 require 'flipper/errors'
 require 'flipper/feature'
 require 'flipper/gate'
+require 'flipper/group'
 require 'flipper/registry'
 require 'flipper/type'
 require 'flipper/typecast'

--- a/lib/flipper/dsl.rb
+++ b/lib/flipper/dsl.rb
@@ -183,14 +183,14 @@ module Flipper
     # Returns a Flipper::Types::Boolean instance.
     alias_method :bool, :boolean
 
-    # Public: Access a flipper group by name.
+    # Public: Shortcut for getting a group type instance.
     #
-    # name - The String or Symbol name of the feature.
+    # name - The String or Symbol name of the group.
     #
-    # Returns an instance of Flipper::Group.
+    # Returns an instance of Flipper::Types::Group.
     # Raises Flipper::GroupNotRegistered if group has not been registered.
     def group(name)
-      Flipper.group(name)
+      Types::Group.new(name)
     end
 
     # Public: Wraps an object as a flipper actor.

--- a/lib/flipper/dsl.rb
+++ b/lib/flipper/dsl.rb
@@ -186,11 +186,13 @@ module Flipper
     # Public: Shortcut for getting a group type instance.
     #
     # name - The String or Symbol name of the group.
+    # block_param - An optional String or Symbol (or other object that responds
+    #               to to_str) to be passed to the group's block.
     #
     # Returns an instance of Flipper::Types::Group.
     # Raises Flipper::GroupNotRegistered if group has not been registered.
-    def group(name)
-      Types::Group.new(name)
+    def group(name, block_param = nil)
+      Types::Group.new(name, block_param)
     end
 
     # Public: Wraps an object as a flipper actor.

--- a/lib/flipper/feature.rb
+++ b/lib/flipper/feature.rb
@@ -107,10 +107,12 @@ module Flipper
     #
     # group - a Flipper::Types::Group instance or a String or Symbol name of a
     #         registered group.
+    # block_param - an optional String or Symbol (or other object that responds
+    #               to to_str) to be passed to the group's block.
     #
     # Returns result of enable.
-    def enable_group(group)
-      enable Flipper::Types::Group.wrap(group)
+    def enable_group(group, block_param = nil)
+      enable Flipper::Types::Group.wrap(group, block_param)
     end
 
     # Public: Enables a feature a percentage of time.
@@ -147,10 +149,13 @@ module Flipper
     #
     # group - a Flipper::Types::Group instance or a String or Symbol name of a
     #         registered group.
+    # block_param - an optional String or Symbol (or other object that responds
+    #               to to_str) to be passed to the group's block. Must be the
+    #               same value that was passed to #enable_group.
     #
     # Returns result of disable.
-    def disable_group(group)
-      disable Flipper::Types::Group.wrap(group)
+    def disable_group(group, block_param = nil)
+      disable Flipper::Types::Group.wrap(group, block_param)
     end
 
     # Public: Disables a feature a percentage of time.
@@ -226,7 +231,7 @@ module Flipper
 
     # Public: Get groups enabled for this feature.
     #
-    # Returns Set of Flipper::Group instances.
+    # Returns Set of Flipper::Types::Group instances.
     def enabled_groups
       groups_value.map { |name| Flipper.group(name) }.to_set
     end
@@ -234,7 +239,7 @@ module Flipper
 
     # Public: Get groups not enabled for this feature.
     #
-    # Returns Set of Flipper::Group instances.
+    # Returns Set of Flipper::Types::Group instances.
     def disabled_groups
       Flipper.groups - enabled_groups
     end

--- a/lib/flipper/feature.rb
+++ b/lib/flipper/feature.rb
@@ -226,7 +226,7 @@ module Flipper
 
     # Public: Get groups enabled for this feature.
     #
-    # Returns Set of Flipper::Types::Group instances.
+    # Returns Set of Flipper::Group instances.
     def enabled_groups
       groups_value.map { |name| Flipper.group(name) }.to_set
     end
@@ -234,7 +234,7 @@ module Flipper
 
     # Public: Get groups not enabled for this feature.
     #
-    # Returns Set of Flipper::Types::Group instances.
+    # Returns Set of Flipper::Group instances.
     def disabled_groups
       Flipper.groups - enabled_groups
     end

--- a/lib/flipper/gates/group.rb
+++ b/lib/flipper/gates/group.rb
@@ -17,8 +17,11 @@ module Flipper
 
       def description(value)
         if enabled?(value)
-          group_names = value.to_a.sort.map { |name| name.to_sym.inspect }
-          "groups (#{group_names.join(', ')})"
+          groups = value.to_a.sort.map do |name|
+            group_name, block_param = Types::Group.hydrate(name)
+            [group_name.to_sym.inspect, block_param && block_param.inspect].compact.join(" ")
+          end
+          "groups (#{groups.join(', ')})"
         else
           'disabled'
         end
@@ -37,8 +40,9 @@ module Flipper
         else
           value.any? { |name|
             begin
-              group = Flipper.group(name)
-              group.match?(thing)
+              group_name, block_param = Types::Group.hydrate(name)
+              group = Flipper.group(group_name)
+              group.match?(thing, block_param)
             rescue GroupNotRegistered
               false
             end

--- a/lib/flipper/group.rb
+++ b/lib/flipper/group.rb
@@ -3,7 +3,12 @@ module Flipper
     attr_reader :name
 
     def initialize(name, &block)
-      @name = name.to_sym
+      name = name.to_sym
+      if name.to_s.include?(Types::Group::SEPARATOR)
+        raise ArgumentError.new("#{name.inspect} must not include #{Types::Group::SEPARATOR.inspect} characters")
+      end
+
+      @name = name
       @block = block
     end
 

--- a/lib/flipper/group.rb
+++ b/lib/flipper/group.rb
@@ -1,0 +1,14 @@
+module Flipper
+  class Group
+    attr_reader :name
+
+    def initialize(name, &block)
+      @name = name.to_sym
+      @block = block
+    end
+
+    def match?(*args)
+      @block.call(*args) == true
+    end
+  end
+end

--- a/lib/flipper/types/group.rb
+++ b/lib/flipper/types/group.rb
@@ -4,22 +4,18 @@ module Flipper
 
       def self.wrap(group_or_name)
         return group_or_name if group_or_name.is_a?(self)
-        Flipper.group(group_or_name)
+        new(group_or_name)
       end
 
-      attr_reader :name
+      attr_reader :value
 
       def initialize(name, &block)
-        @name = name.to_sym
-        @block = block
-      end
+        name = name.to_sym
 
-      def match?(*args)
-        @block.call(*args) == true
-      end
+        # Make sure there's a registered group with this name.
+        Flipper.group(name)
 
-      def value
-        @name
+        @value = name
       end
     end
   end

--- a/lib/flipper/types/group.rb
+++ b/lib/flipper/types/group.rb
@@ -1,21 +1,40 @@
 module Flipper
   module Types
     class Group < Type
+      SEPARATOR = "\x1E".freeze
 
-      def self.wrap(group_or_name)
-        return group_or_name if group_or_name.is_a?(self)
-        new(group_or_name)
+      def self.dehydrate(group_name, block_param)
+        [group_name, block_param].compact.join(SEPARATOR)
+      end
+
+      def self.hydrate(dehydrated)
+        dehydrated.to_s.split(SEPARATOR, 2)
+      end
+
+      def self.wrap(group_or_name, block_param = nil)
+        if group_or_name.is_a?(self)
+          unless block_param.nil?
+            raise ArgumentError.new("Cannot pass a Flipper::Types::Group and a block parameter")
+          end
+          group_or_name
+        else
+          new(group_or_name, block_param)
+        end
       end
 
       attr_reader :value
 
-      def initialize(name, &block)
-        name = name.to_sym
+      def initialize(group_name, block_param = nil)
+        group_name = group_name.to_sym
 
         # Make sure there's a registered group with this name.
-        Flipper.group(name)
+        Flipper.group(group_name)
 
-        @value = name
+        if block_param && !block_param.respond_to?(:to_str)
+          raise ArgumentError.new("#{block_param.inspect} must respond to to_str, but does not")
+        end
+
+        @value = self.class.dehydrate(group_name, block_param && block_param.to_str)
       end
     end
   end

--- a/spec/flipper/dsl_spec.rb
+++ b/spec/flipper/dsl_spec.rb
@@ -69,12 +69,8 @@ describe Flipper::DSL do
         @group = Flipper.register(:admins) { }
       end
 
-      it "returns group" do
-        subject.group(:admins).should eq(@group)
-      end
-
-      it "always returns same instance for same name" do
-        subject.group(:admins).should equal(subject.group(:admins))
+      it "returns group instance" do
+        subject.group(:admins).should be_instance_of(Flipper::Types::Group)
       end
     end
 

--- a/spec/flipper/feature_spec.rb
+++ b/spec/flipper/feature_spec.rb
@@ -270,9 +270,9 @@ describe Flipper::Feature do
         @preview_features = Flipper.register(:preview_features) { |thing| true }
         @not_enabled = Flipper.register(:not_enabled) { |thing| true }
         @disabled = Flipper.register(:disabled) { |thing| true }
-        subject.enable @staff
-        subject.enable @preview_features
-        subject.disable @disabled
+        subject.enable Flipper::Types::Group.new(:staff)
+        subject.enable Flipper::Types::Group.new(:preview_features)
+        subject.disable Flipper::Types::Group.new(:disabled)
       end
 
       it "returns set of enabled groups" do
@@ -309,9 +309,9 @@ describe Flipper::Feature do
         @preview_features = Flipper.register(:preview_features) { |thing| true }
         @not_enabled = Flipper.register(:not_enabled) { |thing| true }
         @disabled = Flipper.register(:disabled) { |thing| true }
-        subject.enable @staff
-        subject.enable @preview_features
-        subject.disable @disabled
+        subject.enable Flipper::Types::Group.new(:staff)
+        subject.enable Flipper::Types::Group.new(:preview_features)
+        subject.disable Flipper::Types::Group.new(:disabled)
       end
 
       it "returns set of groups that are not enabled" do
@@ -336,9 +336,9 @@ describe Flipper::Feature do
         @preview_features = Flipper.register(:preview_features) { |thing| true }
         @not_enabled = Flipper.register(:not_enabled) { |thing| true }
         @disabled = Flipper.register(:disabled) { |thing| true }
-        subject.enable @staff
-        subject.enable @preview_features
-        subject.disable @disabled
+        subject.enable Flipper::Types::Group.new(:staff)
+        subject.enable Flipper::Types::Group.new(:preview_features)
+        subject.disable Flipper::Types::Group.new(:disabled)
       end
 
       it "returns set of enabled groups" do
@@ -476,6 +476,7 @@ describe Flipper::Feature do
 
     context "with gate values set in adapter" do
       before do
+        Flipper.register(:admins) { }
         subject.enable Flipper::Types::Boolean.new(true)
         subject.enable Flipper::Types::Actor.new(Struct.new(:flipper_id).new(5))
         subject.enable Flipper::Types::Group.new(:admins)
@@ -546,9 +547,12 @@ describe Flipper::Feature do
     end
 
     context "with group instance" do
+      before do
+        Flipper.register(:five_only) { }
+      end
+
       it "updates the gate values for the group" do
-        actor = Struct.new(:flipper_id).new(5)
-        group = Flipper.register(:five_only) { |actor| actor.flipper_id == 5 }
+        group = Flipper::Types::Group.new(:five_only)
         subject.gate_values.groups.should be_empty
         subject.enable_group(group)
         subject.gate_values.groups.should eq(Set["five_only"])

--- a/spec/flipper/gates/group_spec.rb
+++ b/spec/flipper/gates/group_spec.rb
@@ -10,8 +10,8 @@ describe Flipper::Gates::Group do
   describe "#description" do
     context "with groups in set" do
       it "returns text" do
-        values = Set['bacon', 'ham']
-        subject.description(values).should eq('groups (:bacon, :ham)')
+        values = Set['bacon', 'ham', "team\x1Eadmins"]
+        subject.description(values).should eq('groups (:bacon, :ham, :team "admins")')
       end
     end
 
@@ -43,6 +43,17 @@ describe Flipper::Gates::Group do
         expect {
           subject.open?(Object.new, Set[:stinkers], feature_name: feature_name)
         }.to raise_error(NoMethodError)
+      end
+    end
+
+    context "with block parameter" do
+      before do
+        Flipper.register(:team) { |actor, team_id| actor.team_id == team_id }
+      end
+
+      it "passes the block parameter to the block" do
+        thing = Struct.new(:team_id).new("admins")
+        subject.open?(thing, Set["team\x1Eadmins"], feature_name: feature_name).should eq(true)
       end
     end
   end

--- a/spec/flipper/group_spec.rb
+++ b/spec/flipper/group_spec.rb
@@ -6,6 +6,12 @@ describe Flipper::Group do
     Flipper.register(:admins) { |actor| actor.admin? }
   end
 
+  it "does not allow names containing \\x1E" do
+    expect {
+      Flipper.register("foo\x1Ebar") { }
+    }.to raise_error(ArgumentError)
+  end
+
   describe "#name" do
     it "returns name" do
       subject.name.should eq(:admins)
@@ -22,6 +28,25 @@ describe Flipper::Group do
 
     it "returns false if block does not match" do
       subject.match?(non_admin_actor).should eq(false)
+    end
+  end
+
+  describe "with block parameter" do
+    subject do
+      Flipper.register(:team) { |actor, team_id| actor.team_id == team_id.to_i }
+    end
+
+    describe "#match?" do
+      let(:team_actor) { double('Actor', :team_id => 5) }
+      let(:non_team_actor) { double('Actor', :team_id => 6) }
+
+      it "returns true if block matches" do
+        subject.match?(team_actor, "5").should eq(true)
+      end
+
+      it "returns false if block does not match" do
+        subject.match?(non_team_actor, "5").should eq(false)
+      end
     end
   end
 end

--- a/spec/flipper/group_spec.rb
+++ b/spec/flipper/group_spec.rb
@@ -1,0 +1,27 @@
+require 'helper'
+require 'flipper/group'
+
+describe Flipper::Group do
+  subject do
+    Flipper.register(:admins) { |actor| actor.admin? }
+  end
+
+  describe "#name" do
+    it "returns name" do
+      subject.name.should eq(:admins)
+    end
+  end
+
+  describe "#match?" do
+    let(:admin_actor) { double('Actor', :admin? => true) }
+    let(:non_admin_actor) { double('Actor', :admin? => false) }
+
+    it "returns true if block matches" do
+      subject.match?(admin_actor).should eq(true)
+    end
+
+    it "returns false if block does not match" do
+      subject.match?(non_admin_actor).should eq(false)
+    end
+  end
+end

--- a/spec/flipper/types/group_spec.rb
+++ b/spec/flipper/types/group_spec.rb
@@ -2,51 +2,37 @@ require 'helper'
 require 'flipper/types/group'
 
 describe Flipper::Types::Group do
+  before do
+    Flipper.register(:admins) { }
+  end
+
   subject do
-    Flipper.register(:admins) { |actor| actor.admin? }
+    Flipper::Types::Group.new(:admins)
   end
 
   describe ".wrap" do
-    context "with group instance" do
-      it "returns group instance" do
-        described_class.wrap(subject).should eq(subject)
-      end
+    it "returns the group when passed a group" do
+      described_class.wrap(subject).should eq(subject)
     end
 
-    context "with Symbol group name" do
-      it "returns group instance" do
-        described_class.wrap(subject.name).should eq(subject)
-      end
+    it "creates a group when passed a name" do
+      described_class.wrap(:admins).should be_instance_of(described_class)
     end
 
-    context "with String group name" do
-      it "returns group instance" do
-        described_class.wrap(subject.name.to_s).should eq(subject)
-      end
+    it "raises an error when the group has not been registered" do
+      expect {
+        described_class.wrap(:early_access)
+      }.to raise_error(Flipper::GroupNotRegistered)
     end
   end
 
   it "initializes with name" do
-    group = Flipper::Types::Group.new(:admins)
-    group.should be_instance_of(Flipper::Types::Group)
+    subject.should be_instance_of(Flipper::Types::Group)
   end
 
-  describe "#name" do
-    it "returns name" do
-      subject.name.should eq(:admins)
-    end
-  end
-
-  describe "#match?" do
-    let(:admin_actor) { double('Actor', :admin? => true) }
-    let(:non_admin_actor) { double('Actor', :admin? => false) }
-
-    it "returns true if block matches" do
-      subject.match?(admin_actor).should eq(true)
-    end
-
-    it "returns false if block does not match" do
-      subject.match?(non_admin_actor).should eq(false)
-    end
+  it "raises an error when the group has not been registered" do
+    expect {
+      described_class.new(:early_access)
+    }.to raise_error(Flipper::GroupNotRegistered)
   end
 end

--- a/spec/flipper/types/group_spec.rb
+++ b/spec/flipper/types/group_spec.rb
@@ -19,10 +19,54 @@ describe Flipper::Types::Group do
       described_class.wrap(:admins).should be_instance_of(described_class)
     end
 
+    it "creates a group when passed a name and block parameter" do
+      described_class.wrap(:admins, "5").should be_instance_of(described_class)
+    end
+
     it "raises an error when the group has not been registered" do
       expect {
         described_class.wrap(:early_access)
       }.to raise_error(Flipper::GroupNotRegistered)
+    end
+
+    it "raises an error when passed a group and backing object" do
+      expect {
+        described_class.wrap(subject, "5")
+      }.to raise_error(ArgumentError)
+    end
+  end
+
+  describe ".dehydrate" do
+    context "with a block parameter" do
+      it "combines name and block parameter into a string" do
+        described_class.dehydrate("admins", "5").should eq("admins\x1E5")
+      end
+    end
+
+    context "without a block parameter" do
+      it "returns the name" do
+        described_class.dehydrate("admins", nil).should eq("admins")
+      end
+    end
+  end
+
+  describe ".hydrate" do
+    context "with a block parameter" do
+      it "returns the name and block parameter as strings" do
+        described_class.hydrate("admins\x1E5").should eq(["admins", "5"])
+      end
+    end
+
+    context "without a block parameter" do
+      it "returns the name" do
+        described_class.hydrate("admins").should eq(["admins"])
+      end
+    end
+
+    context "when passed a symbol" do
+      it "returns the name and block parameter as strings" do
+        described_class.hydrate("admins\x1E5".to_sym).should eq(["admins", "5"])
+      end
     end
   end
 
@@ -34,5 +78,19 @@ describe Flipper::Types::Group do
     expect {
       described_class.new(:early_access)
     }.to raise_error(Flipper::GroupNotRegistered)
+  end
+
+  context "with a block parameter" do
+    subject { described_class.new(:admins, Struct.new(:to_str).new("5")) }
+
+    it "combines name and object ID into the value" do
+      subject.value.should eq("admins\x1E5")
+    end
+
+    it "raises an error if block parameter does not respond to to_str" do
+      expect {
+        described_class.new(:admins, Hash.new)
+      }.to raise_error(ArgumentError)
+    end
   end
 end


### PR DESCRIPTION
Methods that took a group name now take an optional block parameter, which is passed through to the group's block. This can be used, e.g., to implement dynamic groups based on a database. Here's how it looks:

```ruby
Flipper.register(:team) do |actor, team_id|
  Team.find(team_id).members.include?(actor)
end

$flipper[:my_feature].enable $flipper.group(:team, Team.by_name("admins").id.to_s)
```

The block parameter must be convertible to a String via `#to_str`.

Fixes https://github.com/jnunemaker/flipper/issues/50

/cc @rsanheim @jnunemaker 