### PR TITLE
Add support for Rack 2.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,5 +10,13 @@ services:
   - redis-server
   - mongodb
 env:
+  - RAILS_VERSION=5.0.0.beta3
   - RAILS_VERSION=4.2.5
   - RAILS_VERSION=3.2.21
+matrix:
+  # don't run rails 5 on ruby versions that can't install rack 2
+  exclude:
+    - rvm: 2.0.0
+      env: RAILS_VERSION=5.0.0.beta3
+    - rvm: 2.1.8
+      env: RAILS_VERSION=5.0.0.beta3

--- a/flipper-ui.gemspec
+++ b/flipper-ui.gemspec
@@ -19,7 +19,7 @@ Gem::Specification.new do |gem|
   gem.require_paths = ["lib"]
   gem.version       = Flipper::VERSION
 
-  gem.add_dependency 'rack', '~> 1.4', '< 1.7'
+  gem.add_dependency 'rack', '>= 1.4', '< 3'
   gem.add_dependency 'rack-protection', '~> 1.5.3'
   gem.add_dependency 'flipper', "~> #{Flipper::VERSION}"
   gem.add_dependency 'erubis', '~> 2.7.0'

--- a/lib/flipper/adapters/active_record.rb
+++ b/lib/flipper/adapters/active_record.rb
@@ -55,7 +55,7 @@ module Flipper
       # Public: Removes a feature from the set of known features.
       def remove(feature)
         @feature_class.transaction do
-          @feature_class.delete_all(key: feature.key)
+          @feature_class.where(key: feature.key).delete_all
           clear(feature)
         end
         true
@@ -63,7 +63,7 @@ module Flipper
 
       # Public: Clears the gate values for a feature.
       def clear(feature)
-        @gate_class.delete_all(feature_key: feature.key)
+        @gate_class.where(feature_key: feature.key).delete_all
         true
       end
 
@@ -141,7 +141,7 @@ module Flipper
             value: thing.value.to_s,
           })
         when :set
-          @gate_class.delete_all(feature_key: feature.key, key: gate.key, value: thing.value)
+          @gate_class.where(feature_key: feature.key, key: gate.key, value: thing.value).delete_all
         else
           unsupported_data_type gate.data_type
         end

--- a/lib/flipper/ui.rb
+++ b/lib/flipper/ui.rb
@@ -1,6 +1,11 @@
 require 'pathname'
 require 'rack'
-require 'rack/methodoverride'
+begin
+  # Rack 2
+  require 'rack/method_override'
+rescue LoadError
+  require 'rack/methodoverride'
+end
 require 'rack/protection'
 
 require 'flipper'

--- a/script/test
+++ b/script/test
@@ -19,3 +19,7 @@ bundle exec rake
 export RAILS_VERSION=4.2.5
 script/bootstrap || bundle update
 bundle exec rake
+
+export RAILS_VERSION=5.0.0.beta3
+script/bootstrap || bundle update
+bundle exec rake


### PR DESCRIPTION
Require for folks trying out Rails 5. I can tweak the build matrix to run the tests against rack `2.0.0.alpha` in the same way that the repository supports Rails 3.2 + 4.2 if we want to go that road.