### PR TITLE
Read only

### DIFF
--- a/docs/Gates.md
+++ b/docs/Gates.md
@@ -128,3 +128,20 @@ flipper[:search].disable_percentage_of_time # sets to 0
 ```
 
 Timeness is not a good idea for enabling new features in the UI. Most of the time you want a feature on or off for a user, but there are definitely times when I have found percentage of time to be very useful.
+
+# Read Only Mode
+
+If you are using flipper to read the state of features, but using a separate application (ie flipper-ui) to manage which features are enabled, you may want to set flipper to read only mode so you don't accidentally override changes made by the separate application.
+
+```ruby
+flipper = Flipper.new(adapter, read_only: true)
+
+# Querying features and their state still works
+flipper[:stats].enabled?
+flipper[:stats].enabled? user
+
+# Enabling and disabling raises a Flipper::ReadOnlyUpdate error
+flipper[:stats].enable # Flipper::ReadOnlyUpdate: Cannot enable features in read only mode
+
+flipper[:stats].disable # Flipper::ReadOnlyUpdate: Cannot disable features in read only mode
+```

--- a/lib/flipper/dsl.rb
+++ b/lib/flipper/dsl.rb
@@ -10,6 +10,9 @@ module Flipper
     # Private: What is being used to instrument all the things.
     attr_reader :instrumenter
 
+    # Public: Features can not be enabled or disabled in read-only mode
+    attr_accessor :read_only
+
     # Public: Returns a new instance of the DSL.
     #
     # adapter - The adapter that this DSL instance should use.
@@ -25,6 +28,8 @@ module Flipper
       @adapter = memoized
 
       @memoized_features = {}
+
+      @read_only = options.fetch(:read_only, false)
     end
 
     # Public: Check if a feature is enabled.
@@ -157,6 +162,7 @@ module Flipper
 
       @memoized_features[name.to_sym] ||= Feature.new(name, @adapter, {
         :instrumenter => instrumenter,
+        :read_only => read_only
       })
     end
 

--- a/lib/flipper/errors.rb
+++ b/lib/flipper/errors.rb
@@ -14,4 +14,7 @@ module Flipper
 
   # Raised when attempting to access a group that is not registered.
   class GroupNotRegistered < Error; end
+
+  # Raised when trying to enable or disable features when in read only mode
+  class ReadOnlyUpdate < Error; end
 end

--- a/lib/flipper/feature.rb
+++ b/lib/flipper/feature.rb
@@ -18,6 +18,9 @@ module Flipper
     # Public: Name converted to value safe for adapter.
     attr_reader :key
 
+    # Public: Features can not be enabled or disabled in read-only mode
+    attr_accessor :read_only
+
     # Private: The adapter this feature should use.
     attr_reader :adapter
 
@@ -36,6 +39,7 @@ module Flipper
       @name = name
       @key = name.to_s
       @instrumenter = options.fetch(:instrumenter, Instrumenters::Noop)
+      @read_only = options.fetch(:read_only, false)
       @adapter = adapter
     end
 
@@ -43,6 +47,7 @@ module Flipper
     #
     # Returns the result of Adapter#enable.
     def enable(thing = true)
+      raise Flipper::ReadOnlyUpdate.new('Cannot enable features in read only mode') if read_only
       instrument(:enable) { |payload|
         adapter.add self
 
@@ -59,6 +64,7 @@ module Flipper
     #
     # Returns the result of Adapter#disable.
     def disable(thing = false)
+      raise Flipper::ReadOnlyUpdate.new('Cannot disable features in read only mode') if read_only
       instrument(:disable) { |payload|
         adapter.add self
 
@@ -311,6 +317,7 @@ module Flipper
         "state=#{state.inspect}",
         "enabled_gate_names=#{enabled_gate_names.inspect}",
         "adapter=#{adapter.name.inspect}",
+        "read_only=#{read_only.inspect}"
       ]
       "#<#{self.class.name}:#{object_id} #{attributes.join(', ')}>"
     end

--- a/spec/flipper/dsl_spec.rb
+++ b/spec/flipper/dsl_spec.rb
@@ -40,6 +40,14 @@ RSpec.describe Flipper::DSL do
       let(:feature) { dsl.send(method_name, :stats) }
       let(:dsl) { Flipper::DSL.new(adapter, :instrumenter => instrumenter) }
     end
+
+    context "in read only mode" do
+      subject { Flipper::DSL.new(adapter, read_only: true) }
+      it "creates feature with read only mode enabled" do
+        feature = subject.feature(:stats)
+        expect(feature.read_only).to be(true)
+      end
+    end
   end
 
   describe "#[]" do

--- a/spec/flipper/feature_spec.rb
+++ b/spec/flipper/feature_spec.rb
@@ -603,6 +603,25 @@ RSpec.describe Flipper::Feature do
         expect(subject.gate_values.actors).to be_empty
       end
     end
+
+    context "in read only mode" do
+      subject { described_class.new(:search, adapter, read_only: true) }
+      it "raises an error when enabling" do
+        actor = Struct.new(:flipper_id).new(5)
+        instance = Flipper::Types::Actor.wrap(actor)
+        expect(subject.gate_values.actors).to be_empty
+
+        expect { subject.enable_actor(instance) }.to raise_error(Flipper::ReadOnlyUpdate)
+        expect(subject.gate_values.actors).to be_empty
+      end
+
+      it "raises an error when disabling" do
+        actor = Struct.new(:flipper_id).new(5)
+        instance = Flipper::Types::Actor.wrap(actor)
+
+        expect { subject.disable_actor(instance) }.to raise_error(Flipper::ReadOnlyUpdate)
+      end
+    end
   end
 
   describe "#enable_group/disable_group" do

--- a/spec/helper.rb
+++ b/spec/helper.rb
@@ -65,6 +65,10 @@ shared_examples_for 'a DSL feature' do
     expect(feature.instrumenter).to eq(dsl.instrumenter)
   end
 
+  it "sets read only mode" do
+    expect(feature.read_only).to eq(dsl.read_only)
+  end
+
   it "memoizes the feature" do
     expect(dsl.send(method_name, :stats)).to equal(feature)
   end


### PR DESCRIPTION
Adds a `#read_only` accessor on `DSL` and `Feature`, as well as an initialization option.  When set, any attempts to enable or disable features raises an error.

A common use case is where a separate application (using flipper-ui) is managing the feature flags.