### PR TITLE
Explicitly test that feature remains after adapter clear

### DIFF
--- a/lib/flipper/spec/shared_adapter_specs.rb
+++ b/lib/flipper/spec/shared_adapter_specs.rb
@@ -198,6 +198,9 @@ shared_examples_for 'a flipper adapter' do
 
   it "can clear all the gate values for a feature" do
     actor_22 = actor_class.new('22')
+    subject.add(feature)
+    expect(subject.features).to include(feature.key)
+
     expect(subject.enable(feature, boolean_gate, flipper.boolean)).to eq(true)
     expect(subject.enable(feature, group_gate, flipper.group(:admins))).to eq(true)
     expect(subject.enable(feature, actor_gate, flipper.actor(actor_22))).to eq(true)
@@ -205,7 +208,7 @@ shared_examples_for 'a flipper adapter' do
     expect(subject.enable(feature, time_gate, flipper.time(45))).to eq(true)
 
     expect(subject.clear(feature)).to eq(true)
-
+    expect(subject.features).to include(feature.key)
     expect(subject.get(feature)).to eq({
       :boolean => nil,
       :groups => Set.new,

--- a/spec/flipper/adapters/pstore_spec.rb
+++ b/spec/flipper/adapters/pstore_spec.rb
@@ -5,7 +5,9 @@ require 'flipper/spec/shared_adapter_specs'
 RSpec.describe Flipper::Adapters::PStore do
   subject {
     dir = FlipperRoot.join("tmp").tap { |d| d.mkpath }
-    described_class.new(dir.join("flipper.pstore"))
+    pstore_file = dir.join("flipper.pstore")
+    pstore_file.unlink if pstore_file.exist?
+    described_class.new(pstore_file)
   }
 
   it_should_behave_like 'a flipper adapter'


### PR DESCRIPTION
Fixes #104 by ensuring that any adapter passes this. clear should only remove gates, not the feature itself.