### PR TITLE
Add Core Activerecord Adapter

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,5 +10,5 @@ services:
   - redis-server
   - mongodb
 env:
-  - 4.2.0
-  - 3.2.0
+  - RAILS_VERSION=4.2.0
+  - RAILS_VERSION=3.2.0

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,8 +3,6 @@ rvm:
   - 1.9.3
   - 2.1.0
   - 2.2.0
-notifications:
-  email: false
 bundler_args: --without guard
 before_script: sudo service redis-server status && sudo service mongodb status
 script: bundle exec rake

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,6 +7,7 @@ notifications:
   email: false
 bundler_args: --without guard
 before_script: sudo service redis-server status && sudo service mongodb status
+script: bundle exec rake
 services:
   - redis-server
   - mongodb

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,3 +9,6 @@ script: bundle exec rake
 services:
   - redis-server
   - mongodb
+gemfile:
+  - Gemfile
+  - Gemfile-rails32

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,7 @@ rvm:
   - 2.1.0
   - 2.2.0
 bundler_args: --without guard
-before_script: sudo service redis-server status && sudo service mongodb status
+before_script: sudo service redis-server status && sudo service mongodb status && gem install bundler -v 1.10.6
 script: bundle exec rake
 services:
   - redis-server

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,8 @@
 language: ruby
 rvm:
-  - 2.0
-  - 2.1
-  - 2.2
+  - 2.0.0
+  - 2.1.8
+  - 2.2.4
 bundler_args: --without guard
 before_script: gem install bundler -v 1.10.6 && sudo service redis-server status && sudo service mongodb status
 script: bundle exec rake

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 language: ruby
 rvm:
-  - 1.9.3
+  - 2.0.0
   - 2.1.0
   - 2.2.0
 bundler_args: --without guard

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,8 @@
 language: ruby
 rvm:
-  - 2.0.0
-  - 2.1.8
-  - 2.2.4
+  - 2.0
+  - 2.1
+  - 2.2
 bundler_args: --without guard
 before_script: gem install bundler -v 1.10.6 && sudo service redis-server status && sudo service mongodb status
 script: bundle exec rake

--- a/.travis.yml
+++ b/.travis.yml
@@ -10,5 +10,5 @@ services:
   - redis-server
   - mongodb
 env:
-  - RAILS_VERSION=4.2.0
-  - RAILS_VERSION=3.2.0
+  - RAILS_VERSION=4.2.5
+  - RAILS_VERSION=3.2.21

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,10 +1,10 @@
 language: ruby
 rvm:
   - 2.0.0
-  - 2.1.0
-  - 2.2.0
+  - 2.1.8
+  - 2.2.4
 bundler_args: --without guard
-before_script: sudo service redis-server status && sudo service mongodb status && gem install bundler -v 1.10.6
+before_script: gem install bundler -v 1.10.6 && sudo service redis-server status && sudo service mongodb status
 script: bundle exec rake
 services:
   - redis-server

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,6 +9,6 @@ script: bundle exec rake
 services:
   - redis-server
   - mongodb
-gemfile:
-  - Gemfile
-  - Gemfile-rails32
+env:
+  - 4.2.0
+  - 3.2.0

--- a/Gemfile
+++ b/Gemfile
@@ -14,7 +14,7 @@ gem 'rspec', '~> 3.0'
 gem 'rack-test', '~> 0.6.3'
 gem 'activesupport', '~> 4.2.0'
 gem 'sqlite3', '~> 1.3.11'
-gem 'rails', '>= 3.2', '< 5'
+gem 'rails', "~> #{ENV["RAILS_VERSION"] || '4.2.0'}"
 
 group(:guard) do
   gem 'guard', '~> 2.12.5'

--- a/Gemfile
+++ b/Gemfile
@@ -14,6 +14,7 @@ gem 'rspec', '~> 3.0'
 gem 'rack-test', '~> 0.6.3'
 gem 'sqlite3', '~> 1.3.11'
 gem 'rails', "~> #{ENV["RAILS_VERSION"] || '4.2.5'}"
+gem 'test-unit', '~> 3.0'
 
 group(:guard) do
   gem 'guard', '~> 2.12.5'

--- a/Gemfile
+++ b/Gemfile
@@ -13,6 +13,7 @@ gem 'statsd-ruby', '~> 1.2.1'
 gem 'rspec', '~> 3.0'
 gem 'rack-test', '~> 0.6.3'
 gem 'activesupport', '~> 4.2.0'
+gem 'sqlite3', '~> 1.3.11'
 
 group(:guard) do
   gem 'guard', '~> 2.12.5'

--- a/Gemfile
+++ b/Gemfile
@@ -13,7 +13,7 @@ gem 'statsd-ruby', '~> 1.2.1'
 gem 'rspec', '~> 3.0'
 gem 'rack-test', '~> 0.6.3'
 gem 'sqlite3', '~> 1.3.11'
-gem 'rails', "~> #{ENV["RAILS_VERSION"] || '4.2.0'}"
+gem 'rails', "~> #{ENV["RAILS_VERSION"] || '4.2.5'}"
 
 group(:guard) do
   gem 'guard', '~> 2.12.5'

--- a/Gemfile
+++ b/Gemfile
@@ -14,6 +14,8 @@ gem 'rspec', '~> 3.0'
 gem 'rack-test', '~> 0.6.3'
 gem 'sqlite3', '~> 1.3.11'
 gem 'rails', "~> #{ENV["RAILS_VERSION"] || '4.2.5'}"
+
+# for active support tests in test/ and only needed for ruby 2.2.x
 gem 'test-unit', '~> 3.0'
 
 group(:guard) do

--- a/Gemfile
+++ b/Gemfile
@@ -14,6 +14,7 @@ gem 'rspec', '~> 3.0'
 gem 'rack-test', '~> 0.6.3'
 gem 'activesupport', '~> 4.2.0'
 gem 'sqlite3', '~> 1.3.11'
+gem 'rails', '~> 4.2.0'
 
 group(:guard) do
   gem 'guard', '~> 2.12.5'

--- a/Gemfile
+++ b/Gemfile
@@ -12,7 +12,6 @@ gem 'shotgun', '~> 0.9'
 gem 'statsd-ruby', '~> 1.2.1'
 gem 'rspec', '~> 3.0'
 gem 'rack-test', '~> 0.6.3'
-gem 'activesupport', '~> 4.2.0'
 gem 'sqlite3', '~> 1.3.11'
 gem 'rails', "~> #{ENV["RAILS_VERSION"] || '4.2.0'}"
 

--- a/Gemfile
+++ b/Gemfile
@@ -14,7 +14,7 @@ gem 'rspec', '~> 3.0'
 gem 'rack-test', '~> 0.6.3'
 gem 'activesupport', '~> 4.2.0'
 gem 'sqlite3', '~> 1.3.11'
-gem 'rails', '~> 4.2.0'
+gem 'rails', '>= 3.2', '< 5'
 
 group(:guard) do
   gem 'guard', '~> 2.12.5'

--- a/Gemfile-rails32
+++ b/Gemfile-rails32
@@ -1,0 +1,5 @@
+original_gemfile = File.join(File.dirname(__FILE__), 'Gemfile')
+
+eval IO.read(original_gemfile)
+
+gem 'rails', '~ 3.2.22'

--- a/Gemfile-rails32
+++ b/Gemfile-rails32
@@ -2,4 +2,4 @@ original_gemfile = File.join(File.dirname(__FILE__), 'Gemfile')
 
 eval IO.read(original_gemfile)
 
-gem 'rails', '~ 3.2.22'
+gem 'rails', '~> 3.2.22'

--- a/Gemfile-rails32
+++ b/Gemfile-rails32
@@ -1,5 +1,0 @@
-original_gemfile = File.join(File.dirname(__FILE__), 'Gemfile')
-
-eval IO.read(original_gemfile)
-
-gem 'rails', '~> 3.2.22'

--- a/Rakefile
+++ b/Rakefile
@@ -36,3 +36,9 @@ namespace :spec do
 end
 
 task :default => :spec
+
+task :test do
+  sh "bundle exec ruby -Itest test/generators/flipper/active_record_generator_test.rb"
+end
+
+task :default => :test

--- a/docs/active_record/README.md
+++ b/docs/active_record/README.md
@@ -2,6 +2,11 @@
 
 An ActiveRecord adapter for [Flipper](https://github.com/jnunemaker/flipper).
 
+Supported Active Record versions:
+
+* 3.2.x
+* 4.2.x
+
 ## Installation
 
 Add this line to your application's Gemfile:

--- a/docs/active_record/README.md
+++ b/docs/active_record/README.md
@@ -1,0 +1,147 @@
+# Flipper ActiveRecord
+
+An ActiveRecord adapter for [Flipper](https://github.com/jnunemaker/flipper).
+
+## Installation
+
+Add this line to your application's Gemfile:
+
+    gem 'flipper-active_record'
+
+And then execute:
+
+    $ bundle
+
+Or install it yourself with:
+
+    $ gem install flipper-active_record
+
+## Usage
+
+```ruby
+require 'flipper/adapters/active_record'
+adapter = Flipper::Adapters::ActiveRecord.new
+flipper = Flipper.new(adapter)
+# profit...
+```
+
+## Internals
+
+Each feature is stored as a row in a features table. Each gate is stored as a row in a gates table, related to the feature by the feature's key.
+
+```ruby
+require 'flipper/adapters/active_record'
+adapter = Flipper::Adapters::ActiveRecord.new
+flipper = Flipper.new(adapter)
+
+# Register a few groups.
+Flipper.register(:admins) { |thing| thing.admin? }
+Flipper.register(:early_access) { |thing| thing.early_access? }
+
+# Create a user class that has flipper_id instance method.
+User = Struct.new(:flipper_id)
+
+flipper[:stats].enable
+flipper[:stats].enable_group :admins
+flipper[:stats].enable_group :early_access
+flipper[:stats].enable_actor User.new('25')
+flipper[:stats].enable_actor User.new('90')
+flipper[:stats].enable_actor User.new('180')
+flipper[:stats].enable_percentage_of_time 15
+flipper[:stats].enable_percentage_of_actors 45
+
+flipper[:search].enable
+
+puts 'all rows in features table'
+pp Flipper::Adapters::ActiveRecord::Feature.all
+# [#<Flipper::Adapters::ActiveRecord::Feature:0x007fd259b47110
+#   id: 1,
+#   key: "stats",
+#   created_at: 2015-12-21 16:26:29 UTC,
+#   updated_at: 2015-12-21 16:26:29 UTC>,
+#  #<Flipper::Adapters::ActiveRecord::Feature:0x007fd259b46cd8
+#   id: 2,
+#   key: "search",
+#   created_at: 2015-12-21 16:26:29 UTC,
+#   updated_at: 2015-12-21 16:26:29 UTC>]
+puts
+
+puts 'all rows in gates table'
+pp Flipper::Adapters::ActiveRecord::Gate.all
+# [#<Flipper::Adapters::ActiveRecord::Gate:0x007fd259b0f0f8
+#   id: 1,
+#   feature_key: "stats",
+#   key: "boolean",
+#   value: "true",
+#   created_at: 2015-12-21 16:26:29 UTC,
+#   updated_at: 2015-12-21 16:26:29 UTC>,
+#  #<Flipper::Adapters::ActiveRecord::Gate:0x007fd259b0ebd0
+#   id: 2,
+#   feature_key: "stats",
+#   key: "groups",
+#   value: "admins",
+#   created_at: 2015-12-21 16:26:29 UTC,
+#   updated_at: 2015-12-21 16:26:29 UTC>,
+#  #<Flipper::Adapters::ActiveRecord::Gate:0x007fd259b0e748
+#   id: 3,
+#   feature_key: "stats",
+#   key: "groups",
+#   value: "early_access",
+#   created_at: 2015-12-21 16:26:29 UTC,
+#   updated_at: 2015-12-21 16:26:29 UTC>,
+#  #<Flipper::Adapters::ActiveRecord::Gate:0x007fd259b0e568
+#   id: 4,
+#   feature_key: "stats",
+#   key: "actors",
+#   value: "25",
+#   created_at: 2015-12-21 16:26:29 UTC,
+#   updated_at: 2015-12-21 16:26:29 UTC>,
+#  #<Flipper::Adapters::ActiveRecord::Gate:0x007fd259b0e0b8
+#   id: 5,
+#   feature_key: "stats",
+#   key: "actors",
+#   value: "90",
+#   created_at: 2015-12-21 16:26:29 UTC,
+#   updated_at: 2015-12-21 16:26:29 UTC>,
+#  #<Flipper::Adapters::ActiveRecord::Gate:0x007fd259b0da50
+#   id: 6,
+#   feature_key: "stats",
+#   key: "actors",
+#   value: "180",
+#   created_at: 2015-12-21 16:26:29 UTC,
+#   updated_at: 2015-12-21 16:26:29 UTC>,
+#  #<Flipper::Adapters::ActiveRecord::Gate:0x007fd259b0d3c0
+#   id: 7,
+#   feature_key: "stats",
+#   key: "percentage_of_time",
+#   value: "15",
+#   created_at: 2015-12-21 16:26:29 UTC,
+#   updated_at: 2015-12-21 16:26:29 UTC>,
+#  #<Flipper::Adapters::ActiveRecord::Gate:0x007fd259b0cdf8
+#   id: 8,
+#   feature_key: "stats",
+#   key: "percentage_of_actors",
+#   value: "45",
+#   created_at: 2015-12-21 16:26:29 UTC,
+#   updated_at: 2015-12-21 16:26:29 UTC>,
+#  #<Flipper::Adapters::ActiveRecord::Gate:0x007fd259b0cbf0
+#   id: 9,
+#   feature_key: "search",
+#   key: "boolean",
+#   value: "true",
+#   created_at: 2015-12-21 16:26:29 UTC,
+#   updated_at: 2015-12-21 16:26:29 UTC>]
+puts
+
+puts 'flipper get of feature'
+pp adapter.get(flipper[:stats])
+# flipper get of feature
+```
+
+## Contributing
+
+1. Fork it
+2. Create your feature branch (`git checkout -b my-new-feature`)
+3. Commit your changes (`git commit -am 'Added some feature'`)
+4. Push to the branch (`git push origin my-new-feature`)
+5. Create new Pull Request

--- a/docs/active_record/README.md
+++ b/docs/active_record/README.md
@@ -18,6 +18,12 @@ Or install it yourself with:
 
 ## Usage
 
+For your convenience a migration generator is provided to create the necessary migrations for using the active record adapter:
+
+    $ rails g flipper:active_record
+
+Once you have created and executed the migration, you can use the active record adapter like so:
+
 ```ruby
 require 'flipper/adapters/active_record'
 adapter = Flipper::Adapters::ActiveRecord.new

--- a/examples/active_record/basic.rb
+++ b/examples/active_record/basic.rb
@@ -1,0 +1,35 @@
+require 'pathname'
+require 'logger'
+
+root_path = Pathname(__FILE__).dirname.join('..').expand_path
+lib_path  = root_path.join('lib')
+$:.unshift(lib_path)
+
+require 'active_record'
+ActiveRecord::Base.establish_connection({
+  adapter: 'sqlite3',
+  database: ':memory:',
+})
+
+require 'generators/flipper/templates/migration'
+CreateFlipperTables.up
+
+require 'flipper/adapters/active_record'
+adapter = Flipper::Adapters::ActiveRecord.new
+flipper = Flipper.new(adapter)
+
+flipper[:stats].enable
+
+if flipper[:stats].enabled?
+  puts "Enabled!"
+else
+  puts "Disabled!"
+end
+
+flipper[:stats].disable
+
+if flipper[:stats].enabled?
+  puts "Enabled!"
+else
+  puts "Disabled!"
+end

--- a/examples/active_record/internals.rb
+++ b/examples/active_record/internals.rb
@@ -1,0 +1,123 @@
+require 'pp'
+require 'pathname'
+require 'logger'
+
+root_path = Pathname(__FILE__).dirname.join('..').expand_path
+lib_path  = root_path.join('lib')
+$:.unshift(lib_path)
+
+require 'active_record'
+ActiveRecord::Base.establish_connection({
+  adapter: 'sqlite3',
+  database: ':memory:',
+})
+
+require 'generators/flipper/templates/migration'
+CreateFlipperTables.up
+
+require 'flipper/adapters/active_record'
+adapter = Flipper::Adapters::ActiveRecord.new
+flipper = Flipper.new(adapter)
+
+# Register a few groups.
+Flipper.register(:admins) { |thing| thing.admin? }
+Flipper.register(:early_access) { |thing| thing.early_access? }
+
+# Create a user class that has flipper_id instance method.
+User = Struct.new(:flipper_id)
+
+flipper[:stats].enable
+flipper[:stats].enable_group :admins
+flipper[:stats].enable_group :early_access
+flipper[:stats].enable_actor User.new('25')
+flipper[:stats].enable_actor User.new('90')
+flipper[:stats].enable_actor User.new('180')
+flipper[:stats].enable_percentage_of_time 15
+flipper[:stats].enable_percentage_of_actors 45
+
+flipper[:search].enable
+
+puts 'all rows in features table'
+pp Flipper::Adapters::ActiveRecord::Feature.all
+# [#<Flipper::Adapters::ActiveRecord::Feature:0x007fd259b47110
+#   id: 1,
+#   key: "stats",
+#   created_at: 2015-12-21 16:26:29 UTC,
+#   updated_at: 2015-12-21 16:26:29 UTC>,
+#  #<Flipper::Adapters::ActiveRecord::Feature:0x007fd259b46cd8
+#   id: 2,
+#   key: "search",
+#   created_at: 2015-12-21 16:26:29 UTC,
+#   updated_at: 2015-12-21 16:26:29 UTC>]
+puts
+
+puts 'all rows in gates table'
+pp Flipper::Adapters::ActiveRecord::Gate.all
+# [#<Flipper::Adapters::ActiveRecord::Gate:0x007fd259b0f0f8
+#   id: 1,
+#   feature_key: "stats",
+#   key: "boolean",
+#   value: "true",
+#   created_at: 2015-12-21 16:26:29 UTC,
+#   updated_at: 2015-12-21 16:26:29 UTC>,
+#  #<Flipper::Adapters::ActiveRecord::Gate:0x007fd259b0ebd0
+#   id: 2,
+#   feature_key: "stats",
+#   key: "groups",
+#   value: "admins",
+#   created_at: 2015-12-21 16:26:29 UTC,
+#   updated_at: 2015-12-21 16:26:29 UTC>,
+#  #<Flipper::Adapters::ActiveRecord::Gate:0x007fd259b0e748
+#   id: 3,
+#   feature_key: "stats",
+#   key: "groups",
+#   value: "early_access",
+#   created_at: 2015-12-21 16:26:29 UTC,
+#   updated_at: 2015-12-21 16:26:29 UTC>,
+#  #<Flipper::Adapters::ActiveRecord::Gate:0x007fd259b0e568
+#   id: 4,
+#   feature_key: "stats",
+#   key: "actors",
+#   value: "25",
+#   created_at: 2015-12-21 16:26:29 UTC,
+#   updated_at: 2015-12-21 16:26:29 UTC>,
+#  #<Flipper::Adapters::ActiveRecord::Gate:0x007fd259b0e0b8
+#   id: 5,
+#   feature_key: "stats",
+#   key: "actors",
+#   value: "90",
+#   created_at: 2015-12-21 16:26:29 UTC,
+#   updated_at: 2015-12-21 16:26:29 UTC>,
+#  #<Flipper::Adapters::ActiveRecord::Gate:0x007fd259b0da50
+#   id: 6,
+#   feature_key: "stats",
+#   key: "actors",
+#   value: "180",
+#   created_at: 2015-12-21 16:26:29 UTC,
+#   updated_at: 2015-12-21 16:26:29 UTC>,
+#  #<Flipper::Adapters::ActiveRecord::Gate:0x007fd259b0d3c0
+#   id: 7,
+#   feature_key: "stats",
+#   key: "percentage_of_time",
+#   value: "15",
+#   created_at: 2015-12-21 16:26:29 UTC,
+#   updated_at: 2015-12-21 16:26:29 UTC>,
+#  #<Flipper::Adapters::ActiveRecord::Gate:0x007fd259b0cdf8
+#   id: 8,
+#   feature_key: "stats",
+#   key: "percentage_of_actors",
+#   value: "45",
+#   created_at: 2015-12-21 16:26:29 UTC,
+#   updated_at: 2015-12-21 16:26:29 UTC>,
+#  #<Flipper::Adapters::ActiveRecord::Gate:0x007fd259b0cbf0
+#   id: 9,
+#   feature_key: "search",
+#   key: "boolean",
+#   value: "true",
+#   created_at: 2015-12-21 16:26:29 UTC,
+#   updated_at: 2015-12-21 16:26:29 UTC>]
+puts
+
+puts 'flipper get of feature'
+pp adapter.get(flipper[:stats])
+# flipper get of feature

--- a/flipper-active_record.gemspec
+++ b/flipper-active_record.gemspec
@@ -20,5 +20,5 @@ Gem::Specification.new do |gem|
   gem.version       = Flipper::VERSION
 
   gem.add_dependency 'flipper', "~> #{Flipper::VERSION}"
-  gem.add_dependency 'activerecord', '~> 4.2.0'
+  gem.add_dependency 'activerecord', "~> #{ENV["RAILS_VERSION"] || '4.2.0'}"
 end

--- a/flipper-active_record.gemspec
+++ b/flipper-active_record.gemspec
@@ -1,0 +1,24 @@
+# -*- encoding: utf-8 -*-
+require File.expand_path('../lib/flipper/version', __FILE__)
+
+flipper_mongo_files = lambda { |file|
+  file =~ /active_record/
+}
+
+Gem::Specification.new do |gem|
+  gem.authors       = ["John Nunemaker"]
+  gem.email         = ["nunemaker@gmail.com"]
+  gem.summary       = "ActiveRecord adapter for Flipper"
+  gem.description   = "ActiveRecord adapter for Flipper"
+  gem.license       = "MIT"
+  gem.homepage      = "https://github.com/jnunemaker/flipper"
+
+  gem.files         = `git ls-files`.split("\n").select(&flipper_mongo_files) + ["lib/flipper/version.rb"]
+  gem.test_files    = `git ls-files -- {test,spec,features}/*`.split("\n").select(&flipper_mongo_files)
+  gem.name          = "flipper-active_record"
+  gem.require_paths = ["lib"]
+  gem.version       = Flipper::VERSION
+
+  gem.add_dependency 'flipper', "~> #{Flipper::VERSION}"
+  gem.add_dependency 'activerecord', '~> 4.2.0'
+end

--- a/flipper-active_record.gemspec
+++ b/flipper-active_record.gemspec
@@ -20,5 +20,5 @@ Gem::Specification.new do |gem|
   gem.version       = Flipper::VERSION
 
   gem.add_dependency 'flipper', "~> #{Flipper::VERSION}"
-  gem.add_dependency 'activerecord', "~> #{ENV["RAILS_VERSION"] || '4.2.0'}"
+  gem.add_dependency 'activerecord', ">= 3.2", "< 5"
 end

--- a/lib/flipper-active_record.rb
+++ b/lib/flipper-active_record.rb
@@ -1,0 +1,1 @@
+require 'flipper/adapters/active_record'

--- a/lib/flipper/adapters/active_record.rb
+++ b/lib/flipper/adapters/active_record.rb
@@ -1,0 +1,142 @@
+require 'set'
+require 'flipper'
+require 'active_record'
+
+module Flipper
+  module Adapters
+    class ActiveRecord
+      include Flipper::Adapter
+
+      class Feature < ::ActiveRecord::Base
+        self.table_name = "flipper_features"
+      end
+
+      class Gate < ::ActiveRecord::Base
+        self.table_name = "flipper_gates"
+      end
+
+      # Public: The name of the adapter.
+      attr_reader :name
+
+      def initialize
+        @name = :active_record
+      end
+
+      # Public: The set of known features.
+      def features
+        Feature.select(:key).map(&:key).to_set
+      end
+
+      # Public: Adds a feature to the set of known features.
+      def add(feature)
+        attributes = {key: feature.key}
+        # race condition, but add is only used by enable/disable which happen
+        # super rarely, so it shouldn't matter in practice
+        Feature.where(attributes).first || Feature.create!(attributes)
+        true
+      end
+
+      # Public: Removes a feature from the set of known features.
+      def remove(feature)
+        Feature.transaction do
+          Feature.delete_all(key: feature.key)
+          clear(feature)
+        end
+        true
+      end
+
+      # Public: Clears the gate values for a feature.
+      def clear(feature)
+        Gate.delete_all(feature_key: feature.key)
+        true
+      end
+
+      # Public: Gets the values for all gates for a given feature.
+      #
+      # Returns a Hash of Flipper::Gate#key => value.
+      def get(feature)
+        result = {}
+
+        db_gates = Gate.where(feature_key: feature.key)
+
+        feature.gates.each do |gate|
+          result[gate.key] = case gate.data_type
+          when :boolean
+            if db_gate = db_gates.detect { |db_gate| db_gate.key == gate.key.to_s }
+              db_gate.value
+            end
+          when :integer
+            if db_gate = db_gates.detect { |db_gate| db_gate.key == gate.key.to_s }
+              db_gate.value
+            end
+          when :set
+            db_gates.select { |db_gate| db_gate.key == gate.key.to_s }.map(&:value).to_set
+          else
+            unsupported_data_type gate.data_type
+          end
+        end
+
+        result
+      end
+
+      # Public: Enables a gate for a given thing.
+      #
+      # feature - The Flipper::Feature for the gate.
+      # gate - The Flipper::Gate to disable.
+      # thing - The Flipper::Type being disabled for the gate.
+      #
+      # Returns true.
+      def enable(feature, gate, thing)
+        case gate.data_type
+        when :boolean, :integer
+          Gate.create!({
+            feature_key: feature.key,
+            key: gate.key,
+            value: thing.value.to_s,
+          })
+        when :set
+          Gate.create!({
+            feature_key: feature.key,
+            key: gate.key,
+            value: thing.value.to_s,
+          })
+        else
+          unsupported_data_type gate.data_type
+        end
+
+        true
+      end
+
+      # Public: Disables a gate for a given thing.
+      #
+      # feature - The Flipper::Feature for the gate.
+      # gate - The Flipper::Gate to disable.
+      # thing - The Flipper::Type being disabled for the gate.
+      #
+      # Returns true.
+      def disable(feature, gate, thing)
+        case gate.data_type
+        when :boolean
+          clear(feature)
+        when :integer
+          Gate.create!({
+            feature_key: feature.key,
+            key: gate.key,
+            value: thing.value.to_s,
+          })
+        when :set
+          Gate.delete_all(feature_key: feature.key, key: gate.key, value: thing.value)
+        else
+          unsupported_data_type gate.data_type
+        end
+
+        true
+      end
+
+      # Private
+      def unsupported_data_type(data_type)
+        raise "#{data_type} is not supported by this adapter"
+      end
+    end
+  end
+end

--- a/lib/flipper/spec/shared_adapter_specs.rb
+++ b/lib/flipper/spec/shared_adapter_specs.rb
@@ -65,7 +65,7 @@ shared_examples_for 'a flipper adapter' do
     expect(subject.enable(feature, actors_gate, flipper.actors(25))).to eq(true)
     expect(subject.enable(feature, time_gate, flipper.time(45))).to eq(true)
 
-    expect(subject.disable(feature, boolean_gate, flipper.boolean)).to eq(true)
+    expect(subject.disable(feature, boolean_gate, flipper.boolean(false))).to eq(true)
 
     expect(subject.get(feature)).to eq({
       :boolean => nil,

--- a/lib/generators/flipper/active_record_generator.rb
+++ b/lib/generators/flipper/active_record_generator.rb
@@ -1,0 +1,21 @@
+
+require 'rails/generators/active_record'
+
+module Flipper
+  module Generators
+    class ActiveRecordGenerator < Rails::Generators::Base
+      include Rails::Generators::Migration
+      desc "Generates migration for flipper tables"
+
+      source_paths << File.join(File.dirname(__FILE__), "templates")
+
+      def create_migration_file
+        migration_template "migration.rb", "db/migrate/create_flipper_tables.rb"
+      end
+
+      def self.next_migration_number(dirname)
+        ::ActiveRecord::Generators::Base.next_migration_number dirname
+      end
+    end
+  end
+end

--- a/lib/generators/flipper/active_record_generator.rb
+++ b/lib/generators/flipper/active_record_generator.rb
@@ -1,5 +1,4 @@
-
-require 'rails/generators/active_record'
+require "rails/generators/active_record"
 
 module Flipper
   module Generators
@@ -14,7 +13,7 @@ module Flipper
       end
 
       def self.next_migration_number(dirname)
-        ::ActiveRecord::Generators::Base.next_migration_number dirname
+        ::ActiveRecord::Generators::Base.next_migration_number(dirname)
       end
     end
   end

--- a/lib/generators/flipper/templates/migration.rb
+++ b/lib/generators/flipper/templates/migration.rb
@@ -1,0 +1,22 @@
+class CreateFlipperTables < ActiveRecord::Migration
+  def self.up
+    create_table :flipper_features do |t|
+      t.string :key, null: false
+      t.timestamps null: false
+    end
+    add_index :flipper_features, :key, unique: true
+
+    create_table :flipper_gates do |t|
+      t.string :feature_key, null: false
+      t.string :key, null: false
+      t.string :value
+      t.timestamps null: false
+    end
+    add_index :flipper_gates, [:feature_key, :key, :value], unique: true
+  end
+
+  def self.down
+    drop_table :flipper_gates
+    drop_table :flipper_features
+  end
+end

--- a/script/test
+++ b/script/test
@@ -12,4 +12,10 @@ cd $(dirname "$0")/..
     exit 0
 }
 
-script/bootstrap && bundle exec rake
+export RAILS_VERSION=3.2.21
+script/bootstrap || bundle update
+bundle exec rake
+
+export RAILS_VERSION=4.2.5
+script/bootstrap || bundle update
+bundle exec rake

--- a/script/test
+++ b/script/test
@@ -1,15 +1,7 @@
 #!/bin/sh
-#/ Usage: test [individual test file]
+#/ Usage: test
 #/
-#/ Bootstrap and run all tests or an individual test.
-#/
-#/ Examples:
-#/
-#/   # run all tests
-#/   test
-#/
-#/   # run individual test
-#/   test spec/qu_spec.rb
+#/ Bootstrap and run all tests.
 #/
 
 set -e
@@ -20,11 +12,4 @@ cd $(dirname "$0")/..
     exit 0
 }
 
-specs="spec/"
-
-if [ $# -gt 0 ]
-  then
-    specs=$@
-fi
-
-script/bootstrap && bundle exec rspec $specs
+script/bootstrap && bundle exec rake

--- a/spec/flipper/adapters/active_record_spec.rb
+++ b/spec/flipper/adapters/active_record_spec.rb
@@ -5,28 +5,7 @@ require 'flipper/spec/shared_adapter_specs'
 # Turn off migration logging for specs
 ActiveRecord::Migration.verbose = false
 
-class CreateFlipperTables < ActiveRecord::Migration
-  def self.up
-    create_table :flipper_features do |t|
-      t.string :key, null: false
-      t.timestamps null: false
-    end
-    add_index :flipper_features, :key, unique: true
-
-    create_table :flipper_gates do |t|
-      t.string :feature_key, null: false
-      t.string :key, null: false
-      t.string :value
-      t.timestamps null: false
-    end
-    add_index :flipper_gates, [:feature_key, :key, :value], unique: true
-  end
-
-  def self.down
-    drop_table :flipper_gates
-    drop_table :flipper_features
-  end
-end
+require 'generators/flipper/templates/migration'
 
 RSpec.describe Flipper::Adapters::ActiveRecord do
   subject { described_class.new }

--- a/spec/flipper/adapters/active_record_spec.rb
+++ b/spec/flipper/adapters/active_record_spec.rb
@@ -1,0 +1,50 @@
+require 'helper'
+require 'flipper/adapters/active_record'
+require 'flipper/spec/shared_adapter_specs'
+
+# Turn off migration logging for specs
+ActiveRecord::Migration.verbose = false
+
+class CreateFlipperTables < ActiveRecord::Migration
+  def self.up
+    create_table :flipper_features do |t|
+      t.string :key, null: false
+      t.timestamps null: false
+    end
+    add_index :flipper_features, :key, unique: true
+
+    create_table :flipper_gates do |t|
+      t.string :feature_key, null: false
+      t.string :key, null: false
+      t.string :value
+      t.timestamps null: false
+    end
+    add_index :flipper_gates, [:feature_key, :key, :value], unique: true
+  end
+
+  def self.down
+    drop_table :flipper_gates
+    drop_table :flipper_features
+  end
+end
+
+RSpec.describe Flipper::Adapters::ActiveRecord do
+  subject { described_class.new }
+
+  before(:all) do
+    ActiveRecord::Base.establish_connection({
+      adapter: "sqlite3",
+      database: ":memory:",
+    })
+  end
+
+  before(:each) do
+    CreateFlipperTables.up
+  end
+
+  after(:each) do
+    CreateFlipperTables.down
+  end
+
+  it_should_behave_like 'a flipper adapter'
+end

--- a/spec/flipper/ui/actions/actors_gate_spec.rb
+++ b/spec/flipper/ui/actions/actors_gate_spec.rb
@@ -20,7 +20,7 @@ RSpec.describe Flipper::UI::Actions::ActorsGate do
       before do
         post "features/search/actors",
           {"value" => "User:6", "operation" => "enable", "authenticity_token" => "a"},
-          "rack.session" => {:csrf => "a"}
+          "rack.session" => {"_csrf_token" => "a"}
       end
 
       it "adds item to members" do
@@ -38,7 +38,7 @@ RSpec.describe Flipper::UI::Actions::ActorsGate do
         flipper[:search].enable_actor Flipper::UI::Actor.new("User:6")
         post "features/search/actors",
           {"value" => "User:6", "operation" => "disable", "authenticity_token" => "a"},
-          "rack.session" => {:csrf => "a"}
+          "rack.session" => {"_csrf_token" => "a"}
       end
 
       it "removes item from members" do
@@ -55,7 +55,7 @@ RSpec.describe Flipper::UI::Actions::ActorsGate do
       before do
         post "features/search/actors",
           {"value" => "", "operation" => "enable", "authenticity_token" => "a"},
-          "rack.session" => {:csrf => "a"}
+          "rack.session" => {"_csrf_token" => "a"}
       end
 
       it "redirects back to feature" do

--- a/spec/flipper/ui/actions/boolean_gate_spec.rb
+++ b/spec/flipper/ui/actions/boolean_gate_spec.rb
@@ -7,7 +7,7 @@ RSpec.describe Flipper::UI::Actions::BooleanGate do
         flipper.disable :search
         post "features/search/boolean",
           {"action" => "Enable", "authenticity_token" => "a"},
-          "rack.session" => {:csrf => "a"}
+          "rack.session" => {"_csrf_token" => "a"}
       end
 
       it "enables the feature" do
@@ -25,7 +25,7 @@ RSpec.describe Flipper::UI::Actions::BooleanGate do
         flipper.enable :search
         post "features/search/boolean",
           {"action" => "Disable", "authenticity_token" => "a"},
-          "rack.session" => {:csrf => "a"}
+          "rack.session" => {"_csrf_token" => "a"}
       end
 
       it "disables the feature" do

--- a/spec/flipper/ui/actions/feature_spec.rb
+++ b/spec/flipper/ui/actions/feature_spec.rb
@@ -6,7 +6,7 @@ RSpec.describe Flipper::UI::Actions::Feature do
       flipper.enable :search
       delete "/features/search",
         {"authenticity_token" => "a"},
-        "rack.session" => {:csrf => "a"}
+        "rack.session" => {"_csrf_token" => "a"}
     end
 
     it "removes feature" do
@@ -24,7 +24,7 @@ RSpec.describe Flipper::UI::Actions::Feature do
       flipper.enable :search
       post "/features/search",
         {"_method" => "DELETE", "authenticity_token" => "a"},
-        "rack.session" => {:csrf => "a"}
+        "rack.session" => {"_csrf_token" => "a"}
     end
 
     it "removes feature" do

--- a/spec/flipper/ui/actions/features_spec.rb
+++ b/spec/flipper/ui/actions/features_spec.rb
@@ -22,7 +22,7 @@ RSpec.describe Flipper::UI::Actions::Features do
     before do
       post "/features",
         {"value" => "notifications_next", "authenticity_token" => "a"},
-        "rack.session" => {:csrf => "a"}
+        "rack.session" => {"_csrf_token" => "a"}
     end
 
     it "adds feature" do

--- a/spec/flipper/ui/actions/gate_spec.rb
+++ b/spec/flipper/ui/actions/gate_spec.rb
@@ -5,7 +5,7 @@ RSpec.describe Flipper::UI::Actions::Gate do
     before do
       post "/features/search/non-existent-gate",
         {"authenticity_token" => "a"},
-        "rack.session" => {:csrf => "a"}
+        "rack.session" => {"_csrf_token" => "a"}
     end
 
     it "responds with redirect" do

--- a/spec/flipper/ui/actions/groups_gate_spec.rb
+++ b/spec/flipper/ui/actions/groups_gate_spec.rb
@@ -33,7 +33,7 @@ RSpec.describe Flipper::UI::Actions::GroupsGate do
       before do
         post "features/search/groups",
           {"value" => "admins", "operation" => "enable", "authenticity_token" => "a"},
-          "rack.session" => {:csrf => "a"}
+          "rack.session" => {"_csrf_token" => "a"}
       end
 
       it "adds item to members" do
@@ -51,7 +51,7 @@ RSpec.describe Flipper::UI::Actions::GroupsGate do
         flipper[:search].enable_group :admins
         post "features/search/groups",
           {"value" => "admins", "operation" => "disable", "authenticity_token" => "a"},
-          "rack.session" => {:csrf => "a"}
+          "rack.session" => {"_csrf_token" => "a"}
       end
 
       it "removes item from members" do
@@ -68,7 +68,7 @@ RSpec.describe Flipper::UI::Actions::GroupsGate do
       before do
         post "features/search/groups",
           {"value" => "not_here", "operation" => "enable", "authenticity_token" => "a"},
-          "rack.session" => {:csrf => "a"}
+          "rack.session" => {"_csrf_token" => "a"}
       end
 
       it "redirects back to feature" do

--- a/spec/flipper/ui/actions/percentage_of_actors_gate_spec.rb
+++ b/spec/flipper/ui/actions/percentage_of_actors_gate_spec.rb
@@ -6,7 +6,7 @@ RSpec.describe Flipper::UI::Actions::PercentageOfActorsGate do
       before do
         post "features/search/percentage_of_actors",
           {"value" => "24", "authenticity_token" => "a"},
-          "rack.session" => {:csrf => "a"}
+          "rack.session" => {"_csrf_token" => "a"}
       end
 
       it "enables the feature" do
@@ -23,7 +23,7 @@ RSpec.describe Flipper::UI::Actions::PercentageOfActorsGate do
       before do
         post "features/search/percentage_of_actors",
           {"value" => "555", "authenticity_token" => "a"},
-          "rack.session" => {:csrf => "a"}
+          "rack.session" => {"_csrf_token" => "a"}
       end
 
       it "does not change value" do

--- a/spec/flipper/ui/actions/percentage_of_time_gate_spec.rb
+++ b/spec/flipper/ui/actions/percentage_of_time_gate_spec.rb
@@ -6,7 +6,7 @@ RSpec.describe Flipper::UI::Actions::PercentageOfTimeGate do
       before do
         post "features/search/percentage_of_time",
           {"value" => "24", "authenticity_token" => "a"},
-          "rack.session" => {:csrf => "a"}
+          "rack.session" => {"_csrf_token" => "a"}
       end
 
       it "enables the feature" do
@@ -23,7 +23,7 @@ RSpec.describe Flipper::UI::Actions::PercentageOfTimeGate do
       before do
         post "features/search/percentage_of_time",
           {"value" => "555", "authenticity_token" => "a"},
-          "rack.session" => {:csrf => "a"}
+          "rack.session" => {"_csrf_token" => "a"}
       end
 
       it "does not change value" do

--- a/spec/flipper/ui_spec.rb
+++ b/spec/flipper/ui_spec.rb
@@ -37,7 +37,7 @@ RSpec.describe Flipper::UI do
   it "can route features with names that match static directories" do
     post "features/refactor-images/actors",
       {"value" => "User:6", "operation" => "enable", "authenticity_token" => "a"},
-      "rack.session" => {:csrf => "a"}
+      "rack.session" => {"_csrf_token" => "a"}
     expect(last_response.status).to be(302)
     expect(last_response.headers["Location"]).to eq("/features/refactor-images")
   end

--- a/test/generators/flipper/active_record_generator_test.rb
+++ b/test/generators/flipper/active_record_generator_test.rb
@@ -1,0 +1,38 @@
+require 'helper'
+require 'active_record'
+require 'rails/generators/test_case'
+require 'generators/flipper/active_record_generator'
+
+class FlipperActiveRecordGeneratorTest < Rails::Generators::TestCase
+  tests Flipper::Generators::ActiveRecordGenerator
+  destination File.expand_path("../../../../tmp", __FILE__)
+  setup :prepare_destination
+
+  def test_generates_migration
+    run_generator
+    assert_migration "db/migrate/create_flipper_tables.rb", <<-EOM
+class CreateFlipperTables < ActiveRecord::Migration
+  def self.up
+    create_table :flipper_features do |t|
+      t.string :key, null: false
+      t.timestamps null: false
+    end
+    add_index :flipper_features, :key, unique: true
+
+    create_table :flipper_gates do |t|
+      t.string :feature_key, null: false
+      t.string :key, null: false
+      t.string :value
+      t.timestamps null: false
+    end
+    add_index :flipper_gates, [:feature_key, :key, :value], unique: true
+  end
+
+  def self.down
+    drop_table :flipper_gates
+    drop_table :flipper_features
+  end
+end
+EOM
+  end
+end

--- a/test/helper.rb
+++ b/test/helper.rb
@@ -1,0 +1,9 @@
+$:.unshift(File.expand_path('../../lib', __FILE__))
+
+require 'rubygems'
+require 'bundler'
+Bundler.setup(:default)
+require 'rails'
+require 'rails/test_help'
+
+ActiveSupport::TestCase.test_order = :random

--- a/test/helper.rb
+++ b/test/helper.rb
@@ -6,4 +6,8 @@ Bundler.setup(:default)
 require 'rails'
 require 'rails/test_help'
 
-ActiveSupport::TestCase.test_order = :random
+begin
+  ActiveSupport::TestCase.test_order = :random
+rescue NoMethodError => boom
+  # no biggie, means we are on older version of AS that doesn't have this option
+end


### PR DESCRIPTION
I initially didn't want to maintain or provide this as I wasn't sure it was a good idea, but I ended up making and using one on a side project so I might as well drop it in core. This is similar to the existing active record adapters, but doesn't use foreign keys or anything rails 4 specific. Should work with rails 3 as well, but I need to get a travis ci matrix going for rails 3 just to be sure.