### PR TITLE
add #remove method to the Feature class

### DIFF
--- a/lib/flipper/api/v1/actions/feature.rb
+++ b/lib/flipper/api/v1/actions/feature.rb
@@ -20,7 +20,7 @@ module Flipper
 
           def delete
             feature = flipper[feature_name]
-            flipper.adapter.remove(feature)
+            feature.remove
             json_response({}, 204)
           end
 

--- a/lib/flipper/api/v1/actions/feature.rb
+++ b/lib/flipper/api/v1/actions/feature.rb
@@ -19,13 +19,17 @@ module Flipper
           end
 
           def delete
-            feature = flipper[feature_name]
-            feature.remove
-            json_response({}, 204)
+            if feature_names.include?(feature_name)
+              flipper.remove(feature_name)
+
+              json_response({}, 204)
+            else
+              json_response({}, 404)
+            end
           end
 
           private
-          
+
           def feature_name
             @feature_name ||= Rack::Utils.unescape(path_parts.last)
           end

--- a/lib/flipper/dsl.rb
+++ b/lib/flipper/dsl.rb
@@ -145,6 +145,15 @@ module Flipper
       feature(name).disable_percentage_of_actors
     end
 
+    # Public: Remove a feature.
+    #
+    # name - The String or Symbol name of the feature.
+    #
+    # Returns result of remove.
+    def remove(name)
+      feature(name).remove
+    end
+
     # Public: Access a feature instance by name.
     #
     # name - The String or Symbol name of the feature.

--- a/lib/flipper/feature.rb
+++ b/lib/flipper/feature.rb
@@ -72,6 +72,13 @@ module Flipper
       }
     end
 
+    # Public: Removes this feature.
+    #
+    # Returns the result of Adapter#remove.
+    def remove
+      instrument(:remove) { adapter.remove(self) }
+    end
+
     # Public: Check if a feature is enabled for a thing.
     #
     # Returns true if enabled, false if not.

--- a/spec/flipper/dsl_spec.rb
+++ b/spec/flipper/dsl_spec.rb
@@ -235,4 +235,14 @@ RSpec.describe Flipper::DSL do
       expect(subject[:stats].percentage_of_actors_value).to be(0)
     end
   end
+
+  describe '#remove' do
+    it "removes the feature" do
+      subject.enable(:stats)
+
+      expect { subject.remove(:stats) }.to change { subject.enabled?(:stats) }.to(false)
+
+      expect(subject.features).to be_empty
+    end
+  end
 end

--- a/spec/flipper/feature_spec.rb
+++ b/spec/flipper/feature_spec.rb
@@ -197,6 +197,17 @@ RSpec.describe Flipper::Feature do
       expect(event.payload[:thing]).to eq(Flipper::Types::Actor.new(thing))
     end
 
+    it "is recorded for remove" do
+      subject.remove
+
+      event = instrumenter.events.last
+      expect(event).not_to be_nil
+      expect(event.name).to eq('feature_operation.flipper')
+      expect(event.payload[:feature_name]).to eq(:search)
+      expect(event.payload[:operation]).to eq(:remove)
+      expect(event.payload[:result]).not_to be_nil
+    end
+
     it "is recorded for enabled?" do
       thing = Flipper::Types::Actor.new(Struct.new(:flipper_id).new("1"))
       gate = subject.gate_for(thing)


### PR DESCRIPTION
I thought it might make sense for it to be available on the feature level:

```rb
flipper[:feature].remove
```