### PR TITLE
Allow truthy and falsey values to be enough in group match blocks

### DIFF
--- a/lib/flipper/types/group.rb
+++ b/lib/flipper/types/group.rb
@@ -15,7 +15,7 @@ module Flipper
       end
 
       def match?(*args)
-        @block.call(*args) == true
+        @block.call(*args)
       end
     end
   end

--- a/spec/flipper/types/group_spec.rb
+++ b/spec/flipper/types/group_spec.rb
@@ -48,5 +48,19 @@ RSpec.describe Flipper::Types::Group do
     it "returns false if block does not match" do
       expect(subject.match?(non_admin_actor)).to eq(false)
     end
+
+    it "returns true for truthy block results" do
+      group = Flipper::Types::Group.new(:examples) do |actor|
+        actor.email =~ /@example\.com/
+      end
+      expect(group.match?(double('Actor', :email => "foo@example.com"))).to be_truthy
+    end
+
+    it "returns false for falsey block results" do
+      group = Flipper::Types::Group.new(:examples) do |actor|
+        nil
+      end
+      expect(group.match?(double('Actor'))).to be_falsey
+    end
   end
 end

--- a/spec/integration_spec.rb
+++ b/spec/integration_spec.rb
@@ -9,8 +9,8 @@ RSpec.describe Flipper do
 
   let(:actor_class) { Struct.new(:flipper_id) }
 
-  let(:admin_group)  { flipper.group(:admins) }
-  let(:dev_group)    { flipper.group(:devs) }
+  let(:admin_group) { flipper.group(:admins) }
+  let(:dev_group)   { flipper.group(:devs) }
 
   let(:admin_thing) { double 'Non Flipper Thing', :flipper_id => 1,  :admin? => true, :dev? => false }
   let(:dev_thing)   { double 'Non Flipper Thing', :flipper_id => 10, :admin? => false, :dev? => true }

--- a/spec/integration_spec.rb
+++ b/spec/integration_spec.rb
@@ -11,8 +11,6 @@ RSpec.describe Flipper do
 
   let(:admin_group)  { flipper.group(:admins) }
   let(:dev_group)    { flipper.group(:devs) }
-  let(:truthy_group) { flipper.group(:truthy) }
-  let(:falsey_group) { flipper.group(:falsey) }
 
   let(:admin_thing) { double 'Non Flipper Thing', :flipper_id => 1,  :admin? => true, :dev? => false }
   let(:dev_thing)   { double 'Non Flipper Thing', :flipper_id => 10, :admin? => false, :dev? => true }

--- a/spec/integration_spec.rb
+++ b/spec/integration_spec.rb
@@ -9,11 +9,16 @@ RSpec.describe Flipper do
 
   let(:actor_class) { Struct.new(:flipper_id) }
 
-  let(:admin_group) { flipper.group(:admins) }
-  let(:dev_group)   { flipper.group(:devs) }
+  let(:admin_group)  { flipper.group(:admins) }
+  let(:dev_group)    { flipper.group(:devs) }
+  let(:truthy_group) { flipper.group(:truthy) }
+  let(:falsey_group) { flipper.group(:falsey) }
 
   let(:admin_thing) { double 'Non Flipper Thing', :flipper_id => 1,  :admin? => true, :dev? => false }
   let(:dev_thing)   { double 'Non Flipper Thing', :flipper_id => 10, :admin? => false, :dev? => true }
+
+  let(:admin_truthy_thing) { double 'Non Flipper Thing', :flipper_id => 1,  :admin? => "true-ish", :dev? => false }
+  let(:admin_falsey_thing) { double 'Non Flipper Thing', :flipper_id => 1,  :admin? => nil, :dev? => false }
 
   let(:pitt)        { actor_class.new(1) }
   let(:clooney)     { actor_class.new(10) }
@@ -347,12 +352,20 @@ RSpec.describe Flipper do
         expect(feature.enabled?(flipper.actor(admin_thing))).to eq(true)
         expect(feature.enabled?(admin_thing)).to eq(true)
       end
+
+      it "returns true for truthy block values" do
+        expect(feature.enabled?(flipper.actor(admin_truthy_thing))).to eq(true)
+      end
     end
 
     context "for actor in disabled group" do
       it "returns false" do
         expect(feature.enabled?(flipper.actor(dev_thing))).to eq(false)
         expect(feature.enabled?(dev_thing)).to eq(false)
+      end
+
+      it "returns false for falsey block values" do
+        expect(feature.enabled?(flipper.actor(admin_falsey_thing))).to eq(false)
       end
     end
 


### PR DESCRIPTION
## Problem

Ruby general is ok with truthy and falsey values over explicitly true and false. Flipper was different and expected exactly true to be returned by the flipper group match block. 

## Solution

Allow truthy to work. This means that blocks that return truthy values which previously would have returned false will now return true.

Fixes #110