### PR TITLE
Api features endpoint

### DIFF
--- a/lib/flipper/api/middleware.rb
+++ b/lib/flipper/api/middleware.rb
@@ -7,7 +7,7 @@ Pathname(__FILE__).dirname.join('v1/actions').each_child(false) do |name|
 end
 
 module Flipper
-  module Api 
+  module Api
     class Middleware
       # Public: Initializes an instance of the API middleware.
       #
@@ -37,6 +37,7 @@ module Flipper
         @action_collection = ActionCollection.new
         @action_collection.add Api::V1::Actions::BooleanGate
         @action_collection.add Api::V1::Actions::Feature
+        @action_collection.add Api::V1::Actions::Features
       end
 
       def flipper

--- a/lib/flipper/api/v1/actions/features.rb
+++ b/lib/flipper/api/v1/actions/features.rb
@@ -1,0 +1,26 @@
+require 'flipper/api/action'
+require 'flipper/api/v1/decorators/feature'
+require 'json'
+
+module Flipper
+  module Api
+    module V1
+      module Actions
+        class Features < Api::Action
+
+          route %r{api/v1/features\Z}
+
+          def get
+            features = flipper.features.map { |feature|
+              Decorators::Feature.new(feature).as_json
+            }
+
+            json_response({
+              features: features
+            })
+          end
+        end
+      end
+    end
+  end
+end

--- a/spec/flipper/api/v1/actions/features_spec.rb
+++ b/spec/flipper/api/v1/actions/features_spec.rb
@@ -1,0 +1,70 @@
+require 'helper'
+
+RSpec.describe Flipper::Api::V1::Actions::Features do
+  let(:app) { build_api(flipper) }
+  let(:feature) { build_feature }
+  let(:admin) { double 'Fake Fliper Thing', flipper_id: 10 }
+
+  describe 'get' do
+    context 'with flipper features' do
+      before do
+        flipper[:my_feature].enable
+        flipper[:my_feature].enable(admin)
+        get 'api/v1/features'
+      end
+
+      it 'responds with correct attributes' do
+        expected_response = {
+          "features" => [
+            {
+              "key" =>"my_feature",
+              "state" => "on",
+              "gates" => [
+                {
+                  "key"=> "boolean",
+                  "name"=> "boolean",
+                  "value" => true},
+                  {
+                    "key" =>"groups",
+                    "name" => "group",
+                    "value" =>[],
+                  },
+                  {
+                    "key" => "actors",
+                    "name"=>"actor",
+                    "value"=>["10"],
+                  },
+                  {
+                    "key" => "percentage_of_actors",
+                    "name" => "percentage_of_actors",
+                    "value" => 0,
+                  },
+                  {
+                    "key"=> "percentage_of_time",
+                    "name"=> "percentage_of_time",
+                    "value"=> 0,
+                  },
+              ],
+            },
+          ]
+        }
+        expect(last_response.status).to eq(200)
+        expect(json_response).to eq(expected_response)
+      end
+    end
+
+    context 'with no flipper features' do
+      before do
+        get 'api/v1/features'
+      end
+
+      it 'returns empty array for features key' do
+        expected_response = {
+          "features" => []
+        }
+        expect(last_response.status).to eq(200)
+        expect(json_response).to eq(expected_response)
+      end
+    end
+  end
+end


### PR DESCRIPTION
addresses #130 

Having thoughts that might be better to return something like:

```
features = flipper.features.map { |feature|
  { feature: Decorators::Feature.new(feature).as_json }
}
json_response({ features: features })
```
so could add some non-breaking updates to response if wanted to (and add it to /feature), but then I also thought this works and not sure what else would want to add

i.e.
```
features = flipper.features.map {|feature|
  { feature: feature: Decorators::Feature.new(feature).as_json, some_other_data: "..." }
}
```

