### PR TITLE
make add feature button optional

### DIFF
--- a/lib/flipper/ui.rb
+++ b/lib/flipper/ui.rb
@@ -21,6 +21,8 @@ module Flipper
       # says "App" which points to this href. The href can be a path (ie: "/")
       # or full url ("https://app.example.com/").
       attr_accessor :application_breadcrumb_href
+      #Public: If set, then the add_feature button will be removed
+      attr_accessor :remove_add_feature_button
     end
 
     def self.root

--- a/lib/flipper/ui/views/layout.erb
+++ b/lib/flipper/ui/views/layout.erb
@@ -17,7 +17,9 @@
   </head>
   <body>
     <div class="container header">
-      <a class="btn btn-sm right" href="<%= script_name %>/features/new">Add Feature</a>
+      <% unless Flipper::UI.remove_add_feature_button %>
+        <a class="btn btn-sm right" href="<%= script_name %>/features/new">Add Feature</a>
+      <% end %>
 
       <ol class="breadcrumb">
         <% @breadcrumbs.each do |breadcrumb| %>

--- a/spec/flipper/ui_spec.rb
+++ b/spec/flipper/ui_spec.rb
@@ -93,4 +93,41 @@ RSpec.describe Flipper::UI do
       expect(last_response.body).to include('<a href="https://myapp.com/">App</a>')
     end
   end
+
+  it "should not have remove_add_feature_button by default" do
+    expect(Flipper::UI.remove_add_feature_button).to be(nil)
+  end
+
+  context "without remove_add_feature_button" do
+    before do
+      @original_remove_add_feature_button = Flipper::UI.remove_add_feature_button
+      Flipper::UI.remove_add_feature_button = nil
+    end
+
+    it 'has the add_feature button' do
+      get '/features'
+      expect(last_response.body).to include('Add Feature')
+    end
+
+    after do
+      Flipper::UI.remove_add_feature_button = @original_remove_add_feature_button
+    end
+  end
+
+  context "with remove_add_feature_button" do
+    before do
+      @original_remove_add_feature_button = Flipper::UI.remove_add_feature_button
+      Flipper::UI.remove_add_feature_button = true
+    end
+
+    it 'does not have the add_feature button' do
+      get '/features'
+      expect(last_response.body).to_not include('Add Feature')
+    end
+
+    after do
+      Flipper::UI.remove_add_feature_button = @original_remove_add_feature_button
+    end
+  end
+
 end


### PR DESCRIPTION
For our project, we wanted to remove the Add Feature button from the UI.  We made it configurable in case others wanted to do remove it as well.

The code is similar to `application_breadcrumb_href`.  The button can be removed by:
`Flipper::UI.remove_add_feature_button = true`