### PR TITLE
adding an example of namespacing for the redis adapter

### DIFF
--- a/examples/redis/namespaced.rb
+++ b/examples/redis/namespaced.rb
@@ -1,0 +1,48 @@
+require 'pp'
+require 'pathname'
+require 'logger'
+begin
+  require 'redis-namespace'
+rescue LoadError
+  puts 'you must have redis-namespace gem installed'
+  exit 1
+end
+
+root_path = Pathname(__FILE__).dirname.join('..').expand_path
+lib_path  = root_path.join('lib')
+$:.unshift(lib_path)
+
+require 'flipper/adapters/redis'
+options = {url: 'redis://127.0.0.1:6379'}
+if ENV['BOXEN_REDIS_URL']
+  options[:url] = ENV['BOXEN_REDIS_URL']
+end
+client = Redis.new(options)
+namespaced_client = Redis::Namespace.new(:flipper_namespace, redis: client)
+adapter = Flipper::Adapters::Redis.new(namespaced_client)
+flipper = Flipper.new(adapter)
+
+# Register a few groups.
+Flipper.register(:admins) { |thing| thing.admin? }
+Flipper.register(:early_access) { |thing| thing.early_access? }
+
+# Create a user class that has flipper_id instance method.
+User = Struct.new(:flipper_id)
+
+flipper[:stats].enable
+flipper[:stats].enable_group :admins
+flipper[:stats].enable_group :early_access
+flipper[:stats].enable_actor User.new('25')
+flipper[:stats].enable_actor User.new('90')
+flipper[:stats].enable_actor User.new('180')
+flipper[:stats].enable_percentage_of_time 15
+flipper[:stats].enable_percentage_of_actors 45
+
+flipper[:search].enable
+
+print 'all keys: '
+pp client.keys
+# all keys: ["stats", "flipper_features", "search"]
+puts
+
+puts 'notice how all the keys are namespaced'


### PR DESCRIPTION
It took me a while to realize that the way to namespace a redis adapter is to pass in a namespaced redis object as the client. I should have read the comment earlier but it took me a while to find. I created this example so that hopefully it would help other people realize how to do this quicker and also have an example to go off.