### PR TITLE
Rspec3 syntax

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -10,7 +10,7 @@ gem 'rake', '~> 10.4.2'
 gem 'metriks', '~> 0.9.9'
 gem 'shotgun', '~> 0.9'
 gem 'statsd-ruby', '~> 1.2.1'
-gem 'rspec', '~> 2.14'
+gem 'rspec', '~> 3.0'
 gem 'rack-test', '~> 0.6.3'
 gem 'activesupport', '~> 4.2.0'
 

--- a/lib/flipper/spec/shared_adapter_specs.rb
+++ b/lib/flipper/spec/shared_adapter_specs.rb
@@ -27,16 +27,16 @@ shared_examples_for 'a flipper adapter' do
   end
 
   it "has name that is a symbol" do
-    subject.name.should_not be_nil
-    subject.name.should be_instance_of(Symbol)
+    expect(subject.name).to_not be_nil
+    expect(subject.name).to be_instance_of(Symbol)
   end
 
   it "has included the flipper adapter module" do
-    subject.class.ancestors.should include(Flipper::Adapter)
+    expect(subject.class.ancestors).to include(Flipper::Adapter)
   end
 
   it "returns correct default values for the gates if none are enabled" do
-    subject.get(feature).should eq({
+    expect(subject.get(feature)).to eq({
       :boolean => nil,
       :groups => Set.new,
       :actors => Set.new,
@@ -46,28 +46,28 @@ shared_examples_for 'a flipper adapter' do
   end
 
   it "can enable, disable and get value for boolean gate" do
-    subject.enable(feature, boolean_gate, flipper.boolean).should eq(true)
+    expect(subject.enable(feature, boolean_gate, flipper.boolean)).to eq(true)
 
     result = subject.get(feature)
-    result[:boolean].should eq('true')
+    expect(result[:boolean]).to eq('true')
 
-    subject.disable(feature, boolean_gate, flipper.boolean(false)).should eq(true)
+    expect(subject.disable(feature, boolean_gate, flipper.boolean(false))).to eq(true)
 
     result = subject.get(feature)
-    result[:boolean].should eq(nil)
+    expect(result[:boolean]).to eq(nil)
   end
 
   it "fully disables all enabled things when boolean gate disabled" do
     actor_22 = actor_class.new('22')
-    subject.enable(feature, boolean_gate, flipper.boolean).should eq(true)
-    subject.enable(feature, group_gate, flipper.group(:admins)).should eq(true)
-    subject.enable(feature, actor_gate, flipper.actor(actor_22)).should eq(true)
-    subject.enable(feature, actors_gate, flipper.actors(25)).should eq(true)
-    subject.enable(feature, time_gate, flipper.time(45)).should eq(true)
+    expect(subject.enable(feature, boolean_gate, flipper.boolean)).to eq(true)
+    expect(subject.enable(feature, group_gate, flipper.group(:admins))).to eq(true)
+    expect(subject.enable(feature, actor_gate, flipper.actor(actor_22))).to eq(true)
+    expect(subject.enable(feature, actors_gate, flipper.actors(25))).to eq(true)
+    expect(subject.enable(feature, time_gate, flipper.time(45))).to eq(true)
 
-    subject.disable(feature, boolean_gate, flipper.boolean).should eq(true)
+    expect(subject.disable(feature, boolean_gate, flipper.boolean)).to eq(true)
 
-    subject.get(feature).should eq({
+    expect(subject.get(feature)).to eq({
       :boolean => nil,
       :groups => Set.new,
       :actors => Set.new,
@@ -77,117 +77,117 @@ shared_examples_for 'a flipper adapter' do
   end
 
   it "can enable, disable and get value for group gate" do
-    subject.enable(feature, group_gate, flipper.group(:admins)).should eq(true)
-    subject.enable(feature, group_gate, flipper.group(:early_access)).should eq(true)
+    expect(subject.enable(feature, group_gate, flipper.group(:admins))).to eq(true)
+    expect(subject.enable(feature, group_gate, flipper.group(:early_access))).to eq(true)
 
     result = subject.get(feature)
-    result[:groups].should eq(Set['admins', 'early_access'])
+    expect(result[:groups]).to eq(Set['admins', 'early_access'])
 
-    subject.disable(feature, group_gate, flipper.group(:early_access)).should eq(true)
+    expect(subject.disable(feature, group_gate, flipper.group(:early_access))).to eq(true)
     result = subject.get(feature)
-    result[:groups].should eq(Set['admins'])
+    expect(result[:groups]).to eq(Set['admins'])
 
-    subject.disable(feature, group_gate, flipper.group(:admins)).should eq(true)
+    expect(subject.disable(feature, group_gate, flipper.group(:admins))).to eq(true)
     result = subject.get(feature)
-    result[:groups].should eq(Set.new)
+    expect(result[:groups]).to eq(Set.new)
   end
 
   it "can enable, disable and get value for actor gate" do
     actor_22 = actor_class.new('22')
     actor_asdf = actor_class.new('asdf')
 
-    subject.enable(feature, actor_gate, flipper.actor(actor_22)).should eq(true)
-    subject.enable(feature, actor_gate, flipper.actor(actor_asdf)).should eq(true)
+    expect(subject.enable(feature, actor_gate, flipper.actor(actor_22))).to eq(true)
+    expect(subject.enable(feature, actor_gate, flipper.actor(actor_asdf))).to eq(true)
 
     result = subject.get(feature)
-    result[:actors].should eq(Set['22', 'asdf'])
+    expect(result[:actors]).to eq(Set['22', 'asdf'])
 
-    subject.disable(feature, actor_gate, flipper.actor(actor_22)).should eq(true)
+    expect(subject.disable(feature, actor_gate, flipper.actor(actor_22))).to eq(true)
     result = subject.get(feature)
-    result[:actors].should eq(Set['asdf'])
+    expect(result[:actors]).to eq(Set['asdf'])
 
-    subject.disable(feature, actor_gate, flipper.actor(actor_asdf)).should eq(true)
+    expect(subject.disable(feature, actor_gate, flipper.actor(actor_asdf))).to eq(true)
     result = subject.get(feature)
-    result[:actors].should eq(Set.new)
+    expect(result[:actors]).to eq(Set.new)
   end
 
   it "can enable, disable and get value for percentage of actors gate" do
-    subject.enable(feature, actors_gate, flipper.actors(15)).should eq(true)
+    expect(subject.enable(feature, actors_gate, flipper.actors(15))).to eq(true)
     result = subject.get(feature)
-    result[:percentage_of_actors].should eq('15')
+    expect(result[:percentage_of_actors]).to eq('15')
 
-    subject.disable(feature, actors_gate, flipper.actors(0)).should eq(true)
+    expect(subject.disable(feature, actors_gate, flipper.actors(0))).to eq(true)
     result = subject.get(feature)
-    result[:percentage_of_actors].should eq('0')
+    expect(result[:percentage_of_actors]).to eq('0')
   end
 
   it "can enable, disable and get value for percentage of time gate" do
-    subject.enable(feature, time_gate, flipper.time(10)).should eq(true)
+    expect(subject.enable(feature, time_gate, flipper.time(10))).to eq(true)
     result = subject.get(feature)
-    result[:percentage_of_time].should eq('10')
+    expect(result[:percentage_of_time]).to eq('10')
 
-    subject.disable(feature, time_gate, flipper.time(0)).should eq(true)
+    expect(subject.disable(feature, time_gate, flipper.time(0))).to eq(true)
     result = subject.get(feature)
-    result[:percentage_of_time].should eq('0')
+    expect(result[:percentage_of_time]).to eq('0')
   end
 
   it "converts boolean value to a string" do
-    subject.enable(feature, boolean_gate, flipper.boolean).should eq(true)
+    expect(subject.enable(feature, boolean_gate, flipper.boolean)).to eq(true)
     result = subject.get(feature)
-    result[:boolean].should eq('true')
+    expect(result[:boolean]).to eq('true')
   end
 
   it "converts the actor value to a string" do
-    subject.enable(feature, actor_gate, flipper.actor(actor_class.new(22))).should eq(true)
+    expect(subject.enable(feature, actor_gate, flipper.actor(actor_class.new(22)))).to eq(true)
     result = subject.get(feature)
-    result[:actors].should eq(Set['22'])
+    expect(result[:actors]).to eq(Set['22'])
   end
 
   it "converts group value to a string" do
-    subject.enable(feature, group_gate, flipper.group(:admins)).should eq(true)
+    expect(subject.enable(feature, group_gate, flipper.group(:admins))).to eq(true)
     result = subject.get(feature)
-    result[:groups].should eq(Set['admins'])
+    expect(result[:groups]).to eq(Set['admins'])
   end
 
   it "converts percentage of time integer value to a string" do
-    subject.enable(feature, time_gate, flipper.time(10)).should eq(true)
+    expect(subject.enable(feature, time_gate, flipper.time(10))).to eq(true)
     result = subject.get(feature)
-    result[:percentage_of_time].should eq('10')
+    expect(result[:percentage_of_time]).to eq('10')
   end
 
   it "converts percentage of actors integer value to a string" do
-    subject.enable(feature, actors_gate, flipper.actors(10)).should eq(true)
+    expect(subject.enable(feature, actors_gate, flipper.actors(10))).to eq(true)
     result = subject.get(feature)
-    result[:percentage_of_actors].should eq('10')
+    expect(result[:percentage_of_actors]).to eq('10')
   end
 
   it "can add, remove and list known features" do
-    subject.features.should eq(Set.new)
+    expect(subject.features).to eq(Set.new)
 
-    subject.add(flipper[:stats]).should eq(true)
-    subject.features.should eq(Set['stats'])
+    expect(subject.add(flipper[:stats])).to eq(true)
+    expect(subject.features).to eq(Set['stats'])
 
-    subject.add(flipper[:search]).should eq(true)
-    subject.features.should eq(Set['stats', 'search'])
+    expect(subject.add(flipper[:search])).to eq(true)
+    expect(subject.features).to eq(Set['stats', 'search'])
 
-    subject.remove(flipper[:stats]).should eq(true)
-    subject.features.should eq(Set['search'])
+    expect(subject.remove(flipper[:stats])).to eq(true)
+    expect(subject.features).to eq(Set['search'])
 
-    subject.remove(flipper[:search]).should eq(true)
-    subject.features.should eq(Set.new)
+    expect(subject.remove(flipper[:search])).to eq(true)
+    expect(subject.features).to eq(Set.new)
   end
 
   it "clears all the gate values for the feature on remove" do
     actor_22 = actor_class.new('22')
-    subject.enable(feature, boolean_gate, flipper.boolean).should eq(true)
-    subject.enable(feature, group_gate, flipper.group(:admins)).should eq(true)
-    subject.enable(feature, actor_gate, flipper.actor(actor_22)).should eq(true)
-    subject.enable(feature, actors_gate, flipper.actors(25)).should eq(true)
-    subject.enable(feature, time_gate, flipper.time(45)).should eq(true)
+    expect(subject.enable(feature, boolean_gate, flipper.boolean)).to eq(true)
+    expect(subject.enable(feature, group_gate, flipper.group(:admins))).to eq(true)
+    expect(subject.enable(feature, actor_gate, flipper.actor(actor_22))).to eq(true)
+    expect(subject.enable(feature, actors_gate, flipper.actors(25))).to eq(true)
+    expect(subject.enable(feature, time_gate, flipper.time(45))).to eq(true)
 
-    subject.remove(feature).should eq(true)
+    expect(subject.remove(feature)).to eq(true)
 
-    subject.get(feature).should eq({
+    expect(subject.get(feature)).to eq({
       :boolean => nil,
       :groups => Set.new,
       :actors => Set.new,
@@ -198,15 +198,15 @@ shared_examples_for 'a flipper adapter' do
 
   it "can clear all the gate values for a feature" do
     actor_22 = actor_class.new('22')
-    subject.enable(feature, boolean_gate, flipper.boolean).should eq(true)
-    subject.enable(feature, group_gate, flipper.group(:admins)).should eq(true)
-    subject.enable(feature, actor_gate, flipper.actor(actor_22)).should eq(true)
-    subject.enable(feature, actors_gate, flipper.actors(25)).should eq(true)
-    subject.enable(feature, time_gate, flipper.time(45)).should eq(true)
+    expect(subject.enable(feature, boolean_gate, flipper.boolean)).to eq(true)
+    expect(subject.enable(feature, group_gate, flipper.group(:admins))).to eq(true)
+    expect(subject.enable(feature, actor_gate, flipper.actor(actor_22))).to eq(true)
+    expect(subject.enable(feature, actors_gate, flipper.actors(25))).to eq(true)
+    expect(subject.enable(feature, time_gate, flipper.time(45))).to eq(true)
 
-    subject.clear(feature).should eq(true)
+    expect(subject.clear(feature)).to eq(true)
 
-    subject.get(feature).should eq({
+    expect(subject.get(feature)).to eq({
       :boolean => nil,
       :groups => Set.new,
       :actors => Set.new,
@@ -216,6 +216,6 @@ shared_examples_for 'a flipper adapter' do
   end
 
   it "does not complain clearing a feature that does not exist in adapter" do
-    subject.clear(flipper[:stats]).should eq(true)
+    expect(subject.clear(flipper[:stats])).to eq(true)
   end
 end

--- a/spec/flipper/adapters/instrumented_spec.rb
+++ b/spec/flipper/adapters/instrumented_spec.rb
@@ -4,7 +4,7 @@ require 'flipper/adapters/instrumented'
 require 'flipper/instrumenters/memory'
 require 'flipper/spec/shared_adapter_specs'
 
-describe Flipper::Adapters::Instrumented do
+RSpec.describe Flipper::Adapters::Instrumented do
   let(:instrumenter) { Flipper::Instrumenters::Memory.new }
   let(:adapter) { Flipper::Adapters::Memory.new }
   let(:flipper) { Flipper.new(adapter) }
@@ -24,12 +24,12 @@ describe Flipper::Adapters::Instrumented do
       result = subject.get(feature)
 
       event = instrumenter.events.last
-      event.should_not be_nil
-      event.name.should eq('adapter_operation.flipper')
-      event.payload[:operation].should eq(:get)
-      event.payload[:adapter_name].should eq(:memory)
-      event.payload[:feature_name].should eq(:stats)
-      event.payload[:result].should be(result)
+      expect(event).not_to be_nil
+      expect(event.name).to eq('adapter_operation.flipper')
+      expect(event.payload[:operation]).to eq(:get)
+      expect(event.payload[:adapter_name]).to eq(:memory)
+      expect(event.payload[:feature_name]).to eq(:stats)
+      expect(event.payload[:result]).to be(result)
     end
   end
 
@@ -38,13 +38,13 @@ describe Flipper::Adapters::Instrumented do
       result = subject.enable(feature, gate, thing)
 
       event = instrumenter.events.last
-      event.should_not be_nil
-      event.name.should eq('adapter_operation.flipper')
-      event.payload[:operation].should eq(:enable)
-      event.payload[:adapter_name].should eq(:memory)
-      event.payload[:feature_name].should eq(:stats)
-      event.payload[:gate_name].should eq(:percentage_of_actors)
-      event.payload[:result].should be(result)
+      expect(event).not_to be_nil
+      expect(event.name).to eq('adapter_operation.flipper')
+      expect(event.payload[:operation]).to eq(:enable)
+      expect(event.payload[:adapter_name]).to eq(:memory)
+      expect(event.payload[:feature_name]).to eq(:stats)
+      expect(event.payload[:gate_name]).to eq(:percentage_of_actors)
+      expect(event.payload[:result]).to be(result)
     end
   end
 
@@ -53,13 +53,13 @@ describe Flipper::Adapters::Instrumented do
       result = subject.disable(feature, gate, thing)
 
       event = instrumenter.events.last
-      event.should_not be_nil
-      event.name.should eq('adapter_operation.flipper')
-      event.payload[:operation].should eq(:disable)
-      event.payload[:adapter_name].should eq(:memory)
-      event.payload[:feature_name].should eq(:stats)
-      event.payload[:gate_name].should eq(:percentage_of_actors)
-      event.payload[:result].should be(result)
+      expect(event).not_to be_nil
+      expect(event.name).to eq('adapter_operation.flipper')
+      expect(event.payload[:operation]).to eq(:disable)
+      expect(event.payload[:adapter_name]).to eq(:memory)
+      expect(event.payload[:feature_name]).to eq(:stats)
+      expect(event.payload[:gate_name]).to eq(:percentage_of_actors)
+      expect(event.payload[:result]).to be(result)
     end
   end
 
@@ -68,12 +68,12 @@ describe Flipper::Adapters::Instrumented do
       result = subject.add(feature)
 
       event = instrumenter.events.last
-      event.should_not be_nil
-      event.name.should eq('adapter_operation.flipper')
-      event.payload[:operation].should eq(:add)
-      event.payload[:adapter_name].should eq(:memory)
-      event.payload[:feature_name].should eq(:stats)
-      event.payload[:result].should be(result)
+      expect(event).not_to be_nil
+      expect(event.name).to eq('adapter_operation.flipper')
+      expect(event.payload[:operation]).to eq(:add)
+      expect(event.payload[:adapter_name]).to eq(:memory)
+      expect(event.payload[:feature_name]).to eq(:stats)
+      expect(event.payload[:result]).to be(result)
     end
   end
 
@@ -82,12 +82,12 @@ describe Flipper::Adapters::Instrumented do
       result = subject.remove(feature)
 
       event = instrumenter.events.last
-      event.should_not be_nil
-      event.name.should eq('adapter_operation.flipper')
-      event.payload[:operation].should eq(:remove)
-      event.payload[:adapter_name].should eq(:memory)
-      event.payload[:feature_name].should eq(:stats)
-      event.payload[:result].should be(result)
+      expect(event).not_to be_nil
+      expect(event.name).to eq('adapter_operation.flipper')
+      expect(event.payload[:operation]).to eq(:remove)
+      expect(event.payload[:adapter_name]).to eq(:memory)
+      expect(event.payload[:feature_name]).to eq(:stats)
+      expect(event.payload[:result]).to be(result)
     end
   end
 
@@ -96,12 +96,12 @@ describe Flipper::Adapters::Instrumented do
       result = subject.clear(feature)
 
       event = instrumenter.events.last
-      event.should_not be_nil
-      event.name.should eq('adapter_operation.flipper')
-      event.payload[:operation].should eq(:clear)
-      event.payload[:adapter_name].should eq(:memory)
-      event.payload[:feature_name].should eq(:stats)
-      event.payload[:result].should be(result)
+      expect(event).not_to be_nil
+      expect(event.name).to eq('adapter_operation.flipper')
+      expect(event.payload[:operation]).to eq(:clear)
+      expect(event.payload[:adapter_name]).to eq(:memory)
+      expect(event.payload[:feature_name]).to eq(:stats)
+      expect(event.payload[:result]).to be(result)
     end
   end
 
@@ -110,11 +110,11 @@ describe Flipper::Adapters::Instrumented do
       result = subject.features
 
       event = instrumenter.events.last
-      event.should_not be_nil
-      event.name.should eq('adapter_operation.flipper')
-      event.payload[:operation].should eq(:features)
-      event.payload[:adapter_name].should eq(:memory)
-      event.payload[:result].should be(result)
+      expect(event).not_to be_nil
+      expect(event.name).to eq('adapter_operation.flipper')
+      expect(event.payload[:operation]).to eq(:features)
+      expect(event.payload[:adapter_name]).to eq(:memory)
+      expect(event.payload[:result]).to be(result)
     end
   end
 end

--- a/spec/flipper/adapters/memoizable_spec.rb
+++ b/spec/flipper/adapters/memoizable_spec.rb
@@ -3,7 +3,7 @@ require 'flipper/adapters/memoizable'
 require 'flipper/adapters/memory'
 require 'flipper/spec/shared_adapter_specs'
 
-describe Flipper::Adapters::Memoizable do
+RSpec.describe Flipper::Adapters::Memoizable do
   let(:features_key) { described_class::FeaturesKey }
   let(:adapter) { Flipper::Adapters::Memory.new }
   let(:flipper) { Flipper.new(adapter) }
@@ -16,28 +16,28 @@ describe Flipper::Adapters::Memoizable do
   describe "#memoize=" do
     it "sets value" do
       subject.memoize = true
-      subject.memoizing?.should eq(true)
+      expect(subject.memoizing?).to eq(true)
 
       subject.memoize = false
-      subject.memoizing?.should eq(false)
+      expect(subject.memoizing?).to eq(false)
     end
 
     it "clears the local cache" do
       subject.cache['some'] = 'thing'
       subject.memoize = true
-      subject.cache.should be_empty
+      expect(subject.cache).to be_empty
     end
   end
 
   describe "#memoizing?" do
     it "returns true if enabled" do
       subject.memoize = true
-      subject.memoizing?.should eq(true)
+      expect(subject.memoizing?).to eq(true)
     end
 
     it "returns false if disabled" do
       subject.memoize = false
-      subject.memoizing?.should eq(false)
+      expect(subject.memoizing?).to eq(false)
     end
   end
 
@@ -50,7 +50,7 @@ describe Flipper::Adapters::Memoizable do
       it "memoizes feature" do
         feature = flipper[:stats]
         result = subject.get(feature)
-        cache[feature].should be(result)
+        expect(cache[feature]).to be(result)
       end
     end
 
@@ -63,7 +63,7 @@ describe Flipper::Adapters::Memoizable do
         feature = flipper[:stats]
         result = subject.get(feature)
         adapter_result = adapter.get(feature)
-        result.should eq(adapter_result)
+        expect(result).to eq(adapter_result)
       end
     end
   end
@@ -79,7 +79,7 @@ describe Flipper::Adapters::Memoizable do
         gate = feature.gate(:boolean)
         cache[feature] = {:some => 'thing'}
         subject.enable(feature, gate, flipper.bool)
-        cache[feature].should be_nil
+        expect(cache[feature]).to be_nil
       end
     end
 
@@ -93,7 +93,7 @@ describe Flipper::Adapters::Memoizable do
         gate = feature.gate(:boolean)
         result = subject.enable(feature, gate, flipper.bool)
         adapter_result = adapter.enable(feature, gate, flipper.bool)
-        result.should eq(adapter_result)
+        expect(result).to eq(adapter_result)
       end
     end
   end
@@ -109,7 +109,7 @@ describe Flipper::Adapters::Memoizable do
         gate = feature.gate(:boolean)
         cache[feature] = {:some => 'thing'}
         subject.disable(feature, gate, flipper.bool)
-        cache[feature].should be_nil
+        expect(cache[feature]).to be_nil
       end
     end
 
@@ -123,7 +123,7 @@ describe Flipper::Adapters::Memoizable do
         gate = feature.gate(:boolean)
         result = subject.disable(feature, gate, flipper.bool)
         adapter_result = adapter.disable(feature, gate, flipper.bool)
-        result.should eq(adapter_result)
+        expect(result).to eq(adapter_result)
       end
     end
   end
@@ -138,7 +138,7 @@ describe Flipper::Adapters::Memoizable do
         flipper[:stats].enable
         flipper[:search].disable
         result = subject.features
-        cache[:flipper_features].should be(result)
+        expect(cache[:flipper_features]).to be(result)
       end
     end
 
@@ -148,7 +148,7 @@ describe Flipper::Adapters::Memoizable do
       end
 
       it "returns result" do
-        subject.features.should eq(adapter.features)
+        expect(subject.features).to eq(adapter.features)
       end
     end
   end
@@ -162,7 +162,7 @@ describe Flipper::Adapters::Memoizable do
       it "unmemoizes the known features" do
         cache[features_key] = {:some => 'thing'}
         subject.add(flipper[:stats])
-        cache.should be_empty
+        expect(cache).to be_empty
       end
     end
 
@@ -172,7 +172,7 @@ describe Flipper::Adapters::Memoizable do
       end
 
       it "returns result" do
-        subject.add(flipper[:stats]).should eq(adapter.add(flipper[:stats]))
+        expect(subject.add(flipper[:stats])).to eq(adapter.add(flipper[:stats]))
       end
     end
   end
@@ -186,14 +186,14 @@ describe Flipper::Adapters::Memoizable do
       it "unmemoizes the known features" do
         cache[features_key] = {:some => 'thing'}
         subject.remove(flipper[:stats])
-        cache.should be_empty
+        expect(cache).to be_empty
       end
 
       it "unmemoizes the feature" do
         feature = flipper[:stats]
         cache[feature] = {:some => 'thing'}
         subject.remove(feature)
-        cache[feature].should be_nil
+        expect(cache[feature]).to be_nil
       end
     end
 
@@ -203,7 +203,7 @@ describe Flipper::Adapters::Memoizable do
       end
 
       it "returns result" do
-        subject.remove(flipper[:stats]).should eq(adapter.remove(flipper[:stats]))
+        expect(subject.remove(flipper[:stats])).to eq(adapter.remove(flipper[:stats]))
       end
     end
   end
@@ -218,7 +218,7 @@ describe Flipper::Adapters::Memoizable do
         feature = flipper[:stats]
         cache[feature] = {:some => 'thing'}
         subject.clear(feature)
-        cache[feature].should be_nil
+        expect(cache[feature]).to be_nil
       end
     end
 
@@ -229,7 +229,7 @@ describe Flipper::Adapters::Memoizable do
 
       it "returns result" do
         feature = flipper[:stats]
-        subject.clear(feature).should eq(adapter.clear(feature))
+        expect(subject.clear(feature)).to eq(adapter.clear(feature))
       end
     end
   end

--- a/spec/flipper/adapters/memory_spec.rb
+++ b/spec/flipper/adapters/memory_spec.rb
@@ -2,7 +2,7 @@ require 'helper'
 require 'flipper/adapters/memory'
 require 'flipper/spec/shared_adapter_specs'
 
-describe Flipper::Adapters::Memory do
+RSpec.describe Flipper::Adapters::Memory do
   subject { described_class.new }
 
   it_should_behave_like 'a flipper adapter'

--- a/spec/flipper/adapters/mongo_spec.rb
+++ b/spec/flipper/adapters/mongo_spec.rb
@@ -1,4 +1,5 @@
 require 'helper'
+require 'timeout'
 require 'flipper/adapters/mongo'
 require 'flipper/spec/shared_adapter_specs'
 
@@ -16,8 +17,19 @@ describe Flipper::Adapters::Mongo do
 
   before do
     begin
-      collection.drop
-    rescue Mongo::Error::OperationFailure
+      Timeout::timeout(1) do
+        collection.drop
+      end
+    rescue Mongo::Error::OperationFailure => e
+      puts
+      puts "Error executing operation on Mongo. Is Mongo running?"
+      puts
+      raise e
+    rescue Timeout::Error => e
+      puts
+      puts "Timeout connecting to Mongo. Is Mongo running?"
+      puts
+      raise e
     end
     collection.create
   end

--- a/spec/flipper/adapters/mongo_spec.rb
+++ b/spec/flipper/adapters/mongo_spec.rb
@@ -1,5 +1,4 @@
 require 'helper'
-require 'timeout'
 require 'flipper/adapters/mongo'
 require 'flipper/spec/shared_adapter_specs'
 
@@ -17,19 +16,8 @@ RSpec.describe Flipper::Adapters::Mongo do
 
   before do
     begin
-      Timeout::timeout(1) do
-        collection.drop
-      end
-    rescue Mongo::Error::OperationFailure => e
-      puts
-      puts "Error executing operation on Mongo. Is Mongo running?"
-      puts
-      raise e
-    rescue Timeout::Error => e
-      puts
-      puts "Timeout connecting to Mongo. Is Mongo running?"
-      puts
-      raise e
+      collection.drop
+    rescue Mongo::Error::OperationFailure
     end
     collection.create
   end

--- a/spec/flipper/adapters/mongo_spec.rb
+++ b/spec/flipper/adapters/mongo_spec.rb
@@ -5,7 +5,7 @@ require 'flipper/spec/shared_adapter_specs'
 
 Mongo::Logger.logger.level = Logger::INFO
 
-describe Flipper::Adapters::Mongo do
+RSpec.describe Flipper::Adapters::Mongo do
   let(:host) { ENV["BOXEN_MONGODB_HOST"] || '127.0.0.1' }
   let(:port) { ENV["BOXEN_MONGODB_PORT"] || 27017 }
 

--- a/spec/flipper/adapters/operation_logger_spec.rb
+++ b/spec/flipper/adapters/operation_logger_spec.rb
@@ -3,7 +3,7 @@ require 'flipper/adapters/operation_logger'
 require 'flipper/adapters/memory'
 require 'flipper/spec/shared_adapter_specs'
 
-describe Flipper::Adapters::OperationLogger do
+RSpec.describe Flipper::Adapters::OperationLogger do
   let(:operations) { [] }
   let(:adapter)    { Flipper::Adapters::Memory.new }
   let(:flipper)    { Flipper.new(adapter) }
@@ -19,11 +19,11 @@ describe Flipper::Adapters::OperationLogger do
     end
 
     it "logs operation" do
-      subject.count(:get).should be(1)
+      expect(subject.count(:get)).to be(1)
     end
 
     it "returns result" do
-      @result.should eq(adapter.get(@feature))
+      expect(@result).to eq(adapter.get(@feature))
     end
   end
 
@@ -36,11 +36,11 @@ describe Flipper::Adapters::OperationLogger do
     end
 
     it "logs operation" do
-      subject.count(:enable).should be(1)
+      expect(subject.count(:enable)).to be(1)
     end
 
     it "returns result" do
-      @result.should eq(adapter.enable(@feature, @gate, @thing))
+      expect(@result).to eq(adapter.enable(@feature, @gate, @thing))
     end
   end
 
@@ -53,11 +53,11 @@ describe Flipper::Adapters::OperationLogger do
     end
 
     it "logs operation" do
-      subject.count(:disable).should be(1)
+      expect(subject.count(:disable)).to be(1)
     end
 
     it "returns result" do
-      @result.should eq(adapter.disable(@feature, @gate, @thing))
+      expect(@result).to eq(adapter.disable(@feature, @gate, @thing))
     end
   end
 
@@ -68,11 +68,11 @@ describe Flipper::Adapters::OperationLogger do
     end
 
     it "logs operation" do
-      subject.count(:features).should be(1)
+      expect(subject.count(:features)).to be(1)
     end
 
     it "returns result" do
-      @result.should eq(adapter.features)
+      expect(@result).to eq(adapter.features)
     end
   end
 
@@ -83,11 +83,11 @@ describe Flipper::Adapters::OperationLogger do
     end
 
     it "logs operation" do
-      subject.count(:add).should be(1)
+      expect(subject.count(:add)).to be(1)
     end
 
     it "returns result" do
-      @result.should eq(adapter.add(@feature))
+      expect(@result).to eq(adapter.add(@feature))
     end
   end
 end

--- a/spec/flipper/adapters/pstore_spec.rb
+++ b/spec/flipper/adapters/pstore_spec.rb
@@ -2,7 +2,7 @@ require 'helper'
 require 'flipper/adapters/pstore'
 require 'flipper/spec/shared_adapter_specs'
 
-describe Flipper::Adapters::PStore do
+RSpec.describe Flipper::Adapters::PStore do
   subject {
     dir = FlipperRoot.join("tmp").tap { |d| d.mkpath }
     described_class.new(dir.join("flipper.pstore"))
@@ -11,6 +11,6 @@ describe Flipper::Adapters::PStore do
   it_should_behave_like 'a flipper adapter'
 
   it "defaults path to flipper.pstore" do
-    described_class.new.path.should eq("flipper.pstore")
+    expect(described_class.new.path).to eq("flipper.pstore")
   end
 end

--- a/spec/flipper/adapters/redis_spec.rb
+++ b/spec/flipper/adapters/redis_spec.rb
@@ -2,7 +2,7 @@ require 'helper'
 require 'flipper/adapters/redis'
 require 'flipper/spec/shared_adapter_specs'
 
-describe Flipper::Adapters::Redis do
+RSpec.describe Flipper::Adapters::Redis do
   let(:client) {
     options = {}
 

--- a/spec/flipper/dsl_spec.rb
+++ b/spec/flipper/dsl_spec.rb
@@ -2,7 +2,7 @@ require 'helper'
 require 'flipper/dsl'
 require 'flipper/adapters/memory'
 
-describe Flipper::DSL do
+RSpec.describe Flipper::DSL do
   subject { Flipper::DSL.new(adapter) }
 
   let(:adapter) { Flipper::Adapters::Memory.new }
@@ -10,12 +10,12 @@ describe Flipper::DSL do
   describe "#initialize" do
     it "sets adapter" do
       dsl = described_class.new(adapter)
-      dsl.adapter.should_not be_nil
+      expect(dsl.adapter).not_to be_nil
     end
 
     it "defaults instrumenter to noop" do
       dsl = described_class.new(adapter)
-      dsl.instrumenter.should be(Flipper::Instrumenters::Noop)
+      expect(dsl.instrumenter).to be(Flipper::Instrumenters::Noop)
     end
 
     context "with overriden instrumenter" do
@@ -23,12 +23,12 @@ describe Flipper::DSL do
 
       it "overrides default instrumenter" do
         dsl = described_class.new(adapter, :instrumenter => instrumenter)
-        dsl.instrumenter.should be(instrumenter)
+        expect(dsl.instrumenter).to be(instrumenter)
       end
 
       it "passes overridden instrumenter to adapter wrapping" do
         dsl = described_class.new(adapter, :instrumenter => instrumenter)
-        dsl.adapter.instrumenter.should be(instrumenter)
+        expect(dsl.adapter.instrumenter).to be(instrumenter)
       end
     end
   end
@@ -70,11 +70,11 @@ describe Flipper::DSL do
       end
 
       it "returns group" do
-        subject.group(:admins).should eq(@group)
+        expect(subject.group(:admins)).to eq(@group)
       end
 
       it "always returns same instance for same name" do
-        subject.group(:admins).should equal(subject.group(:admins))
+        expect(subject.group(:admins)).to equal(subject.group(:admins))
       end
     end
 
@@ -92,8 +92,8 @@ describe Flipper::DSL do
       it "returns actor instance" do
         thing = Struct.new(:flipper_id).new(33)
         actor = subject.actor(thing)
-        actor.should be_instance_of(Flipper::Types::Actor)
-        actor.value.should eq('33')
+        expect(actor).to be_instance_of(Flipper::Types::Actor)
+        expect(actor.value).to eq('33')
       end
     end
 
@@ -120,15 +120,15 @@ describe Flipper::DSL do
     end
 
     it "returns percentage of time" do
-      @result.should be_instance_of(Flipper::Types::PercentageOfTime)
+      expect(@result).to be_instance_of(Flipper::Types::PercentageOfTime)
     end
 
     it "sets value" do
-      @result.value.should eq(5)
+      expect(@result.value).to eq(5)
     end
 
     it "is aliased to percentage_of_time" do
-      @result.should eq(subject.percentage_of_time(@result.value))
+      expect(@result).to eq(subject.percentage_of_time(@result.value))
     end
   end
 
@@ -138,22 +138,22 @@ describe Flipper::DSL do
     end
 
     it "returns percentage of actors" do
-      @result.should be_instance_of(Flipper::Types::PercentageOfActors)
+      expect(@result).to be_instance_of(Flipper::Types::PercentageOfActors)
     end
 
     it "sets value" do
-      @result.value.should eq(17)
+      expect(@result.value).to eq(17)
     end
 
     it "is aliased to percentage_of_actors" do
-      @result.should eq(subject.percentage_of_actors(@result.value))
+      expect(@result).to eq(subject.percentage_of_actors(@result.value))
     end
   end
 
   describe "#features" do
     context "with no features enabled/disabled" do
       it "defaults to empty set" do
-        subject.features.should eq(Set.new)
+        expect(subject.features).to eq(Set.new)
       end
     end
 
@@ -165,23 +165,23 @@ describe Flipper::DSL do
       end
 
       it "returns set of feature instances" do
-        subject.features.should be_instance_of(Set)
+        expect(subject.features).to be_instance_of(Set)
         subject.features.each do |feature|
-          feature.should be_instance_of(Flipper::Feature)
+          expect(feature).to be_instance_of(Flipper::Feature)
         end
-        subject.features.map(&:name).map(&:to_s).sort.should eq(['cache', 'search', 'stats'])
+        expect(subject.features.map(&:name).map(&:to_s).sort).to eq(['cache', 'search', 'stats'])
       end
     end
   end
 
   describe "#enable/disable" do
     it "enables and disables the feature" do
-      subject[:stats].boolean_value.should eq(false)
+      expect(subject[:stats].boolean_value).to eq(false)
       subject.enable(:stats)
-      subject[:stats].boolean_value.should eq(true)
+      expect(subject[:stats].boolean_value).to eq(true)
 
       subject.disable(:stats)
-      subject[:stats].boolean_value.should eq(false)
+      expect(subject[:stats].boolean_value).to eq(false)
     end
   end
 
@@ -189,12 +189,12 @@ describe Flipper::DSL do
     it "enables and disables the feature for actor" do
       actor = Struct.new(:flipper_id).new(5)
 
-      subject[:stats].actors_value.should be_empty
+      expect(subject[:stats].actors_value).to be_empty
       subject.enable_actor(:stats, actor)
-      subject[:stats].actors_value.should eq(Set["5"])
+      expect(subject[:stats].actors_value).to eq(Set["5"])
 
       subject.disable_actor(:stats, actor)
-      subject[:stats].actors_value.should be_empty
+      expect(subject[:stats].actors_value).to be_empty
     end
   end
 
@@ -203,34 +203,34 @@ describe Flipper::DSL do
       actor = Struct.new(:flipper_id).new(5)
       group = Flipper.register(:fives) { |actor| actor.flipper_id == 5 }
 
-      subject[:stats].groups_value.should be_empty
+      expect(subject[:stats].groups_value).to be_empty
       subject.enable_group(:stats, :fives)
-      subject[:stats].groups_value.should eq(Set["fives"])
+      expect(subject[:stats].groups_value).to eq(Set["fives"])
 
       subject.disable_group(:stats, :fives)
-      subject[:stats].groups_value.should be_empty
+      expect(subject[:stats].groups_value).to be_empty
     end
   end
 
   describe "#enable_percentage_of_time/disable_percentage_of_time" do
     it "enables and disables the feature for percentage of time" do
-      subject[:stats].percentage_of_time_value.should be(0)
+      expect(subject[:stats].percentage_of_time_value).to be(0)
       subject.enable_percentage_of_time(:stats, 6)
-      subject[:stats].percentage_of_time_value.should be(6)
+      expect(subject[:stats].percentage_of_time_value).to be(6)
 
       subject.disable_percentage_of_time(:stats)
-      subject[:stats].percentage_of_time_value.should be(0)
+      expect(subject[:stats].percentage_of_time_value).to be(0)
     end
   end
 
   describe "#enable_percentage_of_actors/disable_percentage_of_actors" do
     it "enables and disables the feature for percentage of time" do
-      subject[:stats].percentage_of_actors_value.should be(0)
+      expect(subject[:stats].percentage_of_actors_value).to be(0)
       subject.enable_percentage_of_actors(:stats, 6)
-      subject[:stats].percentage_of_actors_value.should be(6)
+      expect(subject[:stats].percentage_of_actors_value).to be(6)
 
       subject.disable_percentage_of_actors(:stats)
-      subject[:stats].percentage_of_actors_value.should be(0)
+      expect(subject[:stats].percentage_of_actors_value).to be(0)
     end
   end
 end

--- a/spec/flipper/feature_spec.rb
+++ b/spec/flipper/feature_spec.rb
@@ -3,7 +3,7 @@ require 'flipper/feature'
 require 'flipper/adapters/memory'
 require 'flipper/instrumenters/memory'
 
-describe Flipper::Feature do
+RSpec.describe Flipper::Feature do
   subject { described_class.new(:search, adapter) }
 
   let(:adapter) { Flipper::Adapters::Memory.new }
@@ -11,17 +11,17 @@ describe Flipper::Feature do
   describe "#initialize" do
     it "sets name" do
       feature = described_class.new(:search, adapter)
-      feature.name.should eq(:search)
+      expect(feature.name).to eq(:search)
     end
 
     it "sets adapter" do
       feature = described_class.new(:search, adapter)
-      feature.adapter.should eq(adapter)
+      expect(feature.adapter).to eq(adapter)
     end
 
     it "defaults instrumenter" do
       feature = described_class.new(:search, adapter)
-      feature.instrumenter.should be(Flipper::Instrumenters::Noop)
+      expect(feature.instrumenter).to be(Flipper::Instrumenters::Noop)
     end
 
     context "with overriden instrumenter" do
@@ -31,7 +31,7 @@ describe Flipper::Feature do
         feature = described_class.new(:search, adapter, {
           :instrumenter => instrumenter,
         })
-        feature.instrumenter.should be(instrumenter)
+        expect(feature.instrumenter).to be(instrumenter)
       end
     end
   end
@@ -39,14 +39,14 @@ describe Flipper::Feature do
   describe "#to_s" do
     it "returns name as string" do
       feature = described_class.new(:search, adapter)
-      feature.to_s.should eq("search")
+      expect(feature.to_s).to eq("search")
     end
   end
 
   describe "#to_param" do
     it "returns name as string" do
       feature = described_class.new(:search, adapter)
-      feature.to_param.should eq("search")
+      expect(feature.to_param).to eq("search")
     end
   end
 
@@ -55,7 +55,7 @@ describe Flipper::Feature do
       it "returns percentage of actors gate" do
         percentage = Flipper::Types::PercentageOfActors.new(10)
         gate = subject.gate_for(percentage)
-        gate.should be_instance_of(Flipper::Gates::PercentageOfActors)
+        expect(gate).to be_instance_of(Flipper::Gates::PercentageOfActors)
       end
     end
   end
@@ -63,30 +63,30 @@ describe Flipper::Feature do
   describe "#gates" do
     it "returns array of gates" do
       instance = described_class.new(:search, adapter)
-      instance.gates.should be_instance_of(Array)
+      expect(instance.gates).to be_instance_of(Array)
       instance.gates.each do |gate|
-        gate.should be_a(Flipper::Gate)
+        expect(gate).to be_a(Flipper::Gate)
       end
-      instance.gates.size.should be(5)
+      expect(instance.gates.size).to be(5)
     end
   end
 
   describe "#gate" do
     context "with symbol name" do
       it "returns gate by name" do
-        subject.gate(:boolean).should be_instance_of(Flipper::Gates::Boolean)
+        expect(subject.gate(:boolean)).to be_instance_of(Flipper::Gates::Boolean)
       end
     end
 
     context "with string name" do
       it "returns gate by name" do
-        subject.gate('boolean').should be_instance_of(Flipper::Gates::Boolean)
+        expect(subject.gate('boolean')).to be_instance_of(Flipper::Gates::Boolean)
       end
     end
 
     context "with name that does not exist" do
       it "returns nil" do
-        subject.gate(:poo).should be_nil
+        expect(subject.gate(:poo)).to be_nil
       end
     end
   end
@@ -94,16 +94,16 @@ describe Flipper::Feature do
   describe "#inspect" do
     it "returns easy to read string representation" do
       string = subject.inspect
-      string.should include('Flipper::Feature')
-      string.should include('name=:search')
-      string.should include('state=:off')
-      string.should include('enabled_gate_names=[]')
-      string.should include("adapter=#{subject.adapter.name.inspect}")
+      expect(string).to include('Flipper::Feature')
+      expect(string).to include('name=:search')
+      expect(string).to include('state=:off')
+      expect(string).to include('enabled_gate_names=[]')
+      expect(string).to include("adapter=#{subject.adapter.name.inspect}")
 
       subject.enable
       string = subject.inspect
-      string.should include('state=:on')
-      string.should include('enabled_gate_names=[:boolean]')
+      expect(string).to include('state=:on')
+      expect(string).to include('enabled_gate_names=[:boolean]')
     end
   end
 
@@ -121,12 +121,12 @@ describe Flipper::Feature do
       subject.enable(thing)
 
       event = instrumenter.events.last
-      event.should_not be_nil
-      event.name.should eq('feature_operation.flipper')
-      event.payload[:feature_name].should eq(:search)
-      event.payload[:operation].should eq(:enable)
-      event.payload[:thing].should eq(thing)
-      event.payload[:result].should_not be_nil
+      expect(event).not_to be_nil
+      expect(event.name).to eq('feature_operation.flipper')
+      expect(event.payload[:feature_name]).to eq(:search)
+      expect(event.payload[:operation]).to eq(:enable)
+      expect(event.payload[:thing]).to eq(thing)
+      expect(event.payload[:result]).not_to be_nil
     end
 
     it "always instruments flipper type instance for enable" do
@@ -136,8 +136,8 @@ describe Flipper::Feature do
       subject.enable(thing)
 
       event = instrumenter.events.last
-      event.should_not be_nil
-      event.payload[:thing].should eq(Flipper::Types::Actor.new(thing))
+      expect(event).not_to be_nil
+      expect(event.payload[:thing]).to eq(Flipper::Types::Actor.new(thing))
     end
 
     it "is recorded for disable" do
@@ -147,12 +147,12 @@ describe Flipper::Feature do
       subject.disable(thing)
 
       event = instrumenter.events.last
-      event.should_not be_nil
-      event.name.should eq('feature_operation.flipper')
-      event.payload[:feature_name].should eq(:search)
-      event.payload[:operation].should eq(:disable)
-      event.payload[:thing].should eq(thing)
-      event.payload[:result].should_not be_nil
+      expect(event).not_to be_nil
+      expect(event.name).to eq('feature_operation.flipper')
+      expect(event.payload[:feature_name]).to eq(:search)
+      expect(event.payload[:operation]).to eq(:disable)
+      expect(event.payload[:thing]).to eq(thing)
+      expect(event.payload[:result]).not_to be_nil
     end
 
     user = Struct.new(:flipper_id).new("1")
@@ -179,9 +179,9 @@ describe Flipper::Feature do
         subject.enable(thing)
 
         event = instrumenter.events.last
-        event.should_not be_nil
-        event.payload[:operation].should eq(:enable)
-        event.payload[:thing].should eq(wrapped_thing)
+        expect(event).not_to be_nil
+        expect(event.payload[:operation]).to eq(:enable)
+        expect(event.payload[:thing]).to eq(wrapped_thing)
       end
     end
 
@@ -192,9 +192,9 @@ describe Flipper::Feature do
       subject.disable(thing)
 
       event = instrumenter.events.last
-      event.should_not be_nil
-      event.payload[:operation].should eq(:disable)
-      event.payload[:thing].should eq(Flipper::Types::Actor.new(thing))
+      expect(event).not_to be_nil
+      expect(event.payload[:operation]).to eq(:disable)
+      expect(event.payload[:thing]).to eq(Flipper::Types::Actor.new(thing))
     end
 
     it "is recorded for enabled?" do
@@ -204,12 +204,12 @@ describe Flipper::Feature do
       subject.enabled?(thing)
 
       event = instrumenter.events.last
-      event.should_not be_nil
-      event.name.should eq('feature_operation.flipper')
-      event.payload[:feature_name].should eq(:search)
-      event.payload[:operation].should eq(:enabled?)
-      event.payload[:thing].should eq(thing)
-      event.payload[:result].should eq(false)
+      expect(event).not_to be_nil
+      expect(event.name).to eq('feature_operation.flipper')
+      expect(event.payload[:feature_name]).to eq(:search)
+      expect(event.payload[:operation]).to eq(:enabled?)
+      expect(event.payload[:thing]).to eq(thing)
+      expect(event.payload[:result]).to eq(false)
     end
 
     user = Struct.new(:flipper_id).new("1")
@@ -223,9 +223,9 @@ describe Flipper::Feature do
         subject.enabled?(thing)
 
         event = instrumenter.events.last
-        event.should_not be_nil
-        event.payload[:operation].should eq(:enabled?)
-        event.payload[:thing].should eq(wrapped_thing)
+        expect(event).not_to be_nil
+        expect(event.payload[:operation]).to eq(:enabled?)
+        expect(event.payload[:thing]).to eq(wrapped_thing)
       end
     end
   end
@@ -237,19 +237,19 @@ describe Flipper::Feature do
       end
 
       it "returns :on" do
-        subject.state.should be(:on)
+        expect(subject.state).to be(:on)
       end
 
       it "returns true for on?" do
-        subject.on?.should be(true)
+        expect(subject.on?).to be(true)
       end
 
       it "returns false for off?" do
-        subject.off?.should be(false)
+        expect(subject.off?).to be(false)
       end
 
       it "returns false for conditional?" do
-        subject.conditional?.should be(false)
+        expect(subject.conditional?).to be(false)
       end
     end
 
@@ -259,19 +259,19 @@ describe Flipper::Feature do
       end
 
       it "returns :on" do
-        subject.state.should be(:on)
+        expect(subject.state).to be(:on)
       end
 
       it "returns true for on?" do
-        subject.on?.should be(true)
+        expect(subject.on?).to be(true)
       end
 
       it "returns false for off?" do
-        subject.off?.should be(false)
+        expect(subject.off?).to be(false)
       end
 
       it "returns false for conditional?" do
-        subject.conditional?.should be(false)
+        expect(subject.conditional?).to be(false)
       end
     end
 
@@ -281,19 +281,19 @@ describe Flipper::Feature do
       end
 
       it "returns :on" do
-        subject.state.should be(:on)
+        expect(subject.state).to be(:on)
       end
 
       it "returns true for on?" do
-        subject.on?.should be(true)
+        expect(subject.on?).to be(true)
       end
 
       it "returns false for off?" do
-        subject.off?.should be(false)
+        expect(subject.off?).to be(false)
       end
 
       it "returns false for conditional?" do
-        subject.conditional?.should be(false)
+        expect(subject.conditional?).to be(false)
       end
     end
 
@@ -303,19 +303,19 @@ describe Flipper::Feature do
       end
 
       it "returns :off" do
-        subject.state.should be(:off)
+        expect(subject.state).to be(:off)
       end
 
       it "returns false for on?" do
-        subject.on?.should be(false)
+        expect(subject.on?).to be(false)
       end
 
       it "returns true for off?" do
-        subject.off?.should be(true)
+        expect(subject.off?).to be(true)
       end
 
       it "returns false for conditional?" do
-        subject.conditional?.should be(false)
+        expect(subject.conditional?).to be(false)
       end
     end
 
@@ -325,19 +325,19 @@ describe Flipper::Feature do
       end
 
       it "returns :conditional" do
-        subject.state.should be(:conditional)
+        expect(subject.state).to be(:conditional)
       end
 
       it "returns false for on?" do
-        subject.on?.should be(false)
+        expect(subject.on?).to be(false)
       end
 
       it "returns false for off?" do
-        subject.off?.should be(false)
+        expect(subject.off?).to be(false)
       end
 
       it "returns true for conditional?" do
-        subject.conditional?.should be(true)
+        expect(subject.conditional?).to be(true)
       end
     end
   end
@@ -345,7 +345,7 @@ describe Flipper::Feature do
   describe "#enabled_groups" do
     context "when no groups enabled" do
       it "returns empty set" do
-        subject.enabled_groups.should eq(Set.new)
+        expect(subject.enabled_groups).to eq(Set.new)
       end
     end
 
@@ -361,22 +361,22 @@ describe Flipper::Feature do
       end
 
       it "returns set of enabled groups" do
-        subject.enabled_groups.should eq(Set.new([
-          @staff,
-          @preview_features,
-        ]))
+        expect(subject.enabled_groups).to eq(Set.new([
+                  @staff,
+                  @preview_features,
+                ]))
       end
 
       it "does not include groups that have not been enabled" do
-        subject.enabled_groups.should_not include(@not_enabled)
+        expect(subject.enabled_groups).not_to include(@not_enabled)
       end
 
       it "does not include disabled groups" do
-        subject.enabled_groups.should_not include(@disabled)
+        expect(subject.enabled_groups).not_to include(@disabled)
       end
 
       it "is aliased to groups" do
-        subject.enabled_groups.should eq(subject.groups)
+        expect(subject.enabled_groups).to eq(subject.groups)
       end
     end
   end
@@ -384,7 +384,7 @@ describe Flipper::Feature do
   describe "#disabled_groups" do
     context "when no groups enabled" do
       it "returns empty set" do
-        subject.disabled_groups.should eq(Set.new)
+        expect(subject.disabled_groups).to eq(Set.new)
       end
     end
 
@@ -400,10 +400,10 @@ describe Flipper::Feature do
       end
 
       it "returns set of groups that are not enabled" do
-        subject.disabled_groups.should eq(Set[
-          @not_enabled,
-          @disabled,
-        ])
+        expect(subject.disabled_groups).to eq(Set[
+                  @not_enabled,
+                  @disabled,
+                ])
       end
     end
   end
@@ -411,7 +411,7 @@ describe Flipper::Feature do
   describe "#groups_value" do
     context "when no groups enabled" do
       it "returns empty set" do
-        subject.groups_value.should eq(Set.new)
+        expect(subject.groups_value).to eq(Set.new)
       end
     end
 
@@ -427,18 +427,18 @@ describe Flipper::Feature do
       end
 
       it "returns set of enabled groups" do
-        subject.groups_value.should eq(Set.new([
-          @staff.name.to_s,
-          @preview_features.name.to_s,
-        ]))
+        expect(subject.groups_value).to eq(Set.new([
+                  @staff.name.to_s,
+                  @preview_features.name.to_s,
+                ]))
       end
 
       it "does not include groups that have not been enabled" do
-        subject.groups_value.should_not include(@not_enabled.name.to_s)
+        expect(subject.groups_value).not_to include(@not_enabled.name.to_s)
       end
 
       it "does not include disabled groups" do
-        subject.groups_value.should_not include(@disabled.name.to_s)
+        expect(subject.groups_value).not_to include(@disabled.name.to_s)
       end
     end
   end
@@ -446,7 +446,7 @@ describe Flipper::Feature do
   describe "#actors_value" do
     context "when no groups enabled" do
       it "returns empty set" do
-        subject.actors_value.should eq(Set.new)
+        expect(subject.actors_value).to eq(Set.new)
       end
     end
 
@@ -457,7 +457,7 @@ describe Flipper::Feature do
       end
 
       it "returns set of actor ids" do
-        subject.actors_value.should eq(Set.new(["User:5", "User:22"]))
+        expect(subject.actors_value).to eq(Set.new(["User:5", "User:22"]))
       end
     end
   end
@@ -465,7 +465,7 @@ describe Flipper::Feature do
   describe "#boolean_value" do
     context "when not enabled or disabled" do
       it "returns false" do
-        subject.boolean_value.should be(false)
+        expect(subject.boolean_value).to be(false)
       end
     end
 
@@ -475,7 +475,7 @@ describe Flipper::Feature do
       end
 
       it "returns true" do
-        subject.boolean_value.should be(true)
+        expect(subject.boolean_value).to be(true)
       end
     end
 
@@ -485,7 +485,7 @@ describe Flipper::Feature do
       end
 
       it "returns false" do
-        subject.boolean_value.should be(false)
+        expect(subject.boolean_value).to be(false)
       end
     end
   end
@@ -493,7 +493,7 @@ describe Flipper::Feature do
   describe "#percentage_of_actors_value" do
     context "when not enabled or disabled" do
       it "returns nil" do
-        subject.percentage_of_actors_value.should be(0)
+        expect(subject.percentage_of_actors_value).to be(0)
       end
     end
 
@@ -503,7 +503,7 @@ describe Flipper::Feature do
       end
 
       it "returns true" do
-        subject.percentage_of_actors_value.should eq(5)
+        expect(subject.percentage_of_actors_value).to eq(5)
       end
     end
 
@@ -513,7 +513,7 @@ describe Flipper::Feature do
       end
 
       it "returns nil" do
-        subject.percentage_of_actors_value.should be(0)
+        expect(subject.percentage_of_actors_value).to be(0)
       end
     end
   end
@@ -521,7 +521,7 @@ describe Flipper::Feature do
   describe "#percentage_of_time_value" do
     context "when not enabled or disabled" do
       it "returns nil" do
-        subject.percentage_of_time_value.should be(0)
+        expect(subject.percentage_of_time_value).to be(0)
       end
     end
 
@@ -531,7 +531,7 @@ describe Flipper::Feature do
       end
 
       it "returns true" do
-        subject.percentage_of_time_value.should eq(5)
+        expect(subject.percentage_of_time_value).to eq(5)
       end
     end
 
@@ -541,7 +541,7 @@ describe Flipper::Feature do
       end
 
       it "returns nil" do
-        subject.percentage_of_time_value.should be(0)
+        expect(subject.percentage_of_time_value).to be(0)
       end
     end
   end
@@ -549,13 +549,13 @@ describe Flipper::Feature do
   describe "#gate_values" do
     context "when no gates are set in adapter" do
       it "returns default gate values" do
-        subject.gate_values.should eq(Flipper::GateValues.new({
-          :actors => Set.new,
-          :groups => Set.new,
-          :boolean => nil,
-          :percentage_of_actors => nil,
-          :percentage_of_time => nil,
-        }))
+        expect(subject.gate_values).to eq(Flipper::GateValues.new({
+                  :actors => Set.new,
+                  :groups => Set.new,
+                  :boolean => nil,
+                  :percentage_of_actors => nil,
+                  :percentage_of_time => nil,
+                }))
       end
     end
 
@@ -569,13 +569,13 @@ describe Flipper::Feature do
       end
 
       it "returns gate values" do
-        subject.gate_values.should eq(Flipper::GateValues.new({
-          :actors => Set.new(["5"]),
-          :groups => Set.new(["admins"]),
-          :boolean => "true",
-          :percentage_of_time => "50",
-          :percentage_of_actors => "25",
-        }))
+        expect(subject.gate_values).to eq(Flipper::GateValues.new({
+                  :actors => Set.new(["5"]),
+                  :groups => Set.new(["admins"]),
+                  :boolean => "true",
+                  :percentage_of_time => "50",
+                  :percentage_of_actors => "25",
+                }))
       end
     end
   end
@@ -584,11 +584,11 @@ describe Flipper::Feature do
     context "with object that responds to flipper_id" do
       it "updates the gate values to include the actor" do
         actor = Struct.new(:flipper_id).new(5)
-        subject.gate_values.actors.should be_empty
+        expect(subject.gate_values.actors).to be_empty
         subject.enable_actor(actor)
-        subject.gate_values.actors.should eq(Set["5"])
+        expect(subject.gate_values.actors).to eq(Set["5"])
         subject.disable_actor(actor)
-        subject.gate_values.actors.should be_empty
+        expect(subject.gate_values.actors).to be_empty
       end
     end
 
@@ -596,11 +596,11 @@ describe Flipper::Feature do
       it "updates the gate values to include the actor" do
         actor = Struct.new(:flipper_id).new(5)
         instance = Flipper::Types::Actor.wrap(actor)
-        subject.gate_values.actors.should be_empty
+        expect(subject.gate_values.actors).to be_empty
         subject.enable_actor(instance)
-        subject.gate_values.actors.should eq(Set["5"])
+        expect(subject.gate_values.actors).to eq(Set["5"])
         subject.disable_actor(instance)
-        subject.gate_values.actors.should be_empty
+        expect(subject.gate_values.actors).to be_empty
       end
     end
   end
@@ -610,11 +610,11 @@ describe Flipper::Feature do
       it "updates the gate values to include the group" do
         actor = Struct.new(:flipper_id).new(5)
         group = Flipper.register(:five_only) { |actor| actor.flipper_id == 5 }
-        subject.gate_values.groups.should be_empty
+        expect(subject.gate_values.groups).to be_empty
         subject.enable_group(:five_only)
-        subject.gate_values.groups.should eq(Set["five_only"])
+        expect(subject.gate_values.groups).to eq(Set["five_only"])
         subject.disable_group(:five_only)
-        subject.gate_values.groups.should be_empty
+        expect(subject.gate_values.groups).to be_empty
       end
     end
 
@@ -622,11 +622,11 @@ describe Flipper::Feature do
       it "updates the gate values to include the group" do
         actor = Struct.new(:flipper_id).new(5)
         group = Flipper.register(:five_only) { |actor| actor.flipper_id == 5 }
-        subject.gate_values.groups.should be_empty
+        expect(subject.gate_values.groups).to be_empty
         subject.enable_group("five_only")
-        subject.gate_values.groups.should eq(Set["five_only"])
+        expect(subject.gate_values.groups).to eq(Set["five_only"])
         subject.disable_group("five_only")
-        subject.gate_values.groups.should be_empty
+        expect(subject.gate_values.groups).to be_empty
       end
     end
 
@@ -634,11 +634,11 @@ describe Flipper::Feature do
       it "updates the gate values for the group" do
         actor = Struct.new(:flipper_id).new(5)
         group = Flipper.register(:five_only) { |actor| actor.flipper_id == 5 }
-        subject.gate_values.groups.should be_empty
+        expect(subject.gate_values.groups).to be_empty
         subject.enable_group(group)
-        subject.gate_values.groups.should eq(Set["five_only"])
+        expect(subject.gate_values.groups).to eq(Set["five_only"])
         subject.disable_group(group)
-        subject.gate_values.groups.should be_empty
+        expect(subject.gate_values.groups).to be_empty
       end
     end
   end
@@ -646,32 +646,32 @@ describe Flipper::Feature do
   describe "#enable_percentage_of_time/disable_percentage_of_time" do
     context "with integer" do
       it "updates the gate values" do
-        subject.gate_values.percentage_of_time.should be(0)
+        expect(subject.gate_values.percentage_of_time).to be(0)
         subject.enable_percentage_of_time(56)
-        subject.gate_values.percentage_of_time.should be(56)
+        expect(subject.gate_values.percentage_of_time).to be(56)
         subject.disable_percentage_of_time
-        subject.gate_values.percentage_of_time.should be(0)
+        expect(subject.gate_values.percentage_of_time).to be(0)
       end
     end
 
     context "with string" do
       it "updates the gate values" do
-        subject.gate_values.percentage_of_time.should be(0)
+        expect(subject.gate_values.percentage_of_time).to be(0)
         subject.enable_percentage_of_time("56")
-        subject.gate_values.percentage_of_time.should be(56)
+        expect(subject.gate_values.percentage_of_time).to be(56)
         subject.disable_percentage_of_time
-        subject.gate_values.percentage_of_time.should be(0)
+        expect(subject.gate_values.percentage_of_time).to be(0)
       end
     end
 
     context "with percentage of time instance" do
       it "updates the gate values" do
         percentage = Flipper::Types::PercentageOfTime.new(56)
-        subject.gate_values.percentage_of_time.should be(0)
+        expect(subject.gate_values.percentage_of_time).to be(0)
         subject.enable_percentage_of_time(percentage)
-        subject.gate_values.percentage_of_time.should be(56)
+        expect(subject.gate_values.percentage_of_time).to be(56)
         subject.disable_percentage_of_time
-        subject.gate_values.percentage_of_time.should be(0)
+        expect(subject.gate_values.percentage_of_time).to be(0)
       end
     end
   end
@@ -679,32 +679,32 @@ describe Flipper::Feature do
   describe "#enable_percentage_of_actors/disable_percentage_of_actors" do
     context "with integer" do
       it "updates the gate values" do
-        subject.gate_values.percentage_of_actors.should be(0)
+        expect(subject.gate_values.percentage_of_actors).to be(0)
         subject.enable_percentage_of_actors(56)
-        subject.gate_values.percentage_of_actors.should be(56)
+        expect(subject.gate_values.percentage_of_actors).to be(56)
         subject.disable_percentage_of_actors
-        subject.gate_values.percentage_of_actors.should be(0)
+        expect(subject.gate_values.percentage_of_actors).to be(0)
       end
     end
 
     context "with string" do
       it "updates the gate values" do
-        subject.gate_values.percentage_of_actors.should be(0)
+        expect(subject.gate_values.percentage_of_actors).to be(0)
         subject.enable_percentage_of_actors("56")
-        subject.gate_values.percentage_of_actors.should be(56)
+        expect(subject.gate_values.percentage_of_actors).to be(56)
         subject.disable_percentage_of_actors
-        subject.gate_values.percentage_of_actors.should be(0)
+        expect(subject.gate_values.percentage_of_actors).to be(0)
       end
     end
 
     context "with percentage of actors instance" do
       it "updates the gate values" do
         percentage = Flipper::Types::PercentageOfActors.new(56)
-        subject.gate_values.percentage_of_actors.should be(0)
+        expect(subject.gate_values.percentage_of_actors).to be(0)
         subject.enable_percentage_of_actors(percentage)
-        subject.gate_values.percentage_of_actors.should be(56)
+        expect(subject.gate_values.percentage_of_actors).to be(56)
         subject.disable_percentage_of_actors
-        subject.gate_values.percentage_of_actors.should be(0)
+        expect(subject.gate_values.percentage_of_actors).to be(0)
       end
     end
   end
@@ -716,29 +716,29 @@ describe Flipper::Feature do
     end
 
     it "can return enabled gates" do
-      subject.enabled_gates.map(&:name).to_set.should eq(Set[
-        :percentage_of_actors,
-        :percentage_of_time,
-      ])
+      expect(subject.enabled_gates.map(&:name).to_set).to eq(Set[
+              :percentage_of_actors,
+              :percentage_of_time,
+            ])
 
-      subject.enabled_gate_names.to_set.should eq(Set[
-        :percentage_of_actors,
-        :percentage_of_time,
-      ])
+      expect(subject.enabled_gate_names.to_set).to eq(Set[
+              :percentage_of_actors,
+              :percentage_of_time,
+            ])
     end
 
     it "can return disabled gates" do
-      subject.disabled_gates.map(&:name).to_set.should eq(Set[
-        :actor,
-        :boolean,
-        :group,
-      ])
+      expect(subject.disabled_gates.map(&:name).to_set).to eq(Set[
+              :actor,
+              :boolean,
+              :group,
+            ])
 
-      subject.disabled_gate_names.to_set.should eq(Set[
-        :actor,
-        :boolean,
-        :group,
-      ])
+      expect(subject.disabled_gate_names.to_set).to eq(Set[
+              :actor,
+              :boolean,
+              :group,
+            ])
     end
   end
 end

--- a/spec/flipper/gate_spec.rb
+++ b/spec/flipper/gate_spec.rb
@@ -1,6 +1,6 @@
 require 'helper'
 
-describe Flipper::Gate do
+RSpec.describe Flipper::Gate do
   let(:feature_name) { :stats }
 
   subject {
@@ -31,10 +31,10 @@ describe Flipper::Gate do
 
       it "includes attributes" do
         string = subject.inspect
-        string.should include(subject.object_id.to_s)
-        string.should include('name=:name')
-        string.should include('key=:key')
-        string.should include('data_type=:set')
+        expect(string).to include(subject.object_id.to_s)
+        expect(string).to include('name=:name')
+        expect(string).to include('key=:key')
+        expect(string).to include('data_type=:set')
       end
     end
   end

--- a/spec/flipper/gate_values_spec.rb
+++ b/spec/flipper/gate_values_spec.rb
@@ -1,7 +1,7 @@
 require 'helper'
 require 'flipper/gate_values'
 
-describe Flipper::GateValues do
+RSpec.describe Flipper::GateValues do
   {
     nil => false,
     "" => false,
@@ -16,7 +16,7 @@ describe Flipper::GateValues do
   }.each do |value, expected|
     context "with #{value.inspect} boolean" do
       it "returns #{expected}" do
-        described_class.new(boolean: value).boolean.should be(expected)
+        expect(described_class.new(boolean: value).boolean).to be(expected)
       end
     end
   end
@@ -31,7 +31,7 @@ describe Flipper::GateValues do
   }.each do |value, expected|
     context "with #{value.inspect} percentage of time" do
       it "returns #{expected}" do
-        described_class.new(percentage_of_time: value).percentage_of_time.should be(expected)
+        expect(described_class.new(percentage_of_time: value).percentage_of_time).to be(expected)
       end
     end
   end
@@ -46,7 +46,7 @@ describe Flipper::GateValues do
   }.each do |value, expected|
     context "with #{value.inspect} percentage of actors" do
       it "returns #{expected}" do
-        described_class.new(percentage_of_actors: value).percentage_of_actors.should be(expected)
+        expect(described_class.new(percentage_of_actors: value).percentage_of_actors).to be(expected)
       end
     end
   end
@@ -59,7 +59,7 @@ describe Flipper::GateValues do
   }.each do |value, expected|
     context "with #{value.inspect} actors" do
       it "returns #{expected}" do
-        described_class.new(actors: value).actors.should eq(expected)
+        expect(described_class.new(actors: value).actors).to eq(expected)
       end
     end
   end
@@ -72,7 +72,7 @@ describe Flipper::GateValues do
   }.each do |value, expected|
     context "with #{value.inspect} groups" do
       it "returns #{expected}" do
-        described_class.new(groups: value).groups.should eq(expected)
+        expect(described_class.new(groups: value).groups).to eq(expected)
       end
     end
   end
@@ -103,32 +103,32 @@ describe Flipper::GateValues do
 
   describe "#[]" do
     it "can read the boolean value" do
-      described_class.new(boolean: true)[:boolean].should be(true)
-      described_class.new(boolean: true)["boolean"].should be(true)
+      expect(described_class.new(boolean: true)[:boolean]).to be(true)
+      expect(described_class.new(boolean: true)["boolean"]).to be(true)
     end
 
     it "can read the actors value" do
-      described_class.new(actors: Set[1, 2])[:actors].should eq(Set[1, 2])
-      described_class.new(actors: Set[1, 2])["actors"].should eq(Set[1, 2])
+      expect(described_class.new(actors: Set[1, 2])[:actors]).to eq(Set[1, 2])
+      expect(described_class.new(actors: Set[1, 2])["actors"]).to eq(Set[1, 2])
     end
 
     it "can read the groups value" do
-      described_class.new(groups: Set[:admins])[:groups].should eq(Set[:admins])
-      described_class.new(groups: Set[:admins])["groups"].should eq(Set[:admins])
+      expect(described_class.new(groups: Set[:admins])[:groups]).to eq(Set[:admins])
+      expect(described_class.new(groups: Set[:admins])["groups"]).to eq(Set[:admins])
     end
 
     it "can read the percentage of time value" do
-      described_class.new(percentage_of_time: 15)[:percentage_of_time].should eq(15)
-      described_class.new(percentage_of_time: 15)["percentage_of_time"].should eq(15)
+      expect(described_class.new(percentage_of_time: 15)[:percentage_of_time]).to eq(15)
+      expect(described_class.new(percentage_of_time: 15)["percentage_of_time"]).to eq(15)
     end
 
     it "can read the percentage of actors value" do
-      described_class.new(percentage_of_actors: 15)[:percentage_of_actors].should eq(15)
-      described_class.new(percentage_of_actors: 15)["percentage_of_actors"].should eq(15)
+      expect(described_class.new(percentage_of_actors: 15)[:percentage_of_actors]).to eq(15)
+      expect(described_class.new(percentage_of_actors: 15)["percentage_of_actors"]).to eq(15)
     end
 
     it "returns nil for value that is not present" do
-      described_class.new({})["not legit"].should be(nil)
+      expect(described_class.new({})["not legit"]).to be(nil)
     end
   end
 end

--- a/spec/flipper/gates/actor_spec.rb
+++ b/spec/flipper/gates/actor_spec.rb
@@ -1,6 +1,6 @@
 require 'helper'
 
-describe Flipper::Gates::Actor do
+RSpec.describe Flipper::Gates::Actor do
   let(:feature_name) { :search }
 
   subject {

--- a/spec/flipper/gates/boolean_spec.rb
+++ b/spec/flipper/gates/boolean_spec.rb
@@ -1,6 +1,6 @@
 require 'helper'
 
-describe Flipper::Gates::Boolean do
+RSpec.describe Flipper::Gates::Boolean do
   let(:feature_name) { :search }
 
   subject {
@@ -10,13 +10,13 @@ describe Flipper::Gates::Boolean do
   describe "#enabled?" do
     context "for true value" do
       it "returns true" do
-        subject.enabled?(true).should eq(true)
+        expect(subject.enabled?(true)).to eq(true)
       end
     end
 
     context "for false value" do
       it "returns false" do
-        subject.enabled?(false).should eq(false)
+        expect(subject.enabled?(false)).to eq(false)
       end
     end
   end
@@ -24,44 +24,44 @@ describe Flipper::Gates::Boolean do
   describe "#open?" do
     context "for true value" do
       it "returns true" do
-        subject.open?(Object.new, true, feature_name: feature_name).should eq(true)
+        expect(subject.open?(Object.new, true, feature_name: feature_name)).to eq(true)
       end
     end
 
     context "for false value" do
       it "returns false" do
-        subject.open?(Object.new, false, feature_name: feature_name).should eq(false)
+        expect(subject.open?(Object.new, false, feature_name: feature_name)).to eq(false)
       end
     end
   end
 
   describe "#protects?" do
     it "returns true for boolean type" do
-      subject.protects?(Flipper::Types::Boolean.new(true)).should be(true)
+      expect(subject.protects?(Flipper::Types::Boolean.new(true))).to be(true)
     end
 
     it "returns true for true" do
-      subject.protects?(true).should be(true)
+      expect(subject.protects?(true)).to be(true)
     end
 
     it "returns true for false" do
-      subject.protects?(false).should be(true)
+      expect(subject.protects?(false)).to be(true)
     end
   end
 
   describe "#wrap" do
     it "returns boolean type for boolean type" do
-      subject.wrap(Flipper::Types::Boolean.new(true)).should be_instance_of(Flipper::Types::Boolean)
+      expect(subject.wrap(Flipper::Types::Boolean.new(true))).to be_instance_of(Flipper::Types::Boolean)
     end
 
     it "returns boolean type for true" do
-      subject.wrap(true).should be_instance_of(Flipper::Types::Boolean)
-      subject.wrap(true).value.should be(true)
+      expect(subject.wrap(true)).to be_instance_of(Flipper::Types::Boolean)
+      expect(subject.wrap(true).value).to be(true)
     end
 
     it "returns boolean type for true" do
-      subject.wrap(false).should be_instance_of(Flipper::Types::Boolean)
-      subject.wrap(false).value.should be(false)
+      expect(subject.wrap(false)).to be_instance_of(Flipper::Types::Boolean)
+      expect(subject.wrap(false).value).to be(false)
     end
   end
 end

--- a/spec/flipper/gates/group_spec.rb
+++ b/spec/flipper/gates/group_spec.rb
@@ -1,6 +1,6 @@
 require 'helper'
 
-describe Flipper::Gates::Group do
+RSpec.describe Flipper::Gates::Group do
   let(:feature_name) { :search }
 
   subject {
@@ -15,7 +15,7 @@ describe Flipper::Gates::Group do
 
       it "ignores group" do
         thing = Struct.new(:flipper_id).new('5')
-        subject.open?(thing, Set[:newbs, :staff], feature_name: feature_name).should eq(true)
+        expect(subject.open?(thing, Set[:newbs, :staff], feature_name: feature_name)).to eq(true)
       end
     end
 
@@ -35,23 +35,23 @@ describe Flipper::Gates::Group do
   describe "#wrap" do
     it "returns group instance for symbol" do
       group = Flipper.register(:admins) {}
-      subject.wrap(:admins).should eq(group)
+      expect(subject.wrap(:admins)).to eq(group)
     end
 
     it "returns group instance for group instance" do
       group = Flipper.register(:admins) {}
-      subject.wrap(group).should eq(group)
+      expect(subject.wrap(group)).to eq(group)
     end
   end
 
   describe "#protects?" do
     it "returns true for group" do
       group = Flipper.register(:admins) {}
-      subject.protects?(group).should be(true)
+      expect(subject.protects?(group)).to be(true)
     end
 
     it "returns true for symbol" do
-      subject.protects?(:admins).should be(true)
+      expect(subject.protects?(:admins)).to be(true)
     end
   end
 end

--- a/spec/flipper/gates/percentage_of_actors_spec.rb
+++ b/spec/flipper/gates/percentage_of_actors_spec.rb
@@ -1,6 +1,6 @@
 require 'helper'
 
-describe Flipper::Gates::PercentageOfActors do
+RSpec.describe Flipper::Gates::PercentageOfActors do
   let(:feature_name) { :search }
 
   subject {
@@ -28,7 +28,7 @@ describe Flipper::Gates::PercentageOfActors do
       end
 
       it "does not enable both features for same set of actors" do
-        feature_one_enabled_actors.should_not eq(feature_two_enabled_actors)
+        expect(feature_one_enabled_actors).not_to eq(feature_two_enabled_actors)
       end
 
       it "enables feature for accurate number of actors for each feature" do
@@ -39,7 +39,7 @@ describe Flipper::Gates::PercentageOfActors do
           feature_one_enabled_actors.size,
           feature_two_enabled_actors.size,
         ].each do |actual_enabled_size|
-          actual_enabled_size.should be_within(margin_of_error).of(expected_enabled_size)
+          expect(actual_enabled_size).to be_within(margin_of_error).of(expected_enabled_size)
         end
       end
     end

--- a/spec/flipper/gates/percentage_of_time_spec.rb
+++ b/spec/flipper/gates/percentage_of_time_spec.rb
@@ -1,6 +1,6 @@
 require 'helper'
 
-describe Flipper::Gates::PercentageOfTime do
+RSpec.describe Flipper::Gates::PercentageOfTime do
   let(:feature_name) { :search }
 
   subject {

--- a/spec/flipper/instrumentation/log_subscriber_spec.rb
+++ b/spec/flipper/instrumentation/log_subscriber_spec.rb
@@ -3,7 +3,7 @@ require 'helper'
 require 'flipper/adapters/memory'
 require 'flipper/instrumentation/log_subscriber'
 
-describe Flipper::Instrumentation::LogSubscriber do
+RSpec.describe Flipper::Instrumentation::LogSubscriber do
   let(:adapter) { Flipper::Adapters::Memory.new }
   let(:flipper) {
     Flipper.new(adapter, :instrumenter => ActiveSupport::Notifications)
@@ -34,18 +34,18 @@ describe Flipper::Instrumentation::LogSubscriber do
 
     it "logs feature calls with result after operation" do
       feature_line = find_line('Flipper feature(search) enabled? false')
-      feature_line.should include('[ thing=nil ]')
+      expect(feature_line).to include('[ thing=nil ]')
     end
 
     it "logs adapter calls" do
       adapter_line = find_line('Flipper feature(search) adapter(memory) get')
-      adapter_line.should include('[ result={')
-      adapter_line.should include('} ]')
+      expect(adapter_line).to include('[ result={')
+      expect(adapter_line).to include('} ]')
     end
 
     it "logs gate calls" do
       gate_line = find_line('Flipper feature(search) gate(boolean) open? false')
-      gate_line.should include('[ thing=nil ]')
+      expect(gate_line).to include('[ thing=nil ]')
     end
   end
 
@@ -59,12 +59,12 @@ describe Flipper::Instrumentation::LogSubscriber do
 
     it "logs thing for feature" do
       feature_line = find_line('Flipper feature(search) enabled?')
-      feature_line.should include(user.inspect)
+      expect(feature_line).to include(user.inspect)
     end
 
     it "logs thing for gate" do
       gate_line = find_line('Flipper feature(search) gate(boolean) open')
-      gate_line.should include(user.inspect)
+      expect(gate_line).to include(user.inspect)
     end
   end
 
@@ -78,12 +78,12 @@ describe Flipper::Instrumentation::LogSubscriber do
 
     it "logs feature calls with result in brackets" do
       feature_line = find_line('Flipper feature(search) enable true')
-      feature_line.should include("[ thing=#{user.inspect} gate_name=actor ]")
+      expect(feature_line).to include("[ thing=#{user.inspect} gate_name=actor ]")
     end
 
     it "logs adapter value" do
       adapter_line = find_line('Flipper feature(search) adapter(memory) enable')
-      adapter_line.should include("[ result=")
+      expect(adapter_line).to include("[ result=")
     end
   end
 
@@ -95,7 +95,7 @@ describe Flipper::Instrumentation::LogSubscriber do
 
     it "logs adapter calls" do
       adapter_line = find_line('Flipper adapter(memory) features')
-      adapter_line.should include('[ result=')
+      expect(adapter_line).to include('[ result=')
     end
   end
 

--- a/spec/flipper/instrumentation/metriks_subscriber_spec.rb
+++ b/spec/flipper/instrumentation/metriks_subscriber_spec.rb
@@ -2,7 +2,7 @@ require 'helper'
 require 'flipper/adapters/memory'
 require 'flipper/instrumentation/metriks'
 
-describe Flipper::Instrumentation::MetriksSubscriber do
+RSpec.describe Flipper::Instrumentation::MetriksSubscriber do
   let(:adapter) { Flipper::Adapters::Memory.new }
   let(:flipper) {
     Flipper.new(adapter, :instrumenter => ActiveSupport::Notifications)
@@ -17,43 +17,43 @@ describe Flipper::Instrumentation::MetriksSubscriber do
   context "for enabled feature" do
     it "updates feature metrics when calls happen" do
       flipper[:stats].enable(user)
-      Metriks.timer("flipper.feature_operation.enable").count.should be(1)
+      expect(Metriks.timer("flipper.feature_operation.enable").count).to be(1)
 
       flipper[:stats].enabled?(user)
-      Metriks.timer("flipper.feature_operation.enabled").count.should be(1)
-      Metriks.meter("flipper.feature.stats.enabled").count.should be(1)
+      expect(Metriks.timer("flipper.feature_operation.enabled").count).to be(1)
+      expect(Metriks.meter("flipper.feature.stats.enabled").count).to be(1)
     end
   end
 
   context "for disabled feature" do
     it "updates feature metrics when calls happen" do
       flipper[:stats].disable(user)
-      Metriks.timer("flipper.feature_operation.disable").count.should be(1)
+      expect(Metriks.timer("flipper.feature_operation.disable").count).to be(1)
 
       flipper[:stats].enabled?(user)
-      Metriks.timer("flipper.feature_operation.enabled").count.should be(1)
-      Metriks.meter("flipper.feature.stats.disabled").count.should be(1)
+      expect(Metriks.timer("flipper.feature_operation.enabled").count).to be(1)
+      expect(Metriks.meter("flipper.feature.stats.disabled").count).to be(1)
     end
   end
 
   it "updates adapter metrics when calls happen" do
     flipper[:stats].enable(user)
-    Metriks.timer("flipper.adapter.memory.enable").count.should be(1)
+    expect(Metriks.timer("flipper.adapter.memory.enable").count).to be(1)
 
     flipper[:stats].enabled?(user)
-    Metriks.timer("flipper.adapter.memory.get").count.should be(1)
+    expect(Metriks.timer("flipper.adapter.memory.get").count).to be(1)
 
     flipper[:stats].disable(user)
-    Metriks.timer("flipper.adapter.memory.disable").count.should be(1)
+    expect(Metriks.timer("flipper.adapter.memory.disable").count).to be(1)
   end
 
   it "updates gate metrics when calls happen" do
     flipper[:stats].enable(user)
     flipper[:stats].enabled?(user)
 
-    Metriks.timer("flipper.gate_operation.boolean.open").count.should be(1)
-    Metriks.timer("flipper.feature.stats.gate_operation.boolean.open").count.should be(1)
-    Metriks.meter("flipper.feature.stats.gate.actor.open").count.should be(1)
-    Metriks.meter("flipper.feature.stats.gate.boolean.closed").count.should be(1)
+    expect(Metriks.timer("flipper.gate_operation.boolean.open").count).to be(1)
+    expect(Metriks.timer("flipper.feature.stats.gate_operation.boolean.open").count).to be(1)
+    expect(Metriks.meter("flipper.feature.stats.gate.actor.open").count).to be(1)
+    expect(Metriks.meter("flipper.feature.stats.gate.boolean.closed").count).to be(1)
   end
 end

--- a/spec/flipper/instrumentation/statsd_subscriber_spec.rb
+++ b/spec/flipper/instrumentation/statsd_subscriber_spec.rb
@@ -2,7 +2,7 @@ require 'helper'
 require 'flipper/adapters/memory'
 require 'flipper/instrumentation/statsd'
 
-describe Flipper::Instrumentation::StatsdSubscriber do
+RSpec.describe Flipper::Instrumentation::StatsdSubscriber do
   let(:statsd_client) { Statsd.new }
   let(:socket) { FakeUDPSocket.new }
   let(:adapter) { Flipper::Adapters::Memory.new }
@@ -24,11 +24,13 @@ describe Flipper::Instrumentation::StatsdSubscriber do
 
   def assert_timer(metric)
     regex = /#{Regexp.escape metric}\:\d+\|ms/
-    socket.buffer.detect { |op| op.first =~ regex }.should_not be_nil
+    result = socket.buffer.detect { |op| op.first =~ regex }
+    expect(result).not_to be_nil
   end
 
   def assert_counter(metric)
-    socket.buffer.detect { |op| op.first == "#{metric}:1|c" }.should_not be_nil
+    result = socket.buffer.detect { |op| op.first == "#{metric}:1|c" }
+    expect(result).not_to be_nil
   end
 
   context "for enabled feature" do

--- a/spec/flipper/instrumenters/memory_spec.rb
+++ b/spec/flipper/instrumenters/memory_spec.rb
@@ -1,11 +1,11 @@
 require 'helper'
 require 'flipper/instrumenters/memory'
 
-describe Flipper::Instrumenters::Memory do
+RSpec.describe Flipper::Instrumenters::Memory do
   describe "#initialize" do
     it "sets events to empty array" do
       instrumenter = described_class.new
-      instrumenter.events.should eq([])
+      expect(instrumenter.events).to eq([])
     end
   end
 
@@ -17,10 +17,10 @@ describe Flipper::Instrumenters::Memory do
       block_result = :yielded
 
       result = instrumenter.instrument(name, payload) { block_result }
-      result.should eq(block_result)
+      expect(result).to eq(block_result)
 
       event = described_class::Event.new(name, payload, block_result)
-      instrumenter.events.should eq([event])
+      expect(instrumenter.events).to eq([event])
     end
   end
 end

--- a/spec/flipper/instrumenters/noop_spec.rb
+++ b/spec/flipper/instrumenters/noop_spec.rb
@@ -1,13 +1,13 @@
 require 'helper'
 require 'flipper/instrumenters/noop'
 
-describe Flipper::Instrumenters::Noop do
+RSpec.describe Flipper::Instrumenters::Noop do
   describe ".instrument" do
     context "with name" do
       it "yields block" do
         yielded = false
         described_class.instrument(:foo) { yielded = true }
-        yielded.should eq(true)
+        expect(yielded).to eq(true)
       end
     end
 
@@ -15,7 +15,7 @@ describe Flipper::Instrumenters::Noop do
       it "yields block" do
         yielded = false
         described_class.instrument(:foo, {:pay => :load}) { yielded = true }
-        yielded.should eq(true)
+        expect(yielded).to eq(true)
       end
     end
   end

--- a/spec/flipper/middleware/memoizer_spec.rb
+++ b/spec/flipper/middleware/memoizer_spec.rb
@@ -4,7 +4,7 @@ require 'flipper/middleware/memoizer'
 require 'flipper/adapters/operation_logger'
 require 'flipper/adapters/memory'
 
-describe Flipper::Middleware::Memoizer do
+RSpec.describe Flipper::Middleware::Memoizer do
   include Rack::Test::Methods
 
   let(:memory_adapter) { Flipper::Adapters::Memory.new }
@@ -26,7 +26,7 @@ describe Flipper::Middleware::Memoizer do
       }
       middleware = described_class.new app, flipper
       middleware.call({})
-      called.should eq(true)
+      expect(called).to eq(true)
     end
 
     it "disables local cache after body close" do
@@ -34,9 +34,9 @@ describe Flipper::Middleware::Memoizer do
       middleware = described_class.new app, flipper
       body = middleware.call({}).last
 
-      flipper.adapter.memoizing?.should eq(true)
+      expect(flipper.adapter.memoizing?).to eq(true)
       body.close
-      flipper.adapter.memoizing?.should eq(false)
+      expect(flipper.adapter.memoizing?).to eq(false)
     end
 
     it "clears local cache after body close" do
@@ -46,19 +46,19 @@ describe Flipper::Middleware::Memoizer do
 
       flipper.adapter.cache['hello'] = 'world'
       body.close
-      flipper.adapter.cache.should be_empty
+      expect(flipper.adapter.cache).to be_empty
     end
 
     it "clears the local cache with a successful request" do
       flipper.adapter.cache['hello'] = 'world'
       get '/'
-      flipper.adapter.cache.should be_empty
+      expect(flipper.adapter.cache).to be_empty
     end
 
     it "clears the local cache even when the request raises an error" do
       flipper.adapter.cache['hello'] = 'world'
       get '/fail' rescue nil
-      flipper.adapter.cache.should be_empty
+      expect(flipper.adapter.cache).to be_empty
     end
 
     it "caches getting a feature for duration of request" do
@@ -80,7 +80,7 @@ describe Flipper::Middleware::Memoizer do
       middleware = described_class.new app, flipper
       middleware.call({})
 
-      adapter.count(:get).should be(1)
+      expect(adapter.count(:get)).to be(1)
     end
   end
 

--- a/spec/flipper/registry_spec.rb
+++ b/spec/flipper/registry_spec.rb
@@ -1,7 +1,7 @@
 require 'helper'
 require 'flipper/registry'
 
-describe Flipper::Registry do
+RSpec.describe Flipper::Registry do
   subject { Flipper::Registry.new(source) }
 
   let(:source) { {} }
@@ -10,13 +10,13 @@ describe Flipper::Registry do
     it "adds to source" do
       value = 'thing'
       subject.add(:admins, value)
-      source[:admins].should eq(value)
+      expect(source[:admins]).to eq(value)
     end
 
     it "converts key to symbol" do
       value = 'thing'
       subject.add('admins', value)
-      source[:admins].should eq(value)
+      expect(source[:admins]).to eq(value)
     end
 
     it "raises exception if key already registered" do
@@ -35,11 +35,11 @@ describe Flipper::Registry do
       end
 
       it "returns value" do
-        subject.get(:admins).should eq('thing')
+        expect(subject.get(:admins)).to eq('thing')
       end
 
       it "returns value if given string key" do
-        subject.get('admins').should eq('thing')
+        expect(subject.get('admins')).to eq('thing')
       end
     end
 
@@ -58,11 +58,11 @@ describe Flipper::Registry do
     end
 
     it "returns true if the key exists" do
-      subject.key?(:admins).should eq true
+      expect(subject.key?(:admins)).to eq true
     end
 
     it "returns false if the key does not exists" do
-      subject.key?(:unknown_key).should eq false
+      expect(subject.key?(:unknown_key)).to eq false
     end
   end
 
@@ -77,10 +77,10 @@ describe Flipper::Registry do
       subject.each do |key, value|
         results[key] = value
       end
-      results.should eq({
-        :admins => 'admins',
-        :devs => 'devs',
-      })
+      expect(results).to eq({
+              :admins => 'admins',
+              :devs => 'devs',
+            })
     end
   end
 
@@ -91,12 +91,12 @@ describe Flipper::Registry do
     end
 
     it "returns the keys" do
-      subject.keys.map(&:to_s).sort.should eq(['admins', 'devs'])
+      expect(subject.keys.map(&:to_s).sort).to eq(['admins', 'devs'])
     end
 
     it "returns the keys as symbols" do
       subject.keys.each do |key|
-        key.should be_instance_of(Symbol)
+        expect(key).to be_instance_of(Symbol)
       end
     end
   end
@@ -108,7 +108,7 @@ describe Flipper::Registry do
     end
 
     it "returns the values" do
-      subject.values.map(&:to_s).sort.should eq(['admins', 'devs'])
+      expect(subject.values.map(&:to_s).sort).to eq(['admins', 'devs'])
     end
   end
 
@@ -127,8 +127,8 @@ describe Flipper::Registry do
         values << value
       end
 
-      keys.map(&:to_s).sort.should eq(['admins', 'devs'])
-      values.sort.should eq(['admins', 'devs'])
+      expect(keys.map(&:to_s).sort).to eq(['admins', 'devs'])
+      expect(values.sort).to eq(['admins', 'devs'])
     end
   end
 
@@ -139,7 +139,7 @@ describe Flipper::Registry do
 
     it "clears the source" do
       subject.clear
-      source.should be_empty
+      expect(source).to be_empty
     end
   end
 end

--- a/spec/flipper/typecast_spec.rb
+++ b/spec/flipper/typecast_spec.rb
@@ -1,7 +1,7 @@
 require 'helper'
 require 'flipper/typecast'
 
-describe Flipper::Typecast do
+RSpec.describe Flipper::Typecast do
   {
     nil => false,
     "" => false,
@@ -16,7 +16,7 @@ describe Flipper::Typecast do
   }.each do |value, expected|
     context "#to_boolean for #{value.inspect}" do
       it "returns #{expected}" do
-        described_class.to_boolean(value).should be(expected)
+        expect(described_class.to_boolean(value)).to be(expected)
       end
     end
   end
@@ -31,7 +31,7 @@ describe Flipper::Typecast do
   }.each do |value, expected|
     context "#to_integer for #{value.inspect}" do
       it "returns #{expected}" do
-        described_class.to_integer(value).should be(expected)
+        expect(described_class.to_integer(value)).to be(expected)
       end
     end
   end
@@ -44,7 +44,7 @@ describe Flipper::Typecast do
   }.each do |value, expected|
     context "#to_set for #{value.inspect}" do
       it "returns #{expected}" do
-        described_class.to_set(value).should eq(expected)
+        expect(described_class.to_set(value)).to eq(expected)
       end
     end
   end

--- a/spec/flipper/types/actor_spec.rb
+++ b/spec/flipper/types/actor_spec.rb
@@ -1,7 +1,7 @@
 require 'helper'
 require 'flipper/types/actor'
 
-describe Flipper::Types::Actor do
+RSpec.describe Flipper::Types::Actor do
   subject {
     thing = thing_class.new('2')
     described_class.new(thing)
@@ -25,16 +25,16 @@ describe Flipper::Types::Actor do
     it "returns true if actor" do
       thing = thing_class.new('1')
       actor = described_class.new(thing)
-      described_class.wrappable?(actor).should eq(true)
+      expect(described_class.wrappable?(actor)).to eq(true)
     end
 
     it "returns true if responds to flipper_id" do
       thing = thing_class.new(10)
-      described_class.wrappable?(thing).should eq(true)
+      expect(described_class.wrappable?(thing)).to eq(true)
     end
 
     it "returns false if nil" do
-      described_class.wrappable?(nil).should be(false)
+      expect(described_class.wrappable?(nil)).to be(false)
     end
   end
 
@@ -42,8 +42,8 @@ describe Flipper::Types::Actor do
     context "for actor" do
       it "returns actor" do
         actor = described_class.wrap(subject)
-        actor.should be_instance_of(described_class)
-        actor.should be(subject)
+        expect(actor).to be_instance_of(described_class)
+        expect(actor).to be(subject)
       end
     end
 
@@ -51,7 +51,7 @@ describe Flipper::Types::Actor do
       it "returns actor" do
         thing = thing_class.new('1')
         actor = described_class.wrap(thing)
-        actor.should be_instance_of(described_class)
+        expect(actor).to be_instance_of(described_class)
       end
     end
   end
@@ -59,7 +59,7 @@ describe Flipper::Types::Actor do
   it "initializes with thing that responds to id" do
     thing = thing_class.new('1')
     actor = described_class.new(thing)
-    actor.value.should eq('1')
+    expect(actor.value).to eq('1')
   end
 
   it "raises error when initialized with nil" do
@@ -78,38 +78,38 @@ describe Flipper::Types::Actor do
   it "converts id to string" do
     thing = thing_class.new(2)
     actor = described_class.new(thing)
-    actor.value.should eq('2')
+    expect(actor.value).to eq('2')
   end
 
   it "proxies everything to thing" do
     thing = thing_class.new(10)
     actor = described_class.new(thing)
-    actor.admin?.should eq(true)
+    expect(actor.admin?).to eq(true)
   end
 
   it "exposes thing" do
     thing = thing_class.new(10)
     actor = described_class.new(thing)
-    actor.thing.should be(thing)
+    expect(actor.thing).to be(thing)
   end
 
   describe "#respond_to?" do
     it "returns true if responds to method" do
       thing = thing_class.new('1')
       actor = described_class.new(thing)
-      actor.respond_to?(:value).should eq(true)
+      expect(actor.respond_to?(:value)).to eq(true)
     end
 
     it "returns true if thing responds to method" do
       thing = thing_class.new(10)
       actor = described_class.new(thing)
-      actor.respond_to?(:admin?).should eq(true)
+      expect(actor.respond_to?(:admin?)).to eq(true)
     end
 
     it "returns false if does not respond to method and thing does not respond to method" do
       thing = thing_class.new(10)
       actor = described_class.new(thing)
-      actor.respond_to?(:frankenstein).should eq(false)
+      expect(actor.respond_to?(:frankenstein)).to eq(false)
     end
   end
 end

--- a/spec/flipper/types/boolean_spec.rb
+++ b/spec/flipper/types/boolean_spec.rb
@@ -1,24 +1,24 @@
 require 'helper'
 require 'flipper/types/boolean'
 
-describe Flipper::Types::Boolean do
+RSpec.describe Flipper::Types::Boolean do
   it "defaults value to true" do
     boolean = Flipper::Types::Boolean.new
-    boolean.value.should be(true)
+    expect(boolean.value).to be(true)
   end
 
   it "allows overriding default value" do
     boolean = Flipper::Types::Boolean.new(false)
-    boolean.value.should be(false)
+    expect(boolean.value).to be(false)
   end
 
   it "returns true for nil value" do
     boolean = Flipper::Types::Boolean.new(nil)
-    boolean.value.should be(true)
+    expect(boolean.value).to be(true)
   end
 
   it "typecasts value" do
     boolean = Flipper::Types::Boolean.new(1)
-    boolean.value.should be(true)
+    expect(boolean.value).to be(true)
   end
 end

--- a/spec/flipper/types/group_spec.rb
+++ b/spec/flipper/types/group_spec.rb
@@ -1,7 +1,7 @@
 require 'helper'
 require 'flipper/types/group'
 
-describe Flipper::Types::Group do
+RSpec.describe Flipper::Types::Group do
   subject do
     Flipper.register(:admins) { |actor| actor.admin? }
   end
@@ -9,31 +9,31 @@ describe Flipper::Types::Group do
   describe ".wrap" do
     context "with group instance" do
       it "returns group instance" do
-        described_class.wrap(subject).should eq(subject)
+        expect(described_class.wrap(subject)).to eq(subject)
       end
     end
 
     context "with Symbol group name" do
       it "returns group instance" do
-        described_class.wrap(subject.name).should eq(subject)
+        expect(described_class.wrap(subject.name)).to eq(subject)
       end
     end
 
     context "with String group name" do
       it "returns group instance" do
-        described_class.wrap(subject.name.to_s).should eq(subject)
+        expect(described_class.wrap(subject.name.to_s)).to eq(subject)
       end
     end
   end
 
   it "initializes with name" do
     group = Flipper::Types::Group.new(:admins)
-    group.should be_instance_of(Flipper::Types::Group)
+    expect(group).to be_instance_of(Flipper::Types::Group)
   end
 
   describe "#name" do
     it "returns name" do
-      subject.name.should eq(:admins)
+      expect(subject.name).to eq(:admins)
     end
   end
 
@@ -42,11 +42,11 @@ describe Flipper::Types::Group do
     let(:non_admin_actor) { double('Actor', :admin? => false) }
 
     it "returns true if block matches" do
-      subject.match?(admin_actor).should eq(true)
+      expect(subject.match?(admin_actor)).to eq(true)
     end
 
     it "returns false if block does not match" do
-      subject.match?(non_admin_actor).should eq(false)
+      expect(subject.match?(non_admin_actor)).to eq(false)
     end
   end
 end

--- a/spec/flipper/types/percentage_of_actors_spec.rb
+++ b/spec/flipper/types/percentage_of_actors_spec.rb
@@ -1,6 +1,6 @@
 require 'helper'
 require 'flipper/types/percentage_of_actors'
 
-describe Flipper::Types::PercentageOfActors do
+RSpec.describe Flipper::Types::PercentageOfActors do
   it_should_behave_like 'a percentage'
 end

--- a/spec/flipper/types/percentage_of_time_spec.rb
+++ b/spec/flipper/types/percentage_of_time_spec.rb
@@ -1,6 +1,6 @@
 require 'helper'
 require 'flipper/types/percentage_of_time'
 
-describe Flipper::Types::PercentageOfTime do
+RSpec.describe Flipper::Types::PercentageOfTime do
   it_should_behave_like 'a percentage'
 end

--- a/spec/flipper/types/percentage_spec.rb
+++ b/spec/flipper/types/percentage_spec.rb
@@ -1,7 +1,7 @@
 require 'helper'
 require 'flipper/types/percentage_of_actors'
 
-describe Flipper::Types::Percentage do
+RSpec.describe Flipper::Types::Percentage do
   subject {
     described_class.new(5)
   }
@@ -10,38 +10,38 @@ describe Flipper::Types::Percentage do
   describe ".wrap" do
     context "with percentage instance" do
       it "returns percentage instance" do
-        described_class.wrap(subject).should eq(subject)
+        expect(described_class.wrap(subject)).to eq(subject)
       end
     end
 
     context "with Integer" do
       it "returns percentage instance" do
-        described_class.wrap(subject.value).should eq(subject)
+        expect(described_class.wrap(subject.value)).to eq(subject)
       end
     end
 
     context "with String" do
       it "returns percentage instance" do
-        described_class.wrap(subject.value.to_s).should eq(subject)
+        expect(described_class.wrap(subject.value.to_s)).to eq(subject)
       end
     end
   end
 
   describe "#eql?" do
     it "returns true for same class and value" do
-      subject.eql?(described_class.new(subject.value)).should eq(true)
+      expect(subject.eql?(described_class.new(subject.value))).to eq(true)
     end
 
     it "returns false for different value" do
-      subject.eql?(described_class.new(subject.value + 1)).should eq(false)
+      expect(subject.eql?(described_class.new(subject.value + 1))).to eq(false)
     end
 
     it "returns false for different class" do
-      subject.eql?(Object.new).should eq(false)
+      expect(subject.eql?(Object.new)).to eq(false)
     end
 
     it "is aliased to ==" do
-      (subject == described_class.new(subject.value)).should eq(true)
+      expect((subject == described_class.new(subject.value))).to eq(true)
     end
   end
 end

--- a/spec/flipper/ui/actions/actors_gate_spec.rb
+++ b/spec/flipper/ui/actions/actors_gate_spec.rb
@@ -1,17 +1,17 @@
 require 'helper'
 
-describe Flipper::UI::Actions::ActorsGate do
+RSpec.describe Flipper::UI::Actions::ActorsGate do
   describe "GET /features/:feature/actors" do
     before do
       get "features/search/actors"
     end
 
     it "responds with success" do
-      last_response.status.should be(200)
+      expect(last_response.status).to be(200)
     end
 
     it "renders add new actor form" do
-      last_response.body.should include('<form action="/features/search/actors" method="post">')
+      expect(last_response.body).to include('<form action="/features/search/actors" method="post">')
     end
   end
 
@@ -24,12 +24,12 @@ describe Flipper::UI::Actions::ActorsGate do
       end
 
       it "adds item to members" do
-        flipper[:search].actors_value.should include("User:6")
+        expect(flipper[:search].actors_value).to include("User:6")
       end
 
       it "redirects back to feature" do
-        last_response.status.should be(302)
-        last_response.headers["Location"].should eq("/features/search")
+        expect(last_response.status).to be(302)
+        expect(last_response.headers["Location"]).to eq("/features/search")
       end
     end
 
@@ -42,12 +42,12 @@ describe Flipper::UI::Actions::ActorsGate do
       end
 
       it "removes item from members" do
-        flipper[:search].actors_value.should_not include("User:6")
+        expect(flipper[:search].actors_value).not_to include("User:6")
       end
 
       it "redirects back to feature" do
-        last_response.status.should be(302)
-        last_response.headers["Location"].should eq("/features/search")
+        expect(last_response.status).to be(302)
+        expect(last_response.headers["Location"]).to eq("/features/search")
       end
     end
 
@@ -59,8 +59,8 @@ describe Flipper::UI::Actions::ActorsGate do
       end
 
       it "redirects back to feature" do
-        last_response.status.should be(302)
-        last_response.headers["Location"].should eq("/features/search/actors?error=%22%22+is+not+a+valid+actor+value.")
+        expect(last_response.status).to be(302)
+        expect(last_response.headers["Location"]).to eq("/features/search/actors?error=%22%22+is+not+a+valid+actor+value.")
       end
     end
   end

--- a/spec/flipper/ui/actions/add_feature_spec.rb
+++ b/spec/flipper/ui/actions/add_feature_spec.rb
@@ -1,17 +1,17 @@
 require 'helper'
 
-describe Flipper::UI::Actions::AddFeature do
+RSpec.describe Flipper::UI::Actions::AddFeature do
   describe "GET /features/new" do
     before do
       get "/features/new"
     end
 
     it "responds with success" do
-      last_response.status.should be(200)
+      expect(last_response.status).to be(200)
     end
 
     it "renders template" do
-      last_response.body.should include('<form action="/features" method="post">')
+      expect(last_response.body).to include('<form action="/features" method="post">')
     end
   end
 end

--- a/spec/flipper/ui/actions/boolean_gate_spec.rb
+++ b/spec/flipper/ui/actions/boolean_gate_spec.rb
@@ -1,6 +1,6 @@
 require 'helper'
 
-describe Flipper::UI::Actions::BooleanGate do
+RSpec.describe Flipper::UI::Actions::BooleanGate do
   describe "POST /features/:feature/boolean" do
     context "with enable" do
       before do
@@ -11,12 +11,12 @@ describe Flipper::UI::Actions::BooleanGate do
       end
 
       it "enables the feature" do
-        flipper.enabled?(:search).should be(true)
+        expect(flipper.enabled?(:search)).to be(true)
       end
 
       it "redirects back to feature" do
-        last_response.status.should be(302)
-        last_response.headers["Location"].should eq("/features/search")
+        expect(last_response.status).to be(302)
+        expect(last_response.headers["Location"]).to eq("/features/search")
       end
     end
 
@@ -29,12 +29,12 @@ describe Flipper::UI::Actions::BooleanGate do
       end
 
       it "disables the feature" do
-        flipper.enabled?(:search).should be(false)
+        expect(flipper.enabled?(:search)).to be(false)
       end
 
       it "redirects back to feature" do
-        last_response.status.should be(302)
-        last_response.headers["Location"].should eq("/features/search")
+        expect(last_response.status).to be(302)
+        expect(last_response.headers["Location"]).to eq("/features/search")
       end
     end
   end

--- a/spec/flipper/ui/actions/feature_spec.rb
+++ b/spec/flipper/ui/actions/feature_spec.rb
@@ -1,6 +1,6 @@
 require 'helper'
 
-describe Flipper::UI::Actions::Feature do
+RSpec.describe Flipper::UI::Actions::Feature do
   describe "DELETE /features/:feature" do
     before do
       flipper.enable :search
@@ -10,12 +10,12 @@ describe Flipper::UI::Actions::Feature do
     end
 
     it "removes feature" do
-      flipper.features.map(&:key).should_not include("search")
+      expect(flipper.features.map(&:key)).not_to include("search")
     end
 
     it "redirects to features" do
-      last_response.status.should be(302)
-      last_response.headers["Location"].should eq("/features")
+      expect(last_response.status).to be(302)
+      expect(last_response.headers["Location"]).to eq("/features")
     end
   end
 
@@ -28,12 +28,12 @@ describe Flipper::UI::Actions::Feature do
     end
 
     it "removes feature" do
-      flipper.features.map(&:key).should_not include("search")
+      expect(flipper.features.map(&:key)).not_to include("search")
     end
 
     it "redirects to features" do
-      last_response.status.should be(302)
-      last_response.headers["Location"].should eq("/features")
+      expect(last_response.status).to be(302)
+      expect(last_response.headers["Location"]).to eq("/features")
     end
   end
 
@@ -43,17 +43,17 @@ describe Flipper::UI::Actions::Feature do
     end
 
     it "responds with success" do
-      last_response.status.should be(200)
+      expect(last_response.status).to be(200)
     end
 
     it "renders template" do
-      last_response.body.should include("search")
-      last_response.body.should include("Enable")
-      last_response.body.should include("Disable")
-      last_response.body.should include("Actors")
-      last_response.body.should include("Groups")
-      last_response.body.should include("Percentage of Time")
-      last_response.body.should include("Percentage of Actors")
+      expect(last_response.body).to include("search")
+      expect(last_response.body).to include("Enable")
+      expect(last_response.body).to include("Disable")
+      expect(last_response.body).to include("Actors")
+      expect(last_response.body).to include("Groups")
+      expect(last_response.body).to include("Percentage of Time")
+      expect(last_response.body).to include("Percentage of Actors")
     end
   end
 end

--- a/spec/flipper/ui/actions/features_spec.rb
+++ b/spec/flipper/ui/actions/features_spec.rb
@@ -1,6 +1,6 @@
 require 'helper'
 
-describe Flipper::UI::Actions::Features do
+RSpec.describe Flipper::UI::Actions::Features do
   describe "GET /features" do
     before do
       flipper[:stats].enable
@@ -9,12 +9,12 @@ describe Flipper::UI::Actions::Features do
     end
 
     it "responds with success" do
-      last_response.status.should be(200)
+      expect(last_response.status).to be(200)
     end
 
     it "renders template" do
-      last_response.body.should include("stats")
-      last_response.body.should include("search")
+      expect(last_response.body).to include("stats")
+      expect(last_response.body).to include("search")
     end
   end
 
@@ -26,12 +26,12 @@ describe Flipper::UI::Actions::Features do
     end
 
     it "adds feature" do
-      flipper.features.map(&:key).should include("notifications_next")
+      expect(flipper.features.map(&:key)).to include("notifications_next")
     end
 
     it "redirects to feature" do
-      last_response.status.should be(302)
-      last_response.headers["Location"].should eq("/features/notifications_next")
+      expect(last_response.status).to be(302)
+      expect(last_response.headers["Location"]).to eq("/features/notifications_next")
     end
   end
 end

--- a/spec/flipper/ui/actions/file_spec.rb
+++ b/spec/flipper/ui/actions/file_spec.rb
@@ -1,13 +1,13 @@
 require 'helper'
 
-describe Flipper::UI::Actions::File do
+RSpec.describe Flipper::UI::Actions::File do
   describe "GET /images/logo.png" do
     before do
       get '/images/logo.png'
     end
 
     it "responds with 200" do
-      last_response.status.should be(200)
+      expect(last_response.status).to be(200)
     end
   end
 
@@ -17,7 +17,7 @@ describe Flipper::UI::Actions::File do
     end
 
     it "responds with 200" do
-      last_response.status.should be(200)
+      expect(last_response.status).to be(200)
     end
   end
 
@@ -27,7 +27,7 @@ describe Flipper::UI::Actions::File do
     end
 
     it "responds with 200" do
-      last_response.status.should be(200)
+      expect(last_response.status).to be(200)
     end
   end
 
@@ -37,7 +37,7 @@ describe Flipper::UI::Actions::File do
     end
 
     it "responds with 200" do
-      last_response.status.should be(200)
+      expect(last_response.status).to be(200)
     end
   end
 end

--- a/spec/flipper/ui/actions/gate_spec.rb
+++ b/spec/flipper/ui/actions/gate_spec.rb
@@ -1,6 +1,6 @@
 require 'helper'
 
-describe Flipper::UI::Actions::Gate do
+RSpec.describe Flipper::UI::Actions::Gate do
   describe "POST /features/:feature/non-existent-gate" do
     before do
       post "/features/search/non-existent-gate",
@@ -9,16 +9,16 @@ describe Flipper::UI::Actions::Gate do
     end
 
     it "responds with redirect" do
-      last_response.status.should be(302)
+      expect(last_response.status).to be(302)
     end
 
     it "escapes error message" do
-      last_response.headers["Location"].should eq("/features/search?error=%22non-existent-gate%22+gate+does+not+exist+therefore+it+cannot+be+updated.")
+      expect(last_response.headers["Location"]).to eq("/features/search?error=%22non-existent-gate%22+gate+does+not+exist+therefore+it+cannot+be+updated.")
     end
 
     it "renders error in template" do
       follow_redirect!
-      last_response.body.should match(/non-existent-gate.*gate does not exist/)
+      expect(last_response.body).to match(/non-existent-gate.*gate does not exist/)
     end
   end
 end

--- a/spec/flipper/ui/actions/groups_gate_spec.rb
+++ b/spec/flipper/ui/actions/groups_gate_spec.rb
@@ -1,6 +1,6 @@
 require 'helper'
 
-describe Flipper::UI::Actions::GroupsGate do
+RSpec.describe Flipper::UI::Actions::GroupsGate do
   describe "GET /features/:feature/groups" do
     before do
       Flipper.register(:admins) { |user| user.admin? }
@@ -12,11 +12,11 @@ describe Flipper::UI::Actions::GroupsGate do
     end
 
     it "responds with success" do
-      last_response.status.should be(200)
+      expect(last_response.status).to be(200)
     end
 
     it "renders add new group form" do
-      last_response.body.should include('<form action="/features/search/groups" method="post">')
+      expect(last_response.body).to include('<form action="/features/search/groups" method="post">')
     end
   end
 
@@ -37,12 +37,12 @@ describe Flipper::UI::Actions::GroupsGate do
       end
 
       it "adds item to members" do
-        flipper[:search].groups_value.should include("admins")
+        expect(flipper[:search].groups_value).to include("admins")
       end
 
       it "redirects back to feature" do
-        last_response.status.should be(302)
-        last_response.headers["Location"].should eq("/features/search")
+        expect(last_response.status).to be(302)
+        expect(last_response.headers["Location"]).to eq("/features/search")
       end
     end
 
@@ -55,12 +55,12 @@ describe Flipper::UI::Actions::GroupsGate do
       end
 
       it "removes item from members" do
-        flipper[:search].groups_value.should_not include("admins")
+        expect(flipper[:search].groups_value).not_to include("admins")
       end
 
       it "redirects back to feature" do
-        last_response.status.should be(302)
-        last_response.headers["Location"].should eq("/features/search")
+        expect(last_response.status).to be(302)
+        expect(last_response.headers["Location"]).to eq("/features/search")
       end
     end
 
@@ -72,8 +72,8 @@ describe Flipper::UI::Actions::GroupsGate do
       end
 
       it "redirects back to feature" do
-        last_response.status.should be(302)
-        last_response.headers["Location"].should eq("/features/search/groups?error=The+group+named+%22not_here%22+has+not+been+registered.")
+        expect(last_response.status).to be(302)
+        expect(last_response.headers["Location"]).to eq("/features/search/groups?error=The+group+named+%22not_here%22+has+not+been+registered.")
       end
     end
   end

--- a/spec/flipper/ui/actions/home_spec.rb
+++ b/spec/flipper/ui/actions/home_spec.rb
@@ -1,6 +1,6 @@
 require 'helper'
 
-describe Flipper::UI::Actions::Home do
+RSpec.describe Flipper::UI::Actions::Home do
   describe "GET /" do
     before do
       flipper[:stats].enable
@@ -9,8 +9,8 @@ describe Flipper::UI::Actions::Home do
     end
 
     it "responds with redirect" do
-      last_response.status.should be(302)
-      last_response.headers["Location"].should eq("/features")
+      expect(last_response.status).to be(302)
+      expect(last_response.headers["Location"]).to eq("/features")
     end
   end
 end

--- a/spec/flipper/ui/actions/percentage_of_actors_gate_spec.rb
+++ b/spec/flipper/ui/actions/percentage_of_actors_gate_spec.rb
@@ -1,6 +1,6 @@
 require 'helper'
 
-describe Flipper::UI::Actions::PercentageOfActorsGate do
+RSpec.describe Flipper::UI::Actions::PercentageOfActorsGate do
   describe "POST /features/:feature/percentage_of_actors" do
     context "with valid value" do
       before do
@@ -10,12 +10,12 @@ describe Flipper::UI::Actions::PercentageOfActorsGate do
       end
 
       it "enables the feature" do
-        flipper[:search].percentage_of_actors_value.should be(24)
+        expect(flipper[:search].percentage_of_actors_value).to be(24)
       end
 
       it "redirects back to feature" do
-        last_response.status.should be(302)
-        last_response.headers["Location"].should eq("/features/search")
+        expect(last_response.status).to be(302)
+        expect(last_response.headers["Location"]).to eq("/features/search")
       end
     end
 
@@ -27,12 +27,12 @@ describe Flipper::UI::Actions::PercentageOfActorsGate do
       end
 
       it "does not change value" do
-        flipper[:search].percentage_of_actors_value.should be(0)
+        expect(flipper[:search].percentage_of_actors_value).to be(0)
       end
 
       it "redirects back to feature" do
-        last_response.status.should be(302)
-        last_response.headers["Location"].should eq("/features/search?error=Invalid+percentage+of+actors+value%3A+value+must+be+a+positive+number+less+than+or+equal+to+100%2C+but+was+555")
+        expect(last_response.status).to be(302)
+        expect(last_response.headers["Location"]).to eq("/features/search?error=Invalid+percentage+of+actors+value%3A+value+must+be+a+positive+number+less+than+or+equal+to+100%2C+but+was+555")
       end
     end
   end

--- a/spec/flipper/ui/actions/percentage_of_time_gate_spec.rb
+++ b/spec/flipper/ui/actions/percentage_of_time_gate_spec.rb
@@ -1,6 +1,6 @@
 require 'helper'
 
-describe Flipper::UI::Actions::PercentageOfTimeGate do
+RSpec.describe Flipper::UI::Actions::PercentageOfTimeGate do
   describe "POST /features/:feature/percentage_of_time" do
     context "with valid value" do
       before do
@@ -10,12 +10,12 @@ describe Flipper::UI::Actions::PercentageOfTimeGate do
       end
 
       it "enables the feature" do
-        flipper[:search].percentage_of_time_value.should be(24)
+        expect(flipper[:search].percentage_of_time_value).to be(24)
       end
 
       it "redirects back to feature" do
-        last_response.status.should be(302)
-        last_response.headers["Location"].should eq("/features/search")
+        expect(last_response.status).to be(302)
+        expect(last_response.headers["Location"]).to eq("/features/search")
       end
     end
 
@@ -27,12 +27,12 @@ describe Flipper::UI::Actions::PercentageOfTimeGate do
       end
 
       it "does not change value" do
-        flipper[:search].percentage_of_time_value.should be(0)
+        expect(flipper[:search].percentage_of_time_value).to be(0)
       end
 
       it "redirects back to feature" do
-        last_response.status.should be(302)
-        last_response.headers["Location"].should eq("/features/search?error=Invalid+percentage+of+time+value%3A+value+must+be+a+positive+number+less+than+or+equal+to+100%2C+but+was+555")
+        expect(last_response.status).to be(302)
+        expect(last_response.headers["Location"]).to eq("/features/search?error=Invalid+percentage+of+time+value%3A+value+must+be+a+positive+number+less+than+or+equal+to+100%2C+but+was+555")
       end
     end
   end

--- a/spec/flipper/ui/decorators/feature_spec.rb
+++ b/spec/flipper/ui/decorators/feature_spec.rb
@@ -1,7 +1,7 @@
 require 'helper'
 require 'flipper/adapters/memory'
 
-describe Flipper::UI::Decorators::Feature do
+RSpec.describe Flipper::UI::Decorators::Feature do
   let(:source)  { {} }
   let(:adapter) { Flipper::Adapters::Memory.new(source) }
   let(:flipper) { build_flipper }
@@ -13,13 +13,13 @@ describe Flipper::UI::Decorators::Feature do
 
   describe "#initialize" do
     it "sets the feature" do
-      subject.feature.should be(feature)
+      expect(subject.feature).to be(feature)
     end
   end
 
   describe "#pretty_name" do
     it "capitalizes each word separated by underscores" do
-      subject.pretty_name.should eq('Some Awesome Feature')
+      expect(subject.pretty_name).to eq('Some Awesome Feature')
     end
   end
 
@@ -29,19 +29,19 @@ describe Flipper::UI::Decorators::Feature do
     end
 
     it "returns Hash" do
-      @result.should be_instance_of(Hash)
+      expect(@result).to be_instance_of(Hash)
     end
 
     it "includes id" do
-      @result['id'].should eq('some_awesome_feature')
+      expect(@result['id']).to eq('some_awesome_feature')
     end
 
     it "includes pretty name" do
-      @result['name'].should eq('Some Awesome Feature')
+      expect(@result['name']).to eq('Some Awesome Feature')
     end
 
     it "includes state" do
-      @result['state'].should eq('off')
+      expect(@result['state']).to eq('off')
     end
 
     it "includes gates" do
@@ -49,7 +49,7 @@ describe Flipper::UI::Decorators::Feature do
         value = subject.gate_values[gate.key]
         Flipper::UI::Decorators::Gate.new(gate, value).as_json
       }
-      @result['gates'].should eq(gates)
+      expect(@result['gates']).to eq(gates)
     end
   end
 
@@ -74,19 +74,19 @@ describe Flipper::UI::Decorators::Feature do
     }
 
     it "sorts :on before :conditional" do
-      (on <=> conditional).should be(-1)
+      expect((on <=> conditional)).to be(-1)
     end
 
     it "sorts :on before :off" do
-      (on <=> conditional).should be(-1)
+      expect((on <=> conditional)).to be(-1)
     end
 
     it "sorts :conditional before :off" do
-      (on <=> conditional).should be(-1)
+      expect((on <=> conditional)).to be(-1)
     end
 
     it "sorts on key for identical states" do
-      (on <=> on_b).should be(-1)
+      expect((on <=> on_b)).to be(-1)
     end
   end
 end

--- a/spec/flipper/ui/decorators/gate_spec.rb
+++ b/spec/flipper/ui/decorators/gate_spec.rb
@@ -2,7 +2,7 @@ require 'helper'
 require 'flipper/adapters/memory'
 require 'flipper/ui/decorators/gate'
 
-describe Flipper::UI::Decorators::Gate do
+RSpec.describe Flipper::UI::Decorators::Gate do
   let(:source)  { {} }
   let(:adapter) { Flipper::Adapters::Memory.new(source) }
   let(:flipper) { build_flipper }
@@ -15,11 +15,11 @@ describe Flipper::UI::Decorators::Gate do
 
   describe "#initialize" do
     it "sets gate" do
-      subject.gate.should be(gate)
+      expect(subject.gate).to be(gate)
     end
 
     it "sets value" do
-      subject.value.should eq(false)
+      expect(subject.value).to eq(false)
     end
   end
 
@@ -29,19 +29,19 @@ describe Flipper::UI::Decorators::Gate do
     end
 
     it "returns Hash" do
-      @result.should be_instance_of(Hash)
+      expect(@result).to be_instance_of(Hash)
     end
 
     it "includes key" do
-      @result['key'].should eq('boolean')
+      expect(@result['key']).to eq('boolean')
     end
 
     it "includes pretty name" do
-      @result['name'].should eq('boolean')
+      expect(@result['name']).to eq('boolean')
     end
 
     it "includes value" do
-      @result['value'].should be(false)
+      expect(@result['value']).to be(false)
     end
   end
 end

--- a/spec/flipper/ui/util_spec.rb
+++ b/spec/flipper/ui/util_spec.rb
@@ -1,17 +1,17 @@
 require 'helper'
 require 'flipper/ui/util'
 
-describe Flipper::UI::Util do
+RSpec.describe Flipper::UI::Util do
   describe "#blank?" do
     context "with a string" do
       it "returns true if blank" do
-        described_class.blank?(nil).should be(true)
-        described_class.blank?('').should be(true)
-        described_class.blank?('   ').should be(true)
+        expect(described_class.blank?(nil)).to be(true)
+        expect(described_class.blank?('')).to be(true)
+        expect(described_class.blank?('   ')).to be(true)
       end
 
       it "returns false if not blank" do
-        described_class.blank?('nope').should be(false)
+        expect(described_class.blank?('nope')).to be(false)
       end
     end
   end

--- a/spec/flipper/ui_spec.rb
+++ b/spec/flipper/ui_spec.rb
@@ -1,14 +1,14 @@
 require 'helper'
 
-describe Flipper::UI do
+RSpec.describe Flipper::UI do
   describe "Initializing middleware with flipper instance" do
     let(:app) { build_app(flipper) }
 
     it "works" do
       flipper.enable :some_great_feature
       get "/features"
-      last_response.status.should be(200)
-      last_response.body.should include("some_great_feature")
+      expect(last_response.status).to be(200)
+      expect(last_response.body).to include("some_great_feature")
     end
   end
 
@@ -20,8 +20,8 @@ describe Flipper::UI do
     it "works" do
       flipper.enable :some_great_feature
       get "/features"
-      last_response.status.should be(200)
-      last_response.body.should include("some_great_feature")
+      expect(last_response.status).to be(200)
+      expect(last_response.body).to include("some_great_feature")
     end
   end
 
@@ -38,7 +38,7 @@ describe Flipper::UI do
     post "features/refactor-images/actors",
       {"value" => "User:6", "operation" => "enable", "authenticity_token" => "a"},
       "rack.session" => {:csrf => "a"}
-    last_response.status.should be(302)
-    last_response.headers["Location"].should eq("/features/refactor-images")
+    expect(last_response.status).to be(302)
+    expect(last_response.headers["Location"]).to eq("/features/refactor-images")
   end
 end

--- a/spec/flipper_spec.rb
+++ b/spec/flipper_spec.rb
@@ -1,27 +1,27 @@
 require 'helper'
 
-describe Flipper do
+RSpec.describe Flipper do
   describe ".new" do
     it "returns new instance of dsl" do
       instance = Flipper.new(double('Adapter'))
-      instance.should be_instance_of(Flipper::DSL)
+      expect(instance).to be_instance_of(Flipper::DSL)
     end
   end
 
   describe ".group_exists" do
     it "returns true if the group is already created" do
       group = Flipper.register('admins') { |actor| actor.admin? }
-      Flipper.group_exists?(:admins).should eq(true)
+      expect(Flipper.group_exists?(:admins)).to eq(true)
     end
 
     it "returns false when the group is not yet registered" do
-      Flipper.group_exists?(:non_existing).should eq(false)
+      expect(Flipper.group_exists?(:non_existing)).to eq(false)
     end
   end
 
   describe ".groups_registry" do
     it "returns a registry instance" do
-      Flipper.groups_registry.should be_instance_of(Flipper::Registry)
+      expect(Flipper.groups_registry).to be_instance_of(Flipper::Registry)
     end
   end
 
@@ -29,7 +29,7 @@ describe Flipper do
     it "sets groups_registry registry" do
       registry = Flipper::Registry.new
       Flipper.groups_registry = registry
-      Flipper.instance_variable_get("@groups_registry").should eq(registry)
+      expect(Flipper.instance_variable_get("@groups_registry")).to eq(registry)
     end
   end
 
@@ -38,14 +38,14 @@ describe Flipper do
       registry = Flipper::Registry.new
       Flipper.groups_registry = registry
       group = Flipper.register(:admins) { |actor| actor.admin? }
-      registry.get(:admins).should eq(group)
+      expect(registry.get(:admins)).to eq(group)
     end
 
     it "adds a group to the group_registry for string name" do
       registry = Flipper::Registry.new
       Flipper.groups_registry = registry
       group = Flipper.register('admins') { |actor| actor.admin? }
-      registry.get(:admins).should eq(group)
+      expect(registry.get(:admins)).to eq(group)
     end
 
     it "raises exception if group already registered" do
@@ -59,7 +59,7 @@ describe Flipper do
 
   describe ".unregister_groups" do
     it "clear group registry" do
-      Flipper.groups_registry.should_receive(:clear)
+      expect(Flipper.groups_registry).to receive(:clear)
       Flipper.unregister_groups
     end
   end
@@ -71,11 +71,11 @@ describe Flipper do
       end
 
       it "returns group" do
-        Flipper.group(:admins).should eq(@group)
+        expect(Flipper.group(:admins)).to eq(@group)
       end
 
       it "returns group with string key" do
-        Flipper.group('admins').should eq(@group)
+        expect(Flipper.group('admins')).to eq(@group)
       end
     end
 
@@ -92,10 +92,10 @@ describe Flipper do
     it "returns array of group instances" do
       admins = Flipper.register(:admins) { |actor| actor.admin? }
       preview_features = Flipper.register(:preview_features) { |actor| actor.preview_features? }
-      Flipper.groups.should eq(Set[
-        admins,
-        preview_features,
-      ])
+      expect(Flipper.groups).to eq(Set[
+              admins,
+              preview_features,
+            ])
     end
   end
 
@@ -103,10 +103,10 @@ describe Flipper do
     it "returns array of group names" do
       Flipper.register(:admins) { |actor| actor.admin? }
       Flipper.register(:preview_features) { |actor| actor.preview_features? }
-      Flipper.group_names.should eq(Set[
-        :admins,
-        :preview_features,
-      ])
+      expect(Flipper.group_names).to eq(Set[
+              :admins,
+              :preview_features,
+            ])
     end
   end
 end

--- a/spec/helper.rb
+++ b/spec/helper.rb
@@ -14,25 +14,25 @@ require 'flipper-ui'
 Dir[FlipperRoot.join("spec/support/**/*.rb")].each { |f| require f }
 
 RSpec.configure do |config|
-  config.before(:each) do
+  config.before(:example) do
     Flipper.unregister_groups
   end
 end
 
-shared_examples_for 'a percentage' do
+RSpec.shared_examples_for 'a percentage' do
   it "initializes with value" do
     percentage = described_class.new(12)
-    percentage.should be_instance_of(described_class)
+    expect(percentage).to be_instance_of(described_class)
   end
 
   it "converts string values to integers when initializing" do
     percentage = described_class.new('15')
-    percentage.value.should eq(15)
+    expect(percentage.value).to eq(15)
   end
 
   it "has a value" do
     percentage = described_class.new(19)
-    percentage.value.should eq(19)
+    expect(percentage.value).to eq(19)
   end
 
   it "raises exception for value higher than 100" do
@@ -50,23 +50,23 @@ end
 
 shared_examples_for 'a DSL feature' do
   it "returns instance of feature" do
-    feature.should be_instance_of(Flipper::Feature)
+    expect(feature).to be_instance_of(Flipper::Feature)
   end
 
   it "sets name" do
-    feature.name.should eq(:stats)
+    expect(feature.name).to eq(:stats)
   end
 
   it "sets adapter" do
-    feature.adapter.name.should eq(dsl.adapter.name)
+    expect(feature.adapter.name).to eq(dsl.adapter.name)
   end
 
   it "sets instrumenter" do
-    feature.instrumenter.should eq(dsl.instrumenter)
+    expect(feature.instrumenter).to eq(dsl.instrumenter)
   end
 
   it "memoizes the feature" do
-    dsl.send(method_name, :stats).should equal(feature)
+    expect(dsl.send(method_name, :stats)).to equal(feature)
   end
 
   it "raises argument error if not string or symbol" do
@@ -79,11 +79,11 @@ end
 shared_examples_for "a DSL boolean method" do
   it "returns boolean with value set" do
     result = subject.send(method_name, true)
-    result.should be_instance_of(Flipper::Types::Boolean)
-    result.value.should be(true)
+    expect(result).to be_instance_of(Flipper::Types::Boolean)
+    expect(result.value).to be(true)
 
     result = subject.send(method_name, false)
-    result.should be_instance_of(Flipper::Types::Boolean)
-    result.value.should be(false)
+    expect(result).to be_instance_of(Flipper::Types::Boolean)
+    expect(result.value).to be(false)
   end
 end

--- a/spec/integration_spec.rb
+++ b/spec/integration_spec.rb
@@ -2,7 +2,7 @@ require 'helper'
 require 'flipper/feature'
 require 'flipper/adapters/memory'
 
-describe Flipper do
+RSpec.describe Flipper do
   let(:adapter)     { Flipper::Adapters::Memory.new }
   let(:flipper)     { Flipper.new(adapter) }
   let(:feature)     { flipper[:search] }
@@ -33,15 +33,15 @@ describe Flipper do
       end
 
       it "returns true" do
-        @result.should eq(true)
+        expect(@result).to eq(true)
       end
 
       it "enables feature for all" do
-        feature.enabled?.should eq(true)
+        expect(feature.enabled?).to eq(true)
       end
 
       it "adds feature to set of features" do
-        flipper.features.map(&:name).should include(:search)
+        expect(flipper.features.map(&:name)).to include(:search)
       end
     end
 
@@ -51,31 +51,31 @@ describe Flipper do
       end
 
       it "returns true" do
-        @result.should eq(true)
+        expect(@result).to eq(true)
       end
 
       it "enables feature for non flipper thing in group" do
-        feature.enabled?(admin_thing).should eq(true)
+        expect(feature.enabled?(admin_thing)).to eq(true)
       end
 
       it "does not enable feature for non flipper thing in other group" do
-        feature.enabled?(dev_thing).should eq(false)
+        expect(feature.enabled?(dev_thing)).to eq(false)
       end
 
       it "enables feature for flipper actor in group" do
-        feature.enabled?(flipper.actor(admin_thing)).should eq(true)
+        expect(feature.enabled?(flipper.actor(admin_thing))).to eq(true)
       end
 
       it "does not enable for flipper actor not in group" do
-        feature.enabled?(flipper.actor(dev_thing)).should eq(false)
+        expect(feature.enabled?(flipper.actor(dev_thing))).to eq(false)
       end
 
       it "does not enable feature for all" do
-        feature.enabled?.should eq(false)
+        expect(feature.enabled?).to eq(false)
       end
 
       it "adds feature to set of features" do
-        flipper.features.map(&:name).should include(:search)
+        expect(flipper.features.map(&:name)).to include(:search)
       end
     end
 
@@ -85,19 +85,19 @@ describe Flipper do
       end
 
       it "returns true" do
-        @result.should eq(true)
+        expect(@result).to eq(true)
       end
 
       it "enables feature for actor" do
-        feature.enabled?(pitt).should eq(true)
+        expect(feature.enabled?(pitt)).to eq(true)
       end
 
       it "does not enable feature for other actors" do
-        feature.enabled?(clooney).should eq(false)
+        expect(feature.enabled?(clooney)).to eq(false)
       end
 
       it "adds feature to set of features" do
-        flipper.features.map(&:name).should include(:search)
+        expect(flipper.features.map(&:name)).to include(:search)
       end
     end
 
@@ -107,7 +107,7 @@ describe Flipper do
       end
 
       it "returns true" do
-        @result.should eq(true)
+        expect(@result).to eq(true)
       end
 
       it "enables feature for actor within percentage" do
@@ -116,11 +116,11 @@ describe Flipper do
           feature.enabled?(thing)
         }.size
 
-        enabled.should be_within(2).of(5)
+        expect(enabled).to be_within(2).of(5)
       end
 
       it "adds feature to set of features" do
-        flipper.features.map(&:name).should include(:search)
+        expect(flipper.features.map(&:name)).to include(:search)
       end
     end
 
@@ -131,21 +131,21 @@ describe Flipper do
       end
 
       it "returns true" do
-        @result.should eq(true)
+        expect(@result).to eq(true)
       end
 
       it "enables feature for time within percentage" do
-        @gate.stub(:rand => 0.04)
-        feature.enabled?.should eq(true)
+        allow(@gate).to receive_messages(:rand => 0.04)
+        expect(feature.enabled?).to eq(true)
       end
 
       it "does not enable feature for time not within percentage" do
-        @gate.stub(:rand => 0.10)
-        feature.enabled?.should eq(false)
+        allow(@gate).to receive_messages(:rand => 0.10)
+        expect(feature.enabled?).to eq(false)
       end
 
       it "adds feature to set of features" do
-        flipper.features.map(&:name).should include(:search)
+        expect(flipper.features.map(&:name)).to include(:search)
       end
     end
 
@@ -164,7 +164,7 @@ describe Flipper do
       before do
         # ensures that time gate is stubbed with result that would be true for pitt
         @gate = feature.gate(:percentage_of_time)
-        @gate.stub(:rand => 0.04)
+        allow(@gate).to receive_messages(:rand => 0.04)
 
         feature.enable admin_group
         feature.enable pitt
@@ -174,19 +174,19 @@ describe Flipper do
       end
 
       it "returns true" do
-        @result.should be(true)
+        expect(@result).to be(true)
       end
 
       it "disables feature" do
-        feature.enabled?.should eq(false)
+        expect(feature.enabled?).to eq(false)
       end
 
       it "disables for individual actor" do
-        feature.enabled?(pitt).should eq(false)
+        expect(feature.enabled?(pitt)).to eq(false)
       end
 
       it "disables actor in group" do
-        feature.enabled?(admin_thing).should eq(false)
+        expect(feature.enabled?(admin_thing)).to eq(false)
       end
 
       it "disables actor in percentage of actors" do
@@ -195,15 +195,15 @@ describe Flipper do
           feature.enabled?(thing)
         }.size
 
-        enabled.should be(0)
+        expect(enabled).to be(0)
       end
 
       it "disables percentage of time" do
-        feature.enabled?(pitt).should eq(false)
+        expect(feature.enabled?(pitt)).to eq(false)
       end
 
       it "adds feature to set of features" do
-        flipper.features.map(&:name).should include(:search)
+        expect(flipper.features.map(&:name)).to include(:search)
       end
     end
 
@@ -215,27 +215,27 @@ describe Flipper do
       end
 
       it "returns true" do
-        @result.should eq(true)
+        expect(@result).to eq(true)
       end
 
       it "disables the feature for non flipper thing in the group" do
-        feature.enabled?(admin_thing).should eq(false)
+        expect(feature.enabled?(admin_thing)).to eq(false)
       end
 
       it "does not disable feature for non flipper thing in other groups" do
-        feature.enabled?(dev_thing).should eq(true)
+        expect(feature.enabled?(dev_thing)).to eq(true)
       end
 
       it "disables feature for flipper actor in group" do
-        feature.enabled?(flipper.actor(admin_thing)).should eq(false)
+        expect(feature.enabled?(flipper.actor(admin_thing))).to eq(false)
       end
 
       it "does not disable feature for flipper actor in other groups" do
-        feature.enabled?(flipper.actor(dev_thing)).should eq(true)
+        expect(feature.enabled?(flipper.actor(dev_thing))).to eq(true)
       end
 
       it "adds feature to set of features" do
-        flipper.features.map(&:name).should include(:search)
+        expect(flipper.features.map(&:name)).to include(:search)
       end
     end
 
@@ -247,19 +247,19 @@ describe Flipper do
       end
 
       it "returns true" do
-        @result.should eq(true)
+        expect(@result).to eq(true)
       end
 
       it "disables feature for actor" do
-        feature.enabled?(pitt).should eq(false)
+        expect(feature.enabled?(pitt)).to eq(false)
       end
 
       it "does not disable feature for other actors" do
-        feature.enabled?(clooney).should eq(true)
+        expect(feature.enabled?(clooney)).to eq(true)
       end
 
       it "adds feature to set of features" do
-        flipper.features.map(&:name).should include(:search)
+        expect(flipper.features.map(&:name)).to include(:search)
       end
     end
 
@@ -269,7 +269,7 @@ describe Flipper do
       end
 
       it "returns true" do
-        @result.should eq(true)
+        expect(@result).to eq(true)
       end
 
       it "disables feature" do
@@ -278,11 +278,11 @@ describe Flipper do
           feature.enabled?(thing)
         }.size
 
-        enabled.should be(0)
+        expect(enabled).to be(0)
       end
 
       it "adds feature to set of features" do
-        flipper.features.map(&:name).should include(:search)
+        expect(flipper.features.map(&:name)).to include(:search)
       end
     end
 
@@ -293,21 +293,21 @@ describe Flipper do
       end
 
       it "returns true" do
-        @result.should eq(true)
+        expect(@result).to eq(true)
       end
 
       it "disables feature for time within percentage" do
-        @gate.stub(:rand => 0.04)
-        feature.enabled?.should eq(false)
+        allow(@gate).to receive_messages(:rand => 0.04)
+        expect(feature.enabled?).to eq(false)
       end
 
       it "disables feature for time not within percentage" do
-        @gate.stub(:rand => 0.10)
-        feature.enabled?.should eq(false)
+        allow(@gate).to receive_messages(:rand => 0.10)
+        expect(feature.enabled?).to eq(false)
       end
 
       it "adds feature to set of features" do
-        flipper.features.map(&:name).should include(:search)
+        expect(flipper.features.map(&:name)).to include(:search)
       end
     end
 
@@ -324,7 +324,7 @@ describe Flipper do
   describe "#enabled?" do
     context "with no arguments" do
       it "defaults to false" do
-        feature.enabled?.should eq(false)
+        expect(feature.enabled?).to eq(false)
       end
     end
 
@@ -334,7 +334,7 @@ describe Flipper do
       end
 
       it "returns true" do
-        feature.enabled?.should eq(true)
+        expect(feature.enabled?).to eq(true)
       end
     end
 
@@ -344,15 +344,15 @@ describe Flipper do
       end
 
       it "returns true" do
-        feature.enabled?(flipper.actor(admin_thing)).should eq(true)
-        feature.enabled?(admin_thing).should eq(true)
+        expect(feature.enabled?(flipper.actor(admin_thing))).to eq(true)
+        expect(feature.enabled?(admin_thing)).to eq(true)
       end
     end
 
     context "for actor in disabled group" do
       it "returns false" do
-        feature.enabled?(flipper.actor(dev_thing)).should eq(false)
-        feature.enabled?(dev_thing).should eq(false)
+        expect(feature.enabled?(flipper.actor(dev_thing))).to eq(false)
+        expect(feature.enabled?(dev_thing)).to eq(false)
       end
     end
 
@@ -362,18 +362,18 @@ describe Flipper do
       end
 
       it "returns true" do
-        feature.enabled?(pitt).should eq(true)
+        expect(feature.enabled?(pitt)).to eq(true)
       end
     end
 
     context "for not enabled actor" do
       it "returns false" do
-        feature.enabled?(clooney).should eq(false)
+        expect(feature.enabled?(clooney)).to eq(false)
       end
 
       it "returns true if boolean enabled" do
         feature.enable
-        feature.enabled?(clooney).should eq(true)
+        expect(feature.enabled?(clooney)).to eq(true)
       end
     end
 
@@ -382,16 +382,16 @@ describe Flipper do
         # ensure percentage of time returns percentage that makes five percent
         # of time true
         @gate = feature.gate(:percentage_of_time)
-        @gate.stub(:rand => 0.04)
+        allow(@gate).to receive_messages(:rand => 0.04)
 
         feature.enable five_percent_of_time
       end
 
       it "returns true" do
-        feature.enabled?.should eq(true)
-        feature.enabled?(nil).should eq(true)
-        feature.enabled?(pitt).should eq(true)
-        feature.enabled?(admin_thing).should eq(true)
+        expect(feature.enabled?).to eq(true)
+        expect(feature.enabled?(nil)).to eq(true)
+        expect(feature.enabled?(pitt)).to eq(true)
+        expect(feature.enabled?(admin_thing)).to eq(true)
       end
     end
 
@@ -400,24 +400,24 @@ describe Flipper do
         # ensure percentage of time returns percentage that makes five percent
         # of time false
         @gate = feature.gate(:percentage_of_time)
-        @gate.stub(:rand => 0.10)
+        allow(@gate).to receive_messages(:rand => 0.10)
 
         feature.enable five_percent_of_time
       end
 
       it "returns false" do
-        feature.enabled?.should eq(false)
-        feature.enabled?(nil).should eq(false)
-        feature.enabled?(pitt).should eq(false)
-        feature.enabled?(admin_thing).should eq(false)
+        expect(feature.enabled?).to eq(false)
+        expect(feature.enabled?(nil)).to eq(false)
+        expect(feature.enabled?(pitt)).to eq(false)
+        expect(feature.enabled?(admin_thing)).to eq(false)
       end
 
       it "returns true if boolean enabled" do
         feature.enable
-        feature.enabled?.should eq(true)
-        feature.enabled?(nil).should eq(true)
-        feature.enabled?(pitt).should eq(true)
-        feature.enabled?(admin_thing).should eq(true)
+        expect(feature.enabled?).to eq(true)
+        expect(feature.enabled?(nil)).to eq(true)
+        expect(feature.enabled?(pitt)).to eq(true)
+        expect(feature.enabled?(admin_thing)).to eq(true)
       end
     end
 
@@ -427,17 +427,17 @@ describe Flipper do
       end
 
       it "returns true if in enabled group" do
-        feature.enabled?(admin_thing).should eq(true)
+        expect(feature.enabled?(admin_thing)).to eq(true)
       end
 
       it "returns false if not in enabled group" do
-        feature.enabled?(dev_thing).should eq(false)
+        expect(feature.enabled?(dev_thing)).to eq(false)
       end
 
       it "returns true if boolean enabled" do
         feature.enable
-        feature.enabled?(admin_thing).should eq(true)
-        feature.enabled?(dev_thing).should eq(true)
+        expect(feature.enabled?(admin_thing)).to eq(true)
+        expect(feature.enabled?(dev_thing)).to eq(true)
       end
     end
   end
@@ -451,11 +451,11 @@ describe Flipper do
     end
 
     it "enables feature for object in enabled group" do
-      feature.enabled?(admin_thing).should eq(true)
+      expect(feature.enabled?(admin_thing)).to eq(true)
     end
 
     it "does not enable feature for object in not enabled group" do
-      feature.enabled?(dev_thing).should eq(false)
+      expect(feature.enabled?(dev_thing)).to eq(false)
     end
   end
 end


### PR DESCRIPTION
Anyone who's writing their own adapter and using flipper's `shared_examples` to test it are likely to get deprecation warnings.

This PR includes 2 unrelated things... sorry!

**First** (and most importantly), it switches the `should` syntax to `expect`. Nearly all the conversion was done with http://xinminlabs.github.io/synvert/, so there should be less chance for user error. The only manually converted file is the shared_spec file in lib.

**Second**, I got a bit frustrated running specs on a clean repo the first time. Turns out, the mongo adapter waits 60 (or so) seconds (per spec!) before failing if it can't connect to the mongo server. This PR shortens that to 1 second and outputs a helpful message about maybe mongo not running.