### PR TITLE
Add a link back to the app via a breadcrumb.

### DIFF
--- a/lib/flipper/ui.rb
+++ b/lib/flipper/ui.rb
@@ -11,6 +11,10 @@ require 'flipper/ui/middleware'
 
 module Flipper
   module UI
+    class << self
+      attr_accessor :app_path
+    end
+
     def self.root
       @root ||= Pathname(__FILE__).dirname.expand_path.join('ui')
     end

--- a/lib/flipper/ui/action.rb
+++ b/lib/flipper/ui/action.rb
@@ -57,6 +57,9 @@ module Flipper
         @code = 200
         @headers = {"Content-Type" => "text/plain"}
         @breadcrumbs = []
+        if app_path
+          @breadcrumbs << Breadcrumb.new("App", app_path)
+        end
       end
 
       # Public: Runs the request method for the provided request.
@@ -159,6 +162,10 @@ module Flipper
       # href - The String href for the anchor tag (optional). If nil, breadcrumb
       #        is assumed to be the end of the trail.
       def breadcrumb(text, href = nil)
+        if href != nil
+          href.prepend(script_name)
+        end
+
         @breadcrumbs << Breadcrumb.new(text, href)
       end
 
@@ -188,6 +195,17 @@ module Flipper
       # Internal: The path the app is mounted at.
       def script_name
         request.env['SCRIPT_NAME']
+      end
+
+      # Internal: Allows the "App" breadcrumb to be:
+      #
+      #  - Turned off via: `Flipper::UI.app_path = false`
+      #  - Set to a specific value via: `Flipper::UI.app_path = '/admin'`
+      #  - Set to the referer (if available) or root of the parent application
+      def app_path
+        if Flipper::UI.app_path != false
+          Flipper::UI.app_path || request.env['HTTP_REFERER'] || '/'
+        end
       end
 
       # Private

--- a/lib/flipper/ui/views/layout.erb
+++ b/lib/flipper/ui/views/layout.erb
@@ -25,7 +25,7 @@
             <% if breadcrumb.active? %>
               <%= breadcrumb.text %>
             <% else %>
-              <a href="<%= script_name %><%= breadcrumb.href %>"><%= breadcrumb.text %></a>
+              <a href="<%= breadcrumb.href %>"><%= breadcrumb.text %></a>
             <% end %>
           </li>
         <% end %>

--- a/spec/flipper/ui/action_spec.rb
+++ b/spec/flipper/ui/action_spec.rb
@@ -1,0 +1,57 @@
+require 'helper'
+
+RSpec.describe Flipper::UI::Action do
+  before(:each) do
+    get '/', {}, headers
+  end
+
+  let(:headers) { {} }
+  let(:action) { Flipper::UI::Action.new(flipper, last_request) }
+
+  it 'should have an app breadcrumb' do
+    expect(action.instance_variable_get("@breadcrumbs")).to be_an(Array)
+    expect(action.instance_variable_get("@breadcrumbs").size).to eq(1)
+    expect(action.instance_variable_get("@breadcrumbs").first.text).to eq('App')
+  end
+
+  context 'with the app_path set to false' do
+    it 'should not have any breadcrumbs' do
+      Flipper::UI.app_path = false
+      expect(action.instance_variable_get("@breadcrumbs")).to be_an(Array)
+      expect(action.instance_variable_get("@breadcrumbs")).to be_empty
+      Flipper::UI.app_path = nil
+    end
+  end
+
+  describe '#app_path' do
+    it 'should default to the application root' do
+      expect(action.app_path).to eq('/')
+    end
+
+    context 'with the app_path turned off' do
+      it 'should be nil' do
+        Flipper::UI.app_path = false
+        expect(action.app_path).to be_nil
+        Flipper::UI.app_path = nil
+      end
+    end
+
+    context 'with the app_path specified' do
+      let(:headers) { { 'HTTP_REFERER' => '/bogus' } }
+
+      it 'should return the correct path' do
+        Flipper::UI.app_path = '/admin'
+        expect(action.app_path).to eq('/admin')
+        Flipper::UI.app_path = nil
+      end
+    end
+
+    context 'with a referer set' do
+      let(:headers) { { 'HTTP_REFERER' => '/admin' } }
+
+      it 'should return the correct path' do
+        expect(action.app_path).to eq('/admin')
+      end
+    end
+  end
+end

--- a/spec/flipper/ui_spec.rb
+++ b/spec/flipper/ui_spec.rb
@@ -41,4 +41,14 @@ RSpec.describe Flipper::UI do
     expect(last_response.status).to be(302)
     expect(last_response.headers["Location"]).to eq("/features/refactor-images")
   end
+
+  it "should not have an app_url by default" do
+    expect(Flipper::UI.app_path).to be(nil)
+  end
+
+  it "should properly store an app_url" do
+    Flipper::UI.app_path = "/admin"
+    expect(Flipper::UI.app_path).to eq("/admin")
+    Flipper::UI.app_path = nil
+  end
 end


### PR DESCRIPTION
An alternate approach that uses the existing breadcrumbs and also has a really sensible default.

![screen shot 2015-12-04 at 5 04 13 pm](https://cloud.githubusercontent.com/assets/221/11605122/9e71936c-9ab4-11e5-93c3-498cc22a8f18.png)
