### PR TITLE
Instrumentation Tweaks

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -1,6 +1,8 @@
 ## master
 
 * Moves SharedAdapterTests module to Flipper::Test::SharedAdapterTests to avoid clobbering anything top level in apps that use Flipper
+* Memoizable, Instrumented and OperationLogger now delegate any missing methods to the original adapter. This was lost with the removal of the official decorator in 0.8, but is actually useful functionality for these "wrapping" adapters.
+* Instrumenting adapters is now off by default. Use Flipper::Adapters::Instrumented.new(adapter) to instrument adapters and maintain the old functionality.
 
 ## 0.8
 

--- a/lib/flipper/adapters/instrumented.rb
+++ b/lib/flipper/adapters/instrumented.rb
@@ -1,10 +1,11 @@
+require 'delegate'
 require 'flipper/instrumenters/noop'
 
 module Flipper
   module Adapters
     # Internal: Adapter that wraps another adapter and instruments all adapter
     # operations. Used by flipper dsl to provide instrumentatin for flipper.
-    class Instrumented
+    class Instrumented < SimpleDelegator
       include ::Flipper::Adapter
 
       # Private: The name of instrumentation events.
@@ -24,6 +25,7 @@ module Flipper
       #           :instrumenter - What to use to instrument all the things.
       #
       def initialize(adapter, options = {})
+        super(adapter)
         @adapter = adapter
         @name = :instrumented
         @instrumenter = options.fetch(:instrumenter, Instrumenters::Noop)

--- a/lib/flipper/adapters/memoizable.rb
+++ b/lib/flipper/adapters/memoizable.rb
@@ -1,9 +1,11 @@
+require 'delegate'
+
 module Flipper
   module Adapters
     # Internal: Adapter that wraps another adapter with the ability to memoize
     # adapter calls in memory. Used by flipper dsl and the memoizer middleware
     # to make it possible to memoize adapter calls for the duration of a request.
-    class Memoizable
+    class Memoizable < SimpleDelegator
       include ::Flipper::Adapter
 
       FeaturesKey = :flipper_features
@@ -19,6 +21,7 @@ module Flipper
 
       # Public
       def initialize(adapter, cache = nil)
+        super(adapter)
         @adapter = adapter
         @name = :memoizable
         @cache = cache || {}

--- a/lib/flipper/adapters/operation_logger.rb
+++ b/lib/flipper/adapters/operation_logger.rb
@@ -1,9 +1,11 @@
+require 'delegate'
+
 module Flipper
   module Adapters
     # Public: Adapter that wraps another adapter and stores the operations.
     #
     # Useful in tests to verify calls and such. Never use outside of testing.
-    class OperationLogger
+    class OperationLogger < SimpleDelegator
       include ::Flipper::Adapter
 
       Operation = Struct.new(:type, :args)
@@ -26,6 +28,7 @@ module Flipper
 
       # Public
       def initialize(adapter, operations = nil)
+        super(adapter)
         @adapter = adapter
         @name = :operation_logger
         @operations = operations || []

--- a/lib/flipper/dsl.rb
+++ b/lib/flipper/dsl.rb
@@ -1,4 +1,3 @@
-require 'flipper/adapters/instrumented'
 require 'flipper/adapters/memoizable'
 require 'flipper/instrumenters/noop'
 
@@ -17,13 +16,8 @@ module Flipper
     #           :instrumenter - What should be used to instrument all the things.
     def initialize(adapter, options = {})
       @instrumenter = options.fetch(:instrumenter, Instrumenters::Noop)
-
-      instrumented = Adapters::Instrumented.new(adapter, {
-        :instrumenter => @instrumenter,
-      })
-      memoized = Adapters::Memoizable.new(instrumented)
+      memoized = Adapters::Memoizable.new(adapter)
       @adapter = memoized
-
       @memoized_features = {}
     end
 

--- a/lib/flipper/feature.rb
+++ b/lib/flipper/feature.rb
@@ -7,7 +7,7 @@ require 'flipper/instrumenters/noop'
 module Flipper
   class Feature
     # Private: The name of feature instrumentation events.
-    InstrumentationName = "feature_operation.#{InstrumentationNamespace}"
+    InstrumentationName = "feature_operation.#{InstrumentationNamespace}".freeze
 
     # Public: The name of the feature.
     attr_reader :name

--- a/lib/flipper/gate_values.rb
+++ b/lib/flipper/gate_values.rb
@@ -4,13 +4,13 @@ module Flipper
   class GateValues
     # Private: Array of instance variables that are readable through the []
     # instance method.
-    LegitIvars = Set.new([
-      "boolean",
-      "actors",
-      "groups",
-      "percentage_of_time",
-      "percentage_of_actors",
-    ]).freeze
+    LegitIvars = {
+      "boolean" => "@boolean",
+      "actors" => "@actors",
+      "groups" => "@groups",
+      "percentage_of_time" => "@percentage_of_time",
+      "percentage_of_actors" => "@percentage_of_actors",
+    }.freeze
 
     attr_reader :boolean
     attr_reader :actors
@@ -27,8 +27,9 @@ module Flipper
     end
 
     def [](key)
-      return nil unless LegitIvars.include?(key.to_s)
-      instance_variable_get("@#{key}")
+      if ivar = LegitIvars[key.to_s]
+        instance_variable_get(ivar)
+      end
     end
 
     def eql?(other)

--- a/lib/flipper/instrumentation/subscriber.rb
+++ b/lib/flipper/instrumentation/subscriber.rb
@@ -71,9 +71,11 @@ module Flipper
         update_timer "flipper.adapter.#{adapter_name}.#{operation}"
       end
 
+      QUESTION_MARK = "?".freeze
+
       # Private
       def strip_trailing_question_mark(operation)
-        operation.to_s.chomp('?')
+        operation.to_s.chomp(QUESTION_MARK)
       end
     end
   end

--- a/lib/flipper/version.rb
+++ b/lib/flipper/version.rb
@@ -1,3 +1,3 @@
 module Flipper
-  VERSION = "0.8.0"
+  VERSION = "0.8.0".freeze
 end

--- a/spec/flipper/adapters/instrumented_spec.rb
+++ b/spec/flipper/adapters/instrumented_spec.rb
@@ -19,6 +19,16 @@ RSpec.describe Flipper::Adapters::Instrumented do
 
   it_should_behave_like 'a flipper adapter'
 
+  it "forwards missing methods to underlying adapter" do
+    adapter = Class.new do
+      def foo
+        :foo
+      end
+    end.new
+    instrumented = described_class.new(adapter)
+    expect(instrumented.foo).to eq(:foo)
+  end
+
   describe "#name" do
     it "is instrumented" do
       expect(subject.name).to be(:instrumented)

--- a/spec/flipper/adapters/memoizable_spec.rb
+++ b/spec/flipper/adapters/memoizable_spec.rb
@@ -13,6 +13,16 @@ RSpec.describe Flipper::Adapters::Memoizable do
 
   it_should_behave_like 'a flipper adapter'
 
+  it "forwards missing methods to underlying adapter" do
+    adapter = Class.new do
+      def foo
+        :foo
+      end
+    end.new
+    memoizable = described_class.new(adapter)
+    expect(memoizable.foo).to eq(:foo)
+  end
+
   describe "#name" do
     it "is instrumented" do
       expect(subject.name).to be(:memoizable)

--- a/spec/flipper/adapters/operation_logger_spec.rb
+++ b/spec/flipper/adapters/operation_logger_spec.rb
@@ -12,6 +12,16 @@ RSpec.describe Flipper::Adapters::OperationLogger do
 
   it_should_behave_like 'a flipper adapter'
 
+  it "forwards missing methods to underlying adapter" do
+    adapter = Class.new do
+      def foo
+        :foo
+      end
+    end.new
+    operation_logger = described_class.new(adapter)
+    expect(operation_logger.foo).to eq(:foo)
+  end
+
   describe "#get" do
     before do
       @feature = flipper[:stats]

--- a/spec/flipper/dsl_spec.rb
+++ b/spec/flipper/dsl_spec.rb
@@ -25,13 +25,6 @@ RSpec.describe Flipper::DSL do
         dsl = described_class.new(adapter, :instrumenter => instrumenter)
         expect(dsl.instrumenter).to be(instrumenter)
       end
-
-      it "passes overridden instrumenter to instrumented adapter" do
-        dsl = described_class.new(adapter, :instrumenter => instrumenter)
-        memoized = dsl.adapter
-        instrumented = memoized.adapter
-        expect(instrumented.instrumenter).to be(instrumenter)
-      end
     end
   end
 

--- a/spec/flipper/instrumentation/log_subscriber_spec.rb
+++ b/spec/flipper/instrumentation/log_subscriber_spec.rb
@@ -1,10 +1,14 @@
 require 'logger'
 require 'helper'
+require 'flipper/adapters/instrumented'
 require 'flipper/adapters/memory'
 require 'flipper/instrumentation/log_subscriber'
 
 RSpec.describe Flipper::Instrumentation::LogSubscriber do
-  let(:adapter) { Flipper::Adapters::Memory.new }
+  let(:adapter) {
+    memory = Flipper::Adapters::Memory.new
+    Flipper::Adapters::Instrumented.new(memory, :instrumenter => ActiveSupport::Notifications)
+  }
   let(:flipper) {
     Flipper.new(adapter, :instrumenter => ActiveSupport::Notifications)
   }

--- a/spec/flipper/instrumentation/metriks_subscriber_spec.rb
+++ b/spec/flipper/instrumentation/metriks_subscriber_spec.rb
@@ -3,7 +3,10 @@ require 'flipper/adapters/memory'
 require 'flipper/instrumentation/metriks'
 
 RSpec.describe Flipper::Instrumentation::MetriksSubscriber do
-  let(:adapter) { Flipper::Adapters::Memory.new }
+  let(:adapter) {
+    memory = Flipper::Adapters::Memory.new
+    Flipper::Adapters::Instrumented.new(memory, :instrumenter => ActiveSupport::Notifications)
+  }
   let(:flipper) {
     Flipper.new(adapter, :instrumenter => ActiveSupport::Notifications)
   }

--- a/spec/flipper/instrumentation/statsd_subscriber_spec.rb
+++ b/spec/flipper/instrumentation/statsd_subscriber_spec.rb
@@ -5,7 +5,10 @@ require 'flipper/instrumentation/statsd'
 RSpec.describe Flipper::Instrumentation::StatsdSubscriber do
   let(:statsd_client) { Statsd.new }
   let(:socket) { FakeUDPSocket.new }
-  let(:adapter) { Flipper::Adapters::Memory.new }
+  let(:adapter) {
+    memory = Flipper::Adapters::Memory.new
+    Flipper::Adapters::Instrumented.new(memory, :instrumenter => ActiveSupport::Notifications)
+  }
   let(:flipper) {
     Flipper.new(adapter, :instrumenter => ActiveSupport::Notifications)
   }


### PR DESCRIPTION
* some constant ❄️ 'ing
* ensure memoizable, instrumented and operation logger delegate missing methods; the reason is that we (GitHub) use some custom adapters that have custom methods and call those on flipper.adapter.some_custom_method and those started failing when I tried to upgrade to 0.8 (which removed decorator)
* instrumenting adapters is now off by default, there was no way to opt out, since this instrumentation isn't insanely useful i'd rather make it opt in, super easy to do so, people can just use the instrumented adapter around their current one (ie: Flipper::Adapters::Instrumented.new(Flipper::Adapters::ActiveRecord.new)).
* dropped a few string allocations

I'll bump to 0.9 since the adapter instrumentation stuff is kind of breaking.