### PR TITLE
Ax description

### DIFF
--- a/lib/flipper/feature.rb
+++ b/lib/flipper/feature.rb
@@ -265,11 +265,25 @@ module Flipper
       gates.select { |gate| gate.enabled?(values[gate.key]) }
     end
 
+    # Public: Get the names of the enabled gates.
+    #
+    # Returns an Array of gate names.
+    def enabled_gate_names
+      enabled_gates.map(&:name)
+    end
+
     # Public: Get the gates that have not been enabled for the feature.
     #
     # Returns an Array of Flipper::Gate instances.
     def disabled_gates
       gates - enabled_gates
+    end
+
+    # Public: Get the names of the disabled gates.
+    #
+    # Returns an Array of gate names.
+    def disabled_gate_names
+      disabled_gates.map(&:name)
     end
 
     # Public: Returns the string representation of the feature.
@@ -287,6 +301,7 @@ module Flipper
       attributes = [
         "name=#{name.inspect}",
         "state=#{state.inspect}",
+        "enabled_gate_names=#{enabled_gate_names.inspect}",
         "adapter=#{adapter.name.inspect}",
       ]
       "#<#{self.class.name}:#{object_id} #{attributes.join(', ')}>"

--- a/lib/flipper/feature.rb
+++ b/lib/flipper/feature.rb
@@ -177,7 +177,7 @@ module Flipper
     def state
       values = gate_values
 
-      if boolean_gate.enabled?(values.boolean)
+      if gate(:boolean).enabled?(values.boolean)
         :on
       elsif conditional_gates(values).any?
         :conditional
@@ -200,23 +200,6 @@ module Flipper
     # percentage of actors or percentage of the time.
     def conditional?
       state == :conditional
-    end
-
-    # Public: Human readable description of the enabled-ness of the feature.
-    def description
-      values = gate_values
-      conditional_gates = conditional_gates(values)
-
-      if boolean_gate.enabled?(values.boolean) || !conditional_gates.any?
-        boolean_gate.description(values.boolean).capitalize
-      else
-        fragments = conditional_gates.map { |gate|
-          value = values[gate.key]
-          gate.description(value)
-        }
-
-        "Enabled for #{fragments.join(', ')}"
-      end
     end
 
     # Public: Returns the raw gate values stored by the adapter.
@@ -289,7 +272,6 @@ module Flipper
       attributes = [
         "name=#{name.inspect}",
         "state=#{state.inspect}",
-        "description=#{description.inspect}",
         "adapter=#{adapter.name.inspect}",
       ]
       "#<#{self.class.name}:#{object_id} #{attributes.join(', ')}>"
@@ -328,19 +310,9 @@ module Flipper
 
     private
 
-    # Private: Get the boolean gate.
-    def boolean_gate
-      @boolean_gate ||= gate(:boolean)
-    end
-
-    # Private: Get all gates except the boolean gate.
-    def non_boolean_gates
-      @non_boolean_gates ||= gates - [boolean_gate]
-    end
-
     # Private: Get all non boolean gates that are enabled in some way.
     def conditional_gates(gate_values)
-      non_boolean_gates.select { |gate|
+      (gates - [gate(:boolean)]).select { |gate|
         value = gate_values[gate.key]
         gate.enabled?(value)
       }

--- a/lib/flipper/gate.rb
+++ b/lib/flipper/gate.rb
@@ -26,10 +26,6 @@ module Flipper
       raise 'Not implemented'
     end
 
-    def description(value)
-      raise 'Not implemented'
-    end
-
     # Internal: Check if a gate is open for a thing. Implemented in subclass.
     #
     # Returns true if gate open for thing, false if not.

--- a/lib/flipper/gates/actor.rb
+++ b/lib/flipper/gates/actor.rb
@@ -15,15 +15,6 @@ module Flipper
         :set
       end
 
-      def description(value)
-        if enabled?(value)
-          actor_ids = value.to_a.sort.map { |id| id.inspect }
-          "actors (#{actor_ids.join(', ')})"
-        else
-          'disabled'
-        end
-      end
-
       def enabled?(value)
         !Typecast.to_set(value).empty?
       end

--- a/lib/flipper/gates/boolean.rb
+++ b/lib/flipper/gates/boolean.rb
@@ -15,14 +15,6 @@ module Flipper
         :boolean
       end
 
-      def description(value)
-        if enabled?(value)
-          'Enabled'
-        else
-          'Disabled'
-        end
-      end
-
       def enabled?(value)
         Typecast.to_boolean(value)
       end

--- a/lib/flipper/gates/group.rb
+++ b/lib/flipper/gates/group.rb
@@ -15,15 +15,6 @@ module Flipper
         :set
       end
 
-      def description(value)
-        if enabled?(value)
-          group_names = value.to_a.sort.map { |name| name.to_sym.inspect }
-          "groups (#{group_names.join(', ')})"
-        else
-          'disabled'
-        end
-      end
-
       def enabled?(value)
         !Typecast.to_set(value).empty?
       end

--- a/lib/flipper/gates/percentage_of_actors.rb
+++ b/lib/flipper/gates/percentage_of_actors.rb
@@ -17,14 +17,6 @@ module Flipper
         :integer
       end
 
-      def description(value)
-        if enabled?(value)
-          "#{value}% of actors"
-        else
-          'disabled'
-        end
-      end
-
       def enabled?(value)
         Typecast.to_integer(value) > 0
       end

--- a/lib/flipper/gates/percentage_of_time.rb
+++ b/lib/flipper/gates/percentage_of_time.rb
@@ -15,14 +15,6 @@ module Flipper
         :integer
       end
 
-      def description(value)
-        if enabled?(value)
-          "#{value}% of the time"
-        else
-          'disabled'
-        end
-      end
-
       def enabled?(value)
         Typecast.to_integer(value) > 0
       end

--- a/spec/flipper/feature_spec.rb
+++ b/spec/flipper/feature_spec.rb
@@ -97,7 +97,13 @@ describe Flipper::Feature do
       string.should include('Flipper::Feature')
       string.should include('name=:search')
       string.should include('state=:off')
+      string.should include('enabled_gate_names=[]')
       string.should include("adapter=#{subject.adapter.name.inspect}")
+
+      subject.enable
+      string = subject.inspect
+      string.should include('state=:on')
+      string.should include('enabled_gate_names=[:boolean]')
     end
   end
 
@@ -596,17 +602,28 @@ describe Flipper::Feature do
     end
 
     it "can return enabled gates" do
-      subject.enabled_gates.map(&:key).to_set.should eq(Set[
+      subject.enabled_gates.map(&:name).to_set.should eq(Set[
+        :percentage_of_actors,
+        :percentage_of_time,
+      ])
+
+      subject.enabled_gate_names.to_set.should eq(Set[
         :percentage_of_actors,
         :percentage_of_time,
       ])
     end
 
     it "can return disabled gates" do
-      subject.disabled_gates.map(&:key).to_set.should eq(Set[
-        :actors,
+      subject.disabled_gates.map(&:name).to_set.should eq(Set[
+        :actor,
         :boolean,
-        :groups,
+        :group,
+      ])
+
+      subject.disabled_gate_names.to_set.should eq(Set[
+        :actor,
+        :boolean,
+        :group,
       ])
     end
   end

--- a/spec/flipper/feature_spec.rb
+++ b/spec/flipper/feature_spec.rb
@@ -97,7 +97,6 @@ describe Flipper::Feature do
       string.should include('Flipper::Feature')
       string.should include('name=:search')
       string.should include('state=:off')
-      string.should include('description="Disabled"')
       string.should include("adapter=#{subject.adapter.name.inspect}")
     end
   end
@@ -219,40 +218,6 @@ describe Flipper::Feature do
 
       it "returns true for conditional?" do
         subject.conditional?.should be(true)
-      end
-    end
-  end
-
-  describe "#description" do
-    context "fully on" do
-      before do
-        subject.enable
-      end
-
-      it "returns enabled" do
-        subject.description.should eq('Enabled')
-      end
-    end
-
-    context "fully off" do
-      before do
-        subject.disable
-      end
-
-      it "returns disabled" do
-        subject.description.should eq('Disabled')
-      end
-    end
-
-    context "partially on" do
-      before do
-        actor = Struct.new(:flipper_id).new(5)
-        subject.enable Flipper::Types::PercentageOfTime.new(5)
-        subject.enable actor
-      end
-
-      it "returns text" do
-        subject.description.should eq('Enabled for actors ("5"), 5% of the time')
       end
     end
   end

--- a/spec/flipper/gates/actor_spec.rb
+++ b/spec/flipper/gates/actor_spec.rb
@@ -6,19 +6,4 @@ describe Flipper::Gates::Actor do
   subject {
     described_class.new
   }
-
-  describe "#description" do
-    context "with actors in set" do
-      it "returns text" do
-        values = Set['bacon', 'ham']
-        subject.description(values).should eq('actors ("bacon", "ham")')
-      end
-    end
-
-    context "with no actors in set" do
-      it "returns disabled" do
-        subject.description(Set.new).should eq('disabled')
-      end
-    end
-  end
 end

--- a/spec/flipper/gates/boolean_spec.rb
+++ b/spec/flipper/gates/boolean_spec.rb
@@ -7,20 +7,6 @@ describe Flipper::Gates::Boolean do
     described_class.new
   }
 
-  describe "#description" do
-    context "for enabled" do
-      it "returns Enabled" do
-        subject.description(true).should eq('Enabled')
-      end
-    end
-
-    context "for disabled" do
-      it "returns Disabled" do
-        subject.description(false).should eq('Disabled')
-      end
-    end
-  end
-
   describe "#enabled?" do
     context "for true value" do
       it "returns true" do

--- a/spec/flipper/gates/group_spec.rb
+++ b/spec/flipper/gates/group_spec.rb
@@ -7,21 +7,6 @@ describe Flipper::Gates::Group do
     described_class.new
   }
 
-  describe "#description" do
-    context "with groups in set" do
-      it "returns text" do
-        values = Set['bacon', 'ham']
-        subject.description(values).should eq('groups (:bacon, :ham)')
-      end
-    end
-
-    context "with no groups in set" do
-      it "returns disabled" do
-        subject.description(Set.new).should eq('disabled')
-      end
-    end
-  end
-
   describe "#open?" do
     context "with a group in adapter, but not registered" do
       before do

--- a/spec/flipper/gates/percentage_of_actors_spec.rb
+++ b/spec/flipper/gates/percentage_of_actors_spec.rb
@@ -7,20 +7,6 @@ describe Flipper::Gates::PercentageOfActors do
     described_class.new
   }
 
-  describe "#description" do
-    context "when enabled" do
-      it "returns text" do
-        subject.description(22).should eq('22% of actors')
-      end
-    end
-
-    context "when disabled" do
-      it "returns disabled" do
-        subject.description(0).should eq('disabled')
-      end
-    end
-  end
-
   describe "#open?" do
     context "when compared against two features" do
       let(:percentage) { 0.05 }

--- a/spec/flipper/gates/percentage_of_time_spec.rb
+++ b/spec/flipper/gates/percentage_of_time_spec.rb
@@ -6,18 +6,4 @@ describe Flipper::Gates::PercentageOfTime do
   subject {
     described_class.new
   }
-
-  describe "#description" do
-    context "when enabled" do
-      it "returns text" do
-        subject.description(22).should eq('22% of the time')
-      end
-    end
-
-    context "when disabled" do
-      it "returns disabled" do
-        subject.description(0).should eq('disabled')
-      end
-    end
-  end
 end


### PR DESCRIPTION
I found it confusing. Sometimes it would say enabled for 15% of actors, 15% of the time which meant 15% of actors and 15% of time but looked like 15% of actors 15% of the time.

Additionally, I’d like to make description available as a user defined thing describing what the feature is used for.

Fixes #56 