### PR TITLE
Disallow multiple gate values for integer values in AR adapter

### DIFF
--- a/lib/flipper/adapters/active_record.rb
+++ b/lib/flipper/adapters/active_record.rb
@@ -105,11 +105,18 @@ module Flipper
       def enable(feature, gate, thing)
         case gate.data_type
         when :boolean, :integer
-          @gate_class.where(
-            feature_key: feature.key,
-            key: gate.key).first_or_initialize.
-	    update_attributes!(
-            value: thing.value.to_s)
+          @gate_class.transaction do
+            @gate_class.where(
+              feature_key: feature.key,
+              key: gate.key
+            ).delete_all
+
+            @gate_class.create!({
+              feature_key: feature.key,
+              key: gate.key,
+              value: thing.value.to_s,
+            })
+          end
         when :set
           @gate_class.create!({
             feature_key: feature.key,
@@ -135,11 +142,18 @@ module Flipper
         when :boolean
           clear(feature)
         when :integer
-          @gate_class.create!({
-            feature_key: feature.key,
-            key: gate.key,
-            value: thing.value.to_s,
-          })
+          @gate_class.transaction do
+            @gate_class.where(
+              feature_key: feature.key,
+              key: gate.key
+            ).delete_all
+
+            @gate_class.create!({
+              feature_key: feature.key,
+              key: gate.key,
+              value: thing.value.to_s,
+            })
+          end
         when :set
           @gate_class.where(feature_key: feature.key, key: gate.key, value: thing.value).delete_all
         else

--- a/lib/flipper/spec/shared_adapter_specs.rb
+++ b/lib/flipper/spec/shared_adapter_specs.rb
@@ -116,13 +116,25 @@ shared_examples_for 'a flipper adapter' do
     result = subject.get(feature)
     expect(result[:percentage_of_actors]).to eq('15')
 
-    expect(subject.enable(feature, actors_gate, flipper.actors(25))).to eq(true)
-    result = subject.get(feature)
-    expect(result[:percentage_of_actors]).to eq('25')
-
     expect(subject.disable(feature, actors_gate, flipper.actors(0))).to eq(true)
     result = subject.get(feature)
     expect(result[:percentage_of_actors]).to eq('0')
+  end
+
+  it "can enable percentage of actors gate many times and consistently return values" do
+    (1..100).each do |percentage|
+      expect(subject.enable(feature, actors_gate, flipper.actors(percentage))).to eq(true)
+      result = subject.get(feature)
+      expect(result[:percentage_of_actors]).to eq(percentage.to_s)
+    end
+  end
+
+  it "can disable percentage of actors gate many times and consistently return values" do
+    (1..100).each do |percentage|
+      expect(subject.disable(feature, actors_gate, flipper.actors(percentage))).to eq(true)
+      result = subject.get(feature)
+      expect(result[:percentage_of_actors]).to eq(percentage.to_s)
+    end
   end
 
   it "can enable, disable and get value for percentage of time gate" do
@@ -133,6 +145,22 @@ shared_examples_for 'a flipper adapter' do
     expect(subject.disable(feature, time_gate, flipper.time(0))).to eq(true)
     result = subject.get(feature)
     expect(result[:percentage_of_time]).to eq('0')
+  end
+
+  it "can enable percentage of time gate many times and consistently return values" do
+    (1..100).each do |percentage|
+      expect(subject.enable(feature, time_gate, flipper.time(percentage))).to eq(true)
+      result = subject.get(feature)
+      expect(result[:percentage_of_time]).to eq(percentage.to_s)
+    end
+  end
+
+  it "can disable percentage of time gate many times and consistently return values" do
+    (1..100).each do |percentage|
+      expect(subject.disable(feature, time_gate, flipper.time(percentage))).to eq(true)
+      result = subject.get(feature)
+      expect(result[:percentage_of_time]).to eq(percentage.to_s)
+    end
   end
 
   it "converts boolean value to a string" do


### PR DESCRIPTION
refs #122. This takes a bit different approach and also fixes the issue for disable. Instead of first or initialize by which could race we use a transaction to delete all and create. Instead of still possibly ending up with dups this approach should mean we just let last write win. I think…