### PR TITLE
Add timeout to Mongo test

### DIFF
--- a/spec/flipper/adapters/mongo_spec.rb
+++ b/spec/flipper/adapters/mongo_spec.rb
@@ -9,7 +9,7 @@ describe Flipper::Adapters::Mongo do
   let(:port) { ENV["BOXEN_MONGODB_PORT"] || 27017 }
 
   let(:collection) {
-    Mongo::Client.new(["#{host}:#{port}"], :database => 'testing')['testing']
+    Mongo::Client.new(["#{host}:#{port}"], :server_selection_timeout => 1, :database => 'testing')['testing']
   }
 
   subject { described_class.new(collection) }


### PR DESCRIPTION
Per discussion in #87.

This is apparently the timeout we need to make tests fail faster when mongo isn't running.