### PR TITLE
Adjust gemspec and test/ci for Rails 5

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,13 +11,13 @@ services:
   - mongodb
   - memcached
 env:
-  - RAILS_VERSION=5.0.0.beta3
+  - RAILS_VERSION=5.0.0
   - RAILS_VERSION=4.2.5
   - RAILS_VERSION=3.2.21
 matrix:
   # don't run rails 5 on ruby versions that can't install rack 2
   exclude:
     - rvm: 2.0.0
-      env: RAILS_VERSION=5.0.0.beta3
+      env: RAILS_VERSION=5.0.0
     - rvm: 2.1.8
-      env: RAILS_VERSION=5.0.0.beta3
+      env: RAILS_VERSION=5.0.0

--- a/flipper-active_record.gemspec
+++ b/flipper-active_record.gemspec
@@ -24,5 +24,5 @@ Gem::Specification.new do |gem|
   gem.version       = Flipper::VERSION
 
   gem.add_dependency 'flipper', "~> #{Flipper::VERSION}"
-  gem.add_dependency 'activerecord', ">= 3.2", "< 5"
+  gem.add_dependency 'activerecord', ">= 3.2", "< 6"
 end

--- a/script/test
+++ b/script/test
@@ -20,6 +20,6 @@ export RAILS_VERSION=4.2.5
 script/bootstrap || bundle update
 bundle exec rake
 
-export RAILS_VERSION=5.0.0.rc1
+export RAILS_VERSION=5.0.0
 script/bootstrap || bundle update
 bundle exec rake


### PR DESCRIPTION
Now that Rails 5 is out the gemspec for the AR adapter needed to be adjusted. Additionally, I updated all the test/ci stuff to run against rails 5.