### PR TITLE
Add #disabled? to DSL

### DIFF
--- a/lib/flipper/dsl.rb
+++ b/lib/flipper/dsl.rb
@@ -91,6 +91,16 @@ module Flipper
       feature(name).enable_percentage_of_actors(percentage)
     end
 
+    # Public: Check if a feature is disabled.
+    #
+    # name - The String or Symbol name of the feature.
+    # args - The args passed through to the enabled check.
+    #
+    # Returns true if feature is disabled, false if not.
+    def disabled?(name, *args)
+      feature(name).disabled?(*args)
+    end
+
     # Public: Disable a feature.
     #
     # name - The String or Symbol name of the feature.

--- a/lib/flipper/feature.rb
+++ b/lib/flipper/feature.rb
@@ -99,6 +99,13 @@ module Flipper
       }
     end
 
+    # Public: Check if a feature is disabled for a thing.
+    #
+    # Returns true if disabled, false if enabled.
+    def disabled?(thing = nil)
+      !enabled?(thing)
+    end
+
     # Public: Enables a feature for an actor.
     #
     # actor - a Flipper::Types::Actor instance or an object that responds


### PR DESCRIPTION
What it says on the tin.

DSL thing I thought should be added, since `$flipper` is used as a global in an app I code for, and `!$flipper[:feature].enabled?` is rather ugly, and you can't always use `unless` to negate stuff.