### PR TITLE
Fix uninitialized constant Flipper::Rails::Generators

### DIFF
--- a/lib/generators/flipper/active_record_generator.rb
+++ b/lib/generators/flipper/active_record_generator.rb
@@ -2,8 +2,8 @@ require "rails/generators/active_record"
 
 module Flipper
   module Generators
-    class ActiveRecordGenerator < Rails::Generators::Base
-      include Rails::Generators::Migration
+    class ActiveRecordGenerator < ::Rails::Generators::Base
+      include ::Rails::Generators::Migration
       desc "Generates migration for flipper tables"
 
       source_paths << File.join(File.dirname(__FILE__), "templates")


### PR DESCRIPTION
Before this fix I was getting `[WARNING] Could not load generator "generators/flipper/active_record_generator". Error: uninitialized constant Flipper::Rails::Generators.` when running the migration alongside a small Rails wrapper I'm writing: https://github.com/bmulholland/flipper-rails