### PR TITLE
Whitelist valid request method names

### DIFF
--- a/lib/flipper/api/action.rb
+++ b/lib/flipper/api/action.rb
@@ -1,7 +1,18 @@
+require 'forwardable'
+require 'flipper/api/error'
+require 'json'
+
 module Flipper
   module Api
     class Action
       extend Forwardable
+
+      VALID_REQUEST_METHOD_NAMES = Set.new([
+        "get".freeze,
+        "post".freeze,
+        "put".freeze,
+        "delete".freeze,
+      ]).freeze
 
       # Public: Call this in subclasses so the action knows its route.
       #
@@ -47,7 +58,7 @@ module Flipper
       #
       # Returns whatever the request method returns in the action.
       def run
-        if respond_to?(request_method_name)
+        if valid_request_method? && respond_to?(request_method_name)
           catch(:halt) { send(request_method_name) }
         else
           raise Api::RequestMethodNotSupported, "#{self.class} does not support request method #{request_method_name.inspect}"
@@ -110,6 +121,10 @@ module Flipper
       # Example: "api/v1/features/feature_name" => ['api', 'v1', 'features', 'feature_name']
       def path_parts
         @request.path.split("/")
+      end
+
+      def valid_request_method?
+        VALID_REQUEST_METHOD_NAMES.include?(request_method_name)
       end
     end
   end

--- a/lib/flipper/ui/action.rb
+++ b/lib/flipper/ui/action.rb
@@ -8,6 +8,13 @@ module Flipper
     class Action
       extend Forwardable
 
+      VALID_REQUEST_METHOD_NAMES = Set.new([
+        "get".freeze,
+        "post".freeze,
+        "put".freeze,
+        "delete".freeze,
+      ]).freeze
+
       # Public: Call this in subclasses so the action knows its route.
       #
       # regex - The Regexp that this action should run for.
@@ -67,7 +74,7 @@ module Flipper
       #
       # Returns whatever the request method returns in the action.
       def run
-        if respond_to?(request_method_name)
+        if valid_request_method? && respond_to?(request_method_name)
           catch(:halt) { send(request_method_name) }
         else
           raise UI::RequestMethodNotSupported, "#{self.class} does not support request method #{request_method_name.inspect}"
@@ -212,6 +219,10 @@ module Flipper
 
       def csrf_input_tag
         %Q(<input type="hidden" name="authenticity_token" value="#{@request.session[:csrf]}">)
+      end
+
+      def valid_request_method?
+        VALID_REQUEST_METHOD_NAMES.include?(request_method_name)
       end
     end
   end

--- a/spec/flipper/api/action_spec.rb
+++ b/spec/flipper/api/action_spec.rb
@@ -1,0 +1,59 @@
+require 'helper'
+
+RSpec.describe Flipper::Api::Action do
+  let(:action_subclass) {
+    Class.new(described_class) do
+      def noooope
+        raise "should never run this"
+      end
+
+      def get
+        [200, {}, "get"]
+      end
+
+      def post
+        [200, {}, "post"]
+      end
+
+      def put
+        [200, {}, "put"]
+      end
+
+      def delete
+        [200, {}, "delete"]
+      end
+    end
+  }
+
+  it "won't run exit method" do
+    fake_request = Struct.new(:request_method, :env, :session).new("NOOOOPE", {}, {})
+    action = action_subclass.new(flipper, fake_request)
+    expect {
+      action.run
+    }.to raise_error(Flipper::Api::RequestMethodNotSupported)
+  end
+
+  it "will run get" do
+    fake_request = Struct.new(:request_method, :env, :session).new("GET", {}, {})
+    action = action_subclass.new(flipper, fake_request)
+    expect(action.run).to eq([200, {}, "get"])
+  end
+
+  it "will run post" do
+    fake_request = Struct.new(:request_method, :env, :session).new("POST", {}, {})
+    action = action_subclass.new(flipper, fake_request)
+    expect(action.run).to eq([200, {}, "post"])
+  end
+
+  it "will run put" do
+    fake_request = Struct.new(:request_method, :env, :session).new("PUT", {}, {})
+    action = action_subclass.new(flipper, fake_request)
+    expect(action.run).to eq([200, {}, "put"])
+  end
+
+  it "will run delete" do
+    fake_request = Struct.new(:request_method, :env, :session).new("DELETE", {}, {})
+    action = action_subclass.new(flipper, fake_request)
+    expect(action.run).to eq([200, {}, "delete"])
+  end
+end

--- a/spec/flipper/api/action_spec.rb
+++ b/spec/flipper/api/action_spec.rb
@@ -25,7 +25,7 @@ RSpec.describe Flipper::Api::Action do
     end
   }
 
-  it "won't run exit method" do
+  it "won't run method that isn't whitelisted" do
     fake_request = Struct.new(:request_method, :env, :session).new("NOOOOPE", {}, {})
     action = action_subclass.new(flipper, fake_request)
     expect {

--- a/spec/flipper/ui/action_spec.rb
+++ b/spec/flipper/ui/action_spec.rb
@@ -1,0 +1,59 @@
+require 'helper'
+
+RSpec.describe Flipper::UI::Action do
+  let(:action_subclass) {
+    Class.new(described_class) do
+      def noooope
+        raise "should never run this"
+      end
+
+      def get
+        [200, {}, "get"]
+      end
+
+      def post
+        [200, {}, "post"]
+      end
+
+      def put
+        [200, {}, "put"]
+      end
+
+      def delete
+        [200, {}, "delete"]
+      end
+    end
+  }
+
+  it "won't run exit method" do
+    fake_request = Struct.new(:request_method, :env, :session).new("NOOOOPE", {}, {})
+    action = action_subclass.new(flipper, fake_request)
+    expect {
+      action.run
+    }.to raise_error(Flipper::UI::RequestMethodNotSupported)
+  end
+
+  it "will run get" do
+    fake_request = Struct.new(:request_method, :env, :session).new("GET", {}, {})
+    action = action_subclass.new(flipper, fake_request)
+    expect(action.run).to eq([200, {}, "get"])
+  end
+
+  it "will run post" do
+    fake_request = Struct.new(:request_method, :env, :session).new("POST", {}, {})
+    action = action_subclass.new(flipper, fake_request)
+    expect(action.run).to eq([200, {}, "post"])
+  end
+
+  it "will run put" do
+    fake_request = Struct.new(:request_method, :env, :session).new("PUT", {}, {})
+    action = action_subclass.new(flipper, fake_request)
+    expect(action.run).to eq([200, {}, "put"])
+  end
+
+  it "will run delete" do
+    fake_request = Struct.new(:request_method, :env, :session).new("DELETE", {}, {})
+    action = action_subclass.new(flipper, fake_request)
+    expect(action.run).to eq([200, {}, "delete"])
+  end
+end

--- a/spec/flipper/ui/action_spec.rb
+++ b/spec/flipper/ui/action_spec.rb
@@ -25,7 +25,7 @@ RSpec.describe Flipper::UI::Action do
     end
   }
 
-  it "won't run exit method" do
+  it "won't run method that isn't whitelisted" do
     fake_request = Struct.new(:request_method, :env, :session).new("NOOOOPE", {}, {})
     action = action_subclass.new(flipper, fake_request)
     expect {


### PR DESCRIPTION
Just a safety precaution since we do respond to and send. We really only want certain methods to "work" for performing an action so let's be explicit.