### PR TITLE
Api /feature endpoint

### DIFF
--- a/lib/flipper/api/action.rb
+++ b/lib/flipper/api/action.rb
@@ -99,9 +99,17 @@ module Flipper
         @headers[name] = value
       end
 
+      private
+
       # Private: Returns the request method converted to an action method.
       def request_method_name
         @request_method_name ||= @request.request_method.downcase
+      end
+
+      # Private: split request path by "/"
+      # Example: "api/v1/features/feature_name" => ['api', 'v1', 'features', 'feature_name']
+      def path_parts
+        @request.path.split("/")
       end
     end
   end

--- a/lib/flipper/api/middleware.rb
+++ b/lib/flipper/api/middleware.rb
@@ -36,6 +36,7 @@ module Flipper
 
         @action_collection = ActionCollection.new
         @action_collection.add Api::V1::Actions::BooleanGate
+        @action_collection.add Api::V1::Actions::Feature
       end
 
       def flipper

--- a/lib/flipper/api/v1/actions/boolean_gate.rb
+++ b/lib/flipper/api/v1/actions/boolean_gate.rb
@@ -14,12 +14,6 @@ module Flipper
             feature.send(action)
             json_response({}, 204)
           end
-
-          private
-
-          def path_parts
-            request.path.split("/")
-          end
         end
       end
     end

--- a/lib/flipper/api/v1/actions/feature.rb
+++ b/lib/flipper/api/v1/actions/feature.rb
@@ -1,0 +1,40 @@
+require 'flipper/api/action'
+require 'flipper/api/v1/decorators/feature'
+
+module Flipper
+  module Api
+    module V1
+      module Actions
+        class Feature < Api::Action
+
+          route %r{api/v1/features/[^/]*/?\Z}
+
+          def get
+            if feature_names.include?(feature_name)
+              feature = Decorators::Feature.new(flipper[feature_name])
+              json_response(feature.as_json)
+            else
+              json_response({}, 404)
+            end
+          end
+
+          def delete
+            feature = flipper[feature_name]
+            flipper.adapter.remove(feature)
+            json_response({}, 204)
+          end
+
+          private
+          
+          def feature_name
+            @feature_name ||= Rack::Utils.unescape(path_parts.last)
+          end
+
+          def feature_names
+            @feature_names ||= flipper.adapter.features
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/flipper/api/v1/decorators/feature.rb
+++ b/lib/flipper/api/v1/decorators/feature.rb
@@ -1,0 +1,33 @@
+require 'delegate'
+require 'flipper/api/v1/decorators/gate'
+
+module Flipper
+  module Api
+    module V1
+      module Decorators
+        class Feature < SimpleDelegator
+
+          # Public: The feature being decorated.
+          alias_method :feature, :__getobj__
+          
+          # Public: Returns instance as hash that is ready to be json dumped.
+          def as_json
+            {
+              'id' => name.to_s,
+              'state' => state.to_s,
+              'gates' => gates.map { |gate|
+                Decorators::Gate.new(gate, gate_values[gate.key]).as_json
+              }
+            }
+          end
+
+          private
+
+          def gate_values
+            feature.gate_values
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/flipper/api/v1/decorators/gate.rb
+++ b/lib/flipper/api/v1/decorators/gate.rb
@@ -1,0 +1,35 @@
+module Flipper
+  module Api
+    module V1
+      module Decorators
+        class Gate < SimpleDelegator
+          # Public the gate being decorated
+          alias_method :gate, :__getobj__
+
+          # Public: the value for the gate from the adapter.
+          attr_reader :value
+
+          def initialize(gate, value = nil)
+            super gate
+            @value = value
+          end
+
+          def as_json
+            {
+              'key' => gate.key.to_s,
+              'name' => gate.name.to_s,
+              'value' => value_as_json
+            }
+          end
+
+          private
+
+          # json doesn't like sets
+          def value_as_json
+            data_type == :set ? value.to_a : value
+          end
+        end
+      end
+    end
+  end
+end

--- a/spec/flipper/api/v1/actions/feature_spec.rb
+++ b/spec/flipper/api/v1/actions/feature_spec.rb
@@ -1,0 +1,120 @@
+require 'helper'
+
+RSpec.describe Flipper::Api::V1::Actions::Feature do
+  let(:app) { build_api(flipper) }
+  let(:feature) { build_feature }
+  let(:gate) { feature.gate(:boolean) }
+
+  describe 'get' do
+    context 'enabled feature' do
+
+      before do
+        flipper[:my_feature].enable
+        get 'api/v1/features/my_feature'
+      end
+
+      it 'responds with correct attributes' do
+        response_body = {
+          'id' => 'my_feature',
+          'state' => 'on',
+          'gates' => [
+            {
+              'key' => 'boolean',
+              'name' => 'boolean',
+              'value' => true
+            },
+            {
+              'key' => 'groups',
+              'name' => 'group',
+              'value' =>[]
+            },
+            {
+              'key' => 'actors',
+              'name' => 'actor',
+              'value' => []
+            },
+            {
+              'key' => 'percentage_of_actors',
+              'name' => 'percentage_of_actors',
+              'value' => 0
+            },
+            {
+              'key' => 'percentage_of_time',
+              'name' => 'percentage_of_time',
+              'value' => 0
+            }
+          ]
+        }
+
+        expect(last_response.status).to eq(200)
+        expect(json_response).to eq(response_body)
+      end
+    end
+
+    context 'disabled feature' do
+      before do
+        flipper[:my_feature].disable
+        get 'api/v1/features/my_feature'
+      end
+
+      it 'responds with correct attributes' do
+        response_body = {
+          'id' => 'my_feature',
+          'state' => 'off',
+          'gates' => [
+            {
+              'key' => 'boolean',
+              'name' => 'boolean',
+              'value' => false
+            },
+            {
+              'key'=> 'groups',
+              'name'=> 'group',
+              'value'=>[]
+            },
+            {
+              'key' => 'actors',
+              'name' => 'actor',
+              'value' => []
+            },
+            {
+              'key' => 'percentage_of_actors',
+              'name' => 'percentage_of_actors',
+              'value'=>0
+            },
+            {
+              'key' => 'percentage_of_time',
+              'name' => 'percentage_of_time',
+              'value' => 0
+            }
+          ]
+        }
+
+        expect(last_response.status).to eq(200)
+        expect(json_response).to eq(response_body)
+      end
+    end
+
+    context 'feature does not exist' do
+      before do
+        get 'api/v1/features/not_a_feature'
+      end
+
+      it 'returns 404' do
+        expect(last_response.status).to eq(404)
+      end
+    end
+  end
+
+  describe 'delete' do
+    before do
+      flipper[:my_feature].enable
+      delete 'api/v1/features/my_feature'
+    end
+
+    it 'deletes feature' do
+      expect(last_response.status).to eq(204)
+      expect(flipper.features.map(&:key)).not_to include('my_feature')
+    end
+  end
+end


### PR DESCRIPTION
Add /feature endpoint

adds:
GET, DELETE actions
* Feature Decorator
* Gate Decorator
* specs



---------------------------------------------------------------------------------------------------------------------
Have two questions (answered - thank you):

1. lib/flipper/gate.rb:17
states that ```key``` is a private method.  Should json from ```get``` only return name and value, and omit key?

2. I want to return a 404 if a get request fails to find a feature, however flipper/dsl defines a public function ```[]``` and aliases it to ```#feature```  which creates an new feature if it doesn't already exist.  What do you think about changing this functionality so that the ```feature``` still creates a new feature, but ```[]``` will return nil if no feature exists for a given key?  I know this is public so we might not want to do that.  We could also add a module like Flipper:Api::Dsl and monkey-patch it, but this is bit messy.  Really curious of your thoughts, thanks!