### PR TITLE
Allow changing of actor or percentage gates in active_record adapter

### DIFF
--- a/lib/flipper/adapters/active_record.rb
+++ b/lib/flipper/adapters/active_record.rb
@@ -105,11 +105,11 @@ module Flipper
       def enable(feature, gate, thing)
         case gate.data_type
         when :boolean, :integer
-          @gate_class.create!({
+          @gate_class.where(
             feature_key: feature.key,
-            key: gate.key,
-            value: thing.value.to_s,
-          })
+            key: gate.key).first_or_initialize.
+	    update_attributes!(
+            value: thing.value.to_s)
         when :set
           @gate_class.create!({
             feature_key: feature.key,

--- a/lib/flipper/spec/shared_adapter_specs.rb
+++ b/lib/flipper/spec/shared_adapter_specs.rb
@@ -116,6 +116,10 @@ shared_examples_for 'a flipper adapter' do
     result = subject.get(feature)
     expect(result[:percentage_of_actors]).to eq('15')
 
+    expect(subject.enable(feature, actors_gate, flipper.actors(25))).to eq(true)
+    result = subject.get(feature)
+    expect(result[:percentage_of_actors]).to eq('25')
+
     expect(subject.disable(feature, actors_gate, flipper.actors(0))).to eq(true)
     result = subject.get(feature)
     expect(result[:percentage_of_actors]).to eq('0')


### PR DESCRIPTION
Choosing a second (or additional) percentage creates an additional row in the feature_gates table.  The one that is used is arbitrary, typically the first one created.

Additionally, if a user chooses a percentage for a feature that was previously chosen, this will create an exception.

The fix should work in rails 3.2 and 4.x.