### PR TITLE
Dalli cache adapter optimization documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,7 +70,7 @@ Of course there are more [examples for you to peruse](examples/). You could also
 * [Gates](docs/Gates.md) - Boolean, Groups, Actors, % of Actors, and % of Time
 * [Adapters](docs/Adapters.md) - Mongo, Redis, Cassandra, Active Record...
 * [Instrumentation](docs/Instrumentation.md) - ActiveSupport::Notifications, Statsd and Metriks
-* [Optimization](docs/Optimization.md) - Memoization middleware
+* [Optimization](docs/Optimization.md) - Memoization middleware and Cache adapters
 * [Web Interface](docs/ui/README.md) - Point and click...
 * [Caveats](docs/Caveats.md) - Flipper beware! (see what I did there)
 

--- a/docs/Optimization.md
+++ b/docs/Optimization.md
@@ -1,5 +1,7 @@
 # Optimization
 
+## Memoizing Middleware
+
 One optimization that flipper provides is a memoizing middleware. The memoizing middleware ensures that you only make one adapter call per feature per request.
 
 This means if you check the same feature over and over, it will only make one Mongo, Redis, or whatever call per feature for the length of the request.
@@ -31,3 +33,21 @@ config.middleware.use Flipper::Middleware::Memoizer, lambda {
 ```
 
 **Note**: Be sure that the middleware is high enough up in your stack that all feature checks are wrapped.
+
+## Cache Adapters
+
+Cache adapters allow you to cache adapter calls for longer than a single request and should be used alongside the memoization middleware to add another caching layer.
+### Dalli
+
+"Dalli is a high performance pure Ruby client for accessing memcached servers"
+
+https://github.com/petergoldstein/dalli
+
+Example using the Dalli cache adapter with the Memory adapter and a TTL of 600 seconds:
+
+```ruby
+dalli_client = Dalli::Client.new('localhost:11211')
+memory_adapter = Flipper::Adapters::Memory.new
+adapter = Flipper::Adapters::Dalli.new(memory_adapter, dalli_client, 600)
+flipper = Flipper.new(adapter)
+```


### PR DESCRIPTION
#140 add documentation for Dalli adapter.  I think it makes most sense to put this under Optimization as opposed to adapters since it's really an optimization and meant to wrap a primary database adapter.  I decided to use the header `Cache Adapters` because we might have more adapters used just for caching in the future.  Curious to hear thoughts and if the example / wording could be improved

<img width="792" alt="screen shot 2016-06-26 at 12 31 33 pm" src="https://cloud.githubusercontent.com/assets/3260042/16365924/3f57654c-3bcb-11e6-9f3e-6521093a5315.png">

