### PR TITLE
Clarify percentage of time/actor functionality being independent in UI

### DIFF
--- a/lib/flipper/ui/assets/stylesheets/application.scss
+++ b/lib/flipper/ui/assets/stylesheets/application.scss
@@ -52,3 +52,7 @@ body {
 .feature-enabled-gates {
   width:380px;
 }
+
+p.help {
+  color: #999;
+}

--- a/lib/flipper/ui/public/css/application.css
+++ b/lib/flipper/ui/public/css/application.css
@@ -2601,3 +2601,6 @@ a.list-group-item-danger {
 
 .feature-enabled-gates {
   width: 380px; }
+
+p.help {
+  color: #999; }

--- a/lib/flipper/ui/views/feature.erb
+++ b/lib/flipper/ui/views/feature.erb
@@ -37,11 +37,6 @@
     <div class="column one-half">
       <div class="panel panel-default">
         <div class="panel-heading">
-          <p class="right">
-            <span class="tooltipped tooltipped-w" aria-label="Percentage of Actors functions independently of Percentage of Time.">
-              <span class="octicon octicon-info"></span>
-            </span>
-          </p>
           <h3 class="panel-title">Percentage of Actors</h3>
         </div>
         <div class="panel-body">
@@ -61,17 +56,13 @@
             <input type="text" name="value" <% if @feature.percentage_of_actors_value > 0 %>value="<%= @feature.percentage_of_actors_value %>"<% end %> placeholder="custom (ie: 26, 32, etc.)" class="input-mini">
             <input type="submit" name="action" value="Enable" class="btn btn-sm">
           </form>
+          <p class="help"><small>Percentage of actors functions independently of percentage of time. If you enable 50% of Actors and 25% of Time then the feature will always be enabled for 50% of users and occasionally enabled 25% of the time for everyone.</small></p>
         </div>
       </div>
     </div>
     <div class="column one-half">
       <div class="panel panel-default">
         <div class="panel-heading">
-          <p class="right">
-            <span class="tooltipped tooltipped-w" aria-label="Percentage of Time functions independently of Percentage of Actor.">
-              <span class="octicon octicon-info"></span>
-            </span>
-          </p>
           <h3 class="panel-title">Percentage of Time</h3>
         </div>
         <div class="panel-body">
@@ -91,6 +82,8 @@
             <input type="text" name="value" <% if @feature.percentage_of_time_value > 0 %>value="<%= @feature.percentage_of_time_value %>"<% end %> placeholder="custom (ie: 26, 32, etc.)" class="input-mini">
             <input type="submit" name="action" value="Enable" class="btn btn-sm">
           </form>
+
+          <p class="help"><small>Percentage of time functions independently of percentage of actors. If you enable 50% of Actors and 25% of Time then the feature will always be enabled for 50% of users and occasionally enabled 25% of the time for everyone.</small></p>
         </div>
       </div>
     </div>

--- a/lib/flipper/ui/views/feature.erb
+++ b/lib/flipper/ui/views/feature.erb
@@ -37,6 +37,11 @@
     <div class="column one-half">
       <div class="panel panel-default">
         <div class="panel-heading">
+          <p class="right">
+            <span class="tooltipped tooltipped-w" aria-label="Percentage of Actors functions independently of Percentage of Time.">
+              <span class="octicon octicon-info"></span>
+            </span>
+          </p>
           <h3 class="panel-title">Percentage of Actors</h3>
         </div>
         <div class="panel-body">
@@ -62,6 +67,11 @@
     <div class="column one-half">
       <div class="panel panel-default">
         <div class="panel-heading">
+          <p class="right">
+            <span class="tooltipped tooltipped-w" aria-label="Percentage of Time functions independently of Percentage of Actor.">
+              <span class="octicon octicon-info"></span>
+            </span>
+          </p>
           <h3 class="panel-title">Percentage of Time</h3>
         </div>
         <div class="panel-body">


### PR DESCRIPTION
## Problem

Sometimes people get confused and think that percentage of actors and time work in tandem. They don't. They work completely independently of each other.

## Solution

A small help note below them to explain the difference. I don't love repeating basically the same text in two spots, but I tried a few things and went with this. Open to better ideas if anyone has any.

![screen shot 2016-03-18 at 4 36 14 pm](https://cloud.githubusercontent.com/assets/235/13891508/e7cefb6a-ed27-11e5-81ef-56786e4bc0c3.png)

## Alternatives

The original suggestion took too much focus from the actual form controls.

![screen shot 2016-03-18 at 4 27 54 pm](https://cloud.githubusercontent.com/assets/235/13891520/f67abd02-ed27-11e5-8ccb-72ee7f21d039.png)

I also tried a tooltip, but it felt too hidden and didn't allow for much text. 

![screen shot 2016-03-18 at 4 25 50 pm](https://cloud.githubusercontent.com/assets/235/13891524/fbdc5a12-ed27-11e5-9b0e-76c2a4b388a9.png)

cc @olivierlacan for thoughts as he brought it up here https://github.com/jnunemaker/flipper/issues/103