### PR TITLE
Add optional env vars to connect with mongodb

### DIFF
--- a/spec/flipper/adapters/mongo_spec.rb
+++ b/spec/flipper/adapters/mongo_spec.rb
@@ -5,8 +5,11 @@ require 'flipper/spec/shared_adapter_specs'
 Mongo::Logger.logger.level = Logger::INFO
 
 describe Flipper::Adapters::Mongo do
+  let(:host) { ENV["BOXEN_MONGODB_HOST"] || '127.0.0.1' }
+  let(:port) { ENV["BOXEN_MONGODB_PORT"] || 27017 }
+
   let(:collection) {
-    Mongo::Client.new(["127.0.0.1:#{ENV["BOXEN_MONGODB_PORT"] || 27017}"], :database => 'testing')['testing']
+    Mongo::Client.new(["#{host}:#{port}"], :database => 'testing')['testing']
   }
 
   subject { described_class.new(collection) }


### PR DESCRIPTION
Hi!

I was struggling to run the specs due my mongodb is running in a specific host, so I did something similar to the Redis adapter spec.

So to run the specs you can execute:
```
BOXEN_MONGODB_HOST=my_mongodb_host bundle exec rspec
```

Thanks!