### PR TITLE
Add Rake::TestTask

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -1,5 +1,6 @@
 #!/usr/bin/env rake
 $LOAD_PATH.push File.expand_path("../lib", __FILE__)
+require 'rake/testtask'
 require "flipper/version"
 
 # gem install pkg/*.gem
@@ -35,10 +36,9 @@ namespace :spec do
   end
 end
 
-task :default => :spec
-
-task :test do
-  sh "bundle exec ruby -Itest test/generators/flipper/active_record_generator_test.rb"
+Rake::TestTask.new do |t|
+  t.libs = ['lib', 'test']
+  t.pattern = "test/**/*_test.rb"
 end
 
-task :default => :test
+task :default => [:spec, :test]

--- a/test/helper.rb
+++ b/test/helper.rb
@@ -1,5 +1,3 @@
-$:.unshift(File.expand_path('../../lib', __FILE__))
-
 require 'rubygems'
 require 'bundler'
 Bundler.setup(:default)


### PR DESCRIPTION
First step towards #55 

*Run Mintests with `rake test`
*Run Rspecs with `rake spec`
*Run all specs with `rake`
Makes it really easy to add files to the LOAD_PATH before running specs and no longer have to execute shell commands to run minitests.  We can put the minitest shared_example type tests under `/test`
http://docs.ruby-lang.org/en/2.1.0/Rake/TestTask.html

