### PR TITLE
Remove instrumentation for gate operations

### DIFF
--- a/lib/flipper/feature.rb
+++ b/lib/flipper/feature.rb
@@ -9,9 +9,6 @@ module Flipper
     # Private: The name of feature instrumentation events.
     InstrumentationName = "feature_operation.#{InstrumentationNamespace}"
 
-    # Private: The name of gate instrumentation events.
-    GateInstrumentationName = "gate_operation.#{InstrumentationNamespace}"
-
     # Public: The name of the feature.
     attr_reader :name
 
@@ -85,9 +82,7 @@ module Flipper
         payload[:thing] = gate(:actor).wrap(thing) unless thing.nil?
 
         open_gate = gates.detect { |gate|
-          instrument_gate(gate, :open?, thing) { |gate_payload|
-            gate.open?(thing, values[gate.key], feature_name: @name)
-          }
+          gate.open?(thing, values[gate.key], feature_name: @name)
         }
 
         if open_gate.nil?
@@ -353,20 +348,6 @@ module Flipper
       @instrumenter.instrument(InstrumentationName) { |payload|
         payload[:feature_name] = name
         payload[:operation] = operation
-        payload[:result] = yield(payload) if block_given?
-      }
-    end
-
-    # Private: Intrument a gate operation.
-    def instrument_gate(gate, operation, thing)
-      payload = {
-        :feature_name => @name,
-        :gate_name => gate.name,
-        :operation => operation,
-        :thing => thing,
-      }
-
-      @instrumenter.instrument(GateInstrumentationName, payload) { |payload|
         payload[:result] = yield(payload) if block_given?
       }
     end

--- a/lib/flipper/instrumentation/log_subscriber.rb
+++ b/lib/flipper/instrumentation/log_subscriber.rb
@@ -65,34 +65,6 @@ module Flipper
         debug "  #{color(name, CYAN, true)}  [ #{details} ]"
       end
 
-      # Logs a gate operation.
-      #
-      # Example Output
-      #
-      #   flipper[:search].enabled?(user)
-      #   # Flipper feature(search) gate(boolean) open false (0.1ms)  [ thing=... ]
-      #   # Flipper feature(search) gate(group) open false (0.1ms)  [ thing=... ]
-      #   # Flipper feature(search) gate(actor) open false (0.1ms)  [ thing=... ]
-      #   # Flipper feature(search) gate(percentage_of_actors) open false (0.1ms)  [ thing=... ]
-      #   # Flipper feature(search) gate(percentage_of_time) open false (0.1ms)  [ thing=... ]
-      #
-      # Returns nothing.
-      def gate_operation(event)
-        return unless logger.debug?
-
-        feature_name = event.payload[:feature_name]
-        gate_name = event.payload[:gate_name]
-        operation = event.payload[:operation]
-        result = event.payload[:result]
-        thing = event.payload[:thing]
-
-        description = "Flipper feature(#{feature_name}) gate(#{gate_name}) #{operation} #{result.inspect}"
-        details = "thing=#{thing.inspect}"
-
-        name = '%s (%.1fms)' % [description, event.duration]
-        debug "  #{color(name, CYAN, true)}  [ #{details} ]"
-      end
-
       def logger
         self.class.logger
       end

--- a/lib/flipper/instrumentation/subscriber.rb
+++ b/lib/flipper/instrumentation/subscriber.rb
@@ -72,28 +72,6 @@ module Flipper
       end
 
       # Private
-      def update_gate_operation_metrics
-        feature_name = @payload[:feature_name]
-        gate_name = @payload[:gate_name]
-        operation = strip_trailing_question_mark(@payload[:operation])
-        result = @payload[:result]
-        thing = @payload[:thing]
-
-        update_timer "flipper.gate_operation.#{gate_name}.#{operation}"
-        update_timer "flipper.feature.#{feature_name}.gate_operation.#{gate_name}.#{operation}"
-
-        if @payload[:operation] == :open?
-          metric_name = if result
-            "flipper.feature.#{feature_name}.gate.#{gate_name}.open"
-          else
-            "flipper.feature.#{feature_name}.gate.#{gate_name}.closed"
-          end
-
-          update_counter metric_name
-        end
-      end
-
-      # Private
       def strip_trailing_question_mark(operation)
         operation.to_s.chomp('?')
       end

--- a/spec/flipper/instrumentation/log_subscriber_spec.rb
+++ b/spec/flipper/instrumentation/log_subscriber_spec.rb
@@ -42,11 +42,6 @@ RSpec.describe Flipper::Instrumentation::LogSubscriber do
       expect(adapter_line).to include('[ result={')
       expect(adapter_line).to include('} ]')
     end
-
-    it "logs gate calls" do
-      gate_line = find_line('Flipper feature(search) gate(boolean) open? false')
-      expect(gate_line).to include('[ thing=nil ]')
-    end
   end
 
   context "feature enabled checks with a thing" do
@@ -60,11 +55,6 @@ RSpec.describe Flipper::Instrumentation::LogSubscriber do
     it "logs thing for feature" do
       feature_line = find_line('Flipper feature(search) enabled?')
       expect(feature_line).to include(user.inspect)
-    end
-
-    it "logs thing for gate" do
-      gate_line = find_line('Flipper feature(search) gate(boolean) open')
-      expect(gate_line).to include(user.inspect)
     end
   end
 

--- a/spec/flipper/instrumentation/metriks_subscriber_spec.rb
+++ b/spec/flipper/instrumentation/metriks_subscriber_spec.rb
@@ -46,14 +46,4 @@ RSpec.describe Flipper::Instrumentation::MetriksSubscriber do
     flipper[:stats].disable(user)
     expect(Metriks.timer("flipper.adapter.memory.disable").count).to be(1)
   end
-
-  it "updates gate metrics when calls happen" do
-    flipper[:stats].enable(user)
-    flipper[:stats].enabled?(user)
-
-    expect(Metriks.timer("flipper.gate_operation.boolean.open").count).to be(1)
-    expect(Metriks.timer("flipper.feature.stats.gate_operation.boolean.open").count).to be(1)
-    expect(Metriks.meter("flipper.feature.stats.gate.actor.open").count).to be(1)
-    expect(Metriks.meter("flipper.feature.stats.gate.boolean.closed").count).to be(1)
-  end
 end

--- a/spec/flipper/instrumentation/statsd_subscriber_spec.rb
+++ b/spec/flipper/instrumentation/statsd_subscriber_spec.rb
@@ -65,14 +65,4 @@ RSpec.describe Flipper::Instrumentation::StatsdSubscriber do
     flipper[:stats].disable(user)
     assert_timer 'flipper.adapter.memory.disable'
   end
-
-  it "updates gate metrics when calls happen" do
-    flipper[:stats].enable(user)
-    flipper[:stats].enabled?(user)
-
-    assert_timer 'flipper.gate_operation.boolean.open'
-    assert_timer 'flipper.feature.stats.gate_operation.boolean.open'
-    assert_counter 'flipper.feature.stats.gate.actor.open'
-    assert_counter 'flipper.feature.stats.gate.boolean.closed'
-  end
 end


### PR DESCRIPTION
Feature operations is what I’ve found most useful. I haven’t actually looked at gate operation metrics ever and they add N + 1 instrument calls (which aren’t free) where N is the number of gates. If we really do need this, let me know. Perhaps we can just tack information on the feature operation instrumentation (trade bigger payload for fewer instrument calls). 