### PR TITLE
Always instrument flipper type

### DIFF
--- a/lib/flipper/gates/group.rb
+++ b/lib/flipper/gates/group.rb
@@ -42,7 +42,7 @@ module Flipper
       end
 
       def protects?(thing)
-        thing.is_a?(Types::Group)
+        thing.is_a?(Types::Group) || thing.is_a?(Symbol)
       end
     end
   end

--- a/lib/flipper/gates/group.rb
+++ b/lib/flipper/gates/group.rb
@@ -37,6 +37,10 @@ module Flipper
         end
       end
 
+      def wrap(thing)
+        Types::Group.wrap(thing)
+      end
+
       def protects?(thing)
         thing.is_a?(Types::Group)
       end

--- a/lib/flipper/types/actor.rb
+++ b/lib/flipper/types/actor.rb
@@ -6,6 +6,8 @@ module Flipper
         thing.respond_to?(:flipper_id)
       end
 
+      attr_reader :thing
+
       def initialize(thing)
         if thing.nil?
           raise ArgumentError.new("thing cannot be nil")

--- a/spec/flipper/feature_spec.rb
+++ b/spec/flipper/feature_spec.rb
@@ -169,6 +169,7 @@ describe Flipper::Feature do
       false => boolean_false,
       boolean_true => boolean_true,
       boolean_false => boolean_false,
+      :admins => group,
       group => group,
       percentage_of_time => percentage_of_time,
       percentage_of_actors => percentage_of_actors,

--- a/spec/flipper/feature_spec.rb
+++ b/spec/flipper/feature_spec.rb
@@ -115,7 +115,7 @@ describe Flipper::Feature do
     }
 
     it "is recorded for enable" do
-      thing = Flipper::Types::Boolean.new
+      thing = Flipper::Types::Actor.new(Struct.new(:flipper_id).new("1"))
       gate = subject.gate_for(thing)
 
       subject.enable(thing)
@@ -127,6 +127,17 @@ describe Flipper::Feature do
       event.payload[:operation].should eq(:enable)
       event.payload[:thing].should eq(thing)
       event.payload[:result].should_not be_nil
+    end
+
+    it "always instruments flipper type instance for enable" do
+      thing = Struct.new(:flipper_id).new("1")
+      gate = subject.gate_for(thing)
+
+      subject.enable(thing)
+
+      event = instrumenter.events.last
+      event.should_not be_nil
+      event.payload[:thing].should eq(Flipper::Types::Actor.new(thing))
     end
 
     it "is recorded for disable" do
@@ -144,8 +155,49 @@ describe Flipper::Feature do
       event.payload[:result].should_not be_nil
     end
 
+    user = Struct.new(:flipper_id).new("1")
+    actor = Flipper::Types::Actor.new(user)
+    boolean_true = Flipper::Types::Boolean.new(true)
+    boolean_false = Flipper::Types::Boolean.new(false)
+    group = Flipper::Types::Group.new(:admins)
+    percentage_of_time = Flipper::Types::PercentageOfTime.new(10)
+    percentage_of_actors = Flipper::Types::PercentageOfActors.new(10)
+    {
+      user => actor,
+      actor => actor,
+      true => boolean_true,
+      false => boolean_false,
+      boolean_true => boolean_true,
+      boolean_false => boolean_false,
+      group => group,
+      percentage_of_time => percentage_of_time,
+      percentage_of_actors => percentage_of_actors,
+    }.each do |thing, wrapped_thing|
+      it "always instruments #{thing.inspect} as #{wrapped_thing.class} for enable" do
+        Flipper.register(:admins) {}
+        subject.enable(thing)
+
+        event = instrumenter.events.last
+        event.should_not be_nil
+        event.payload[:operation].should eq(:enable)
+        event.payload[:thing].should eq(wrapped_thing)
+      end
+    end
+
+    it "always instruments flipper type instance for disable" do
+      thing = Struct.new(:flipper_id).new("1")
+      gate = subject.gate_for(thing)
+
+      subject.disable(thing)
+
+      event = instrumenter.events.last
+      event.should_not be_nil
+      event.payload[:operation].should eq(:disable)
+      event.payload[:thing].should eq(Flipper::Types::Actor.new(thing))
+    end
+
     it "is recorded for enabled?" do
-      thing = Flipper::Types::Boolean.new
+      thing = Flipper::Types::Actor.new(Struct.new(:flipper_id).new("1"))
       gate = subject.gate_for(thing)
 
       subject.enabled?(thing)
@@ -157,6 +209,23 @@ describe Flipper::Feature do
       event.payload[:operation].should eq(:enabled?)
       event.payload[:thing].should eq(thing)
       event.payload[:result].should eq(false)
+    end
+
+    user = Struct.new(:flipper_id).new("1")
+    actor = Flipper::Types::Actor.new(user)
+    {
+      nil => nil,
+      user => actor,
+      actor => actor,
+    }.each do |thing, wrapped_thing|
+      it "always instruments #{thing.inspect} as #{wrapped_thing.class} for enabled?" do
+        subject.enabled?(thing)
+
+        event = instrumenter.events.last
+        event.should_not be_nil
+        event.payload[:operation].should eq(:enabled?)
+        event.payload[:thing].should eq(wrapped_thing)
+      end
     end
   end
 

--- a/spec/flipper/gates/group_spec.rb
+++ b/spec/flipper/gates/group_spec.rb
@@ -31,4 +31,23 @@ describe Flipper::Gates::Group do
       end
     end
   end
+
+  describe "#wrap" do
+    it "returns group instance for symbol" do
+      group = Flipper.register(:admins) {}
+      subject.wrap(:admins).should eq(group)
+    end
+
+    it "returns group instance for group instance" do
+      group = Flipper.register(:admins) {}
+      subject.wrap(group).should eq(group)
+    end
+  end
+
+  describe "#protects?" do
+    it "returns true for group" do
+      group = Flipper.register(:admins) {}
+      subject.protects?(group).should be(true)
+    end
+  end
 end

--- a/spec/flipper/gates/group_spec.rb
+++ b/spec/flipper/gates/group_spec.rb
@@ -49,5 +49,9 @@ describe Flipper::Gates::Group do
       group = Flipper.register(:admins) {}
       subject.protects?(group).should be(true)
     end
+
+    it "returns true for symbol" do
+      subject.protects?(:admins).should be(true)
+    end
   end
 end

--- a/spec/flipper/instrumentation/log_subscriber_spec.rb
+++ b/spec/flipper/instrumentation/log_subscriber_spec.rb
@@ -50,7 +50,7 @@ describe Flipper::Instrumentation::LogSubscriber do
   end
 
   context "feature enabled checks with a thing" do
-    let(:user) { Struct.new(:flipper_id).new('1') }
+    let(:user) { Flipper::Types::Actor.new(Struct.new(:flipper_id).new('1')) }
 
     before do
       clear_logs
@@ -69,7 +69,7 @@ describe Flipper::Instrumentation::LogSubscriber do
   end
 
   context "changing feature enabled state" do
-    let(:user) { Struct.new(:flipper_id).new('1') }
+    let(:user) { Flipper::Types::Actor.new(Struct.new(:flipper_id).new('1')) }
 
     before do
       clear_logs

--- a/spec/flipper/types/actor_spec.rb
+++ b/spec/flipper/types/actor_spec.rb
@@ -87,6 +87,12 @@ describe Flipper::Types::Actor do
     actor.admin?.should eq(true)
   end
 
+  it "exposes thing" do
+    thing = thing_class.new(10)
+    actor = described_class.new(thing)
+    actor.thing.should be(thing)
+  end
+
   describe "#respond_to?" do
     it "returns true if responds to method" do
       thing = thing_class.new('1')


### PR DESCRIPTION
It was split before based on what method you called and what you passed in. Now it always instruments a flipper type for consistency sake.