### PR TITLE
Stop requiring statsd in subscriber

### DIFF
--- a/lib/flipper/instrumentation/statsd_subscriber.rb
+++ b/lib/flipper/instrumentation/statsd_subscriber.rb
@@ -3,7 +3,6 @@
 # that lives in the same directory as this file. The benefit is that it
 # subscribes to the correct events and does everything for your.
 require 'flipper/instrumentation/subscriber'
-require 'statsd'
 
 module Flipper
   module Instrumentation


### PR DESCRIPTION
Nothing statsd specific is referenced other than the client, but that is just through the class var so no need to require this.