### PR TITLE
Make add_actor input placeholder lowercase

### DIFF
--- a/lib/flipper/ui/views/add_actor.erb
+++ b/lib/flipper/ui/views/add_actor.erb
@@ -15,7 +15,7 @@
     <form action="<%= script_name %>/features/<%= @feature.key %>/actors" method="post">
       <%== csrf_input_tag %>
       <input type="hidden" name="operation" value="enable">
-      <input type="text" name="value" placeholder="ie: User:6">
+      <input type="text" name="value" placeholder="ie: user:6">
       <input type="submit" value="Add Actor" class="btn">
     </form>
   </div>


### PR DESCRIPTION
Today I was sitting with one of our QA people as they added an actor for their own user account. Due to the placeholder being `User` she initially add `User:123456` which didn't work. They then added `user:123456` which did. 

If I'm mistaken, feel free to close this but I think it does need to be lowercase and figured this was an easy win rather than calling `downcase` when this string is turned into an actual record.