### PR TITLE
Add shared mini test doc to Adapters docs

### DIFF
--- a/docs/Adapters.md
+++ b/docs/Adapters.md
@@ -29,9 +29,12 @@ The basic API for an adapter is this:
 * `enable(feature, gate, thing)` - Enable a gate for a thing.
 * `disable(feature, gate, thing)` - Disable a gate for a thing.
 
-If you would like to make your own adapter, there are shared adapter specs that you can use to verify that you have everything working correctly.
+If you would like to make your own adapter, there are shared adapter specs (RSpec) and tests (MiniTest) that you can use to verify that you have everything working correctly.
 
+### RSpec
 For example, here is what the in-memory adapter spec looks like:
+
+`spec/flipper/adapters/memory_spec.rb`
 
 ```ruby
 require 'helper'
@@ -50,6 +53,37 @@ describe Flipper::Adapters::Memory do
   it_should_behave_like 'a flipper adapter'
 end
 ```
+
+### MiniTest
+
+Here is what an in-memory adapter MiniTest looks like:
+
+`test/adapters/memory_test.rb`
+
+```ruby
+require 'test_helper'
+require 'flipper/adapters/memory'
+
+class MemoryTest < MiniTest::Test
+  prepend SharedAdapterTests
+
+  def setup
+    # Any code here will run before each test
+    @adapter = Flipper::Adapters::Memory.new
+  end
+
+  def teardown
+    # Any code here will run after each test
+  end
+end
+```
+1. Create a file under `test/adapters` that inherits from MiniTest::Test.
+
+2. `prepend SharedAdapterTests`.
+
+3. Initialize an instance variable `@adapter` referencing an instance of the adapter.
+
+4. Add any code to run before each test in a `setup` method and any code to run after each test in a `teardown` method.
 
 A good place to start when creating your own adapter is to copy one of the adapters mentioned above and replace the client specific code with whatever client you are attempting to adapt.
 


### PR DESCRIPTION
Adds documentation for shared MiniTests


<img width="687" alt="screen shot 2016-06-21 at 9 34 05 am" src="https://cloud.githubusercontent.com/assets/3260042/16231236/5e0b08fe-3793-11e6-9663-9503ae2d2132.png">
