### PR TITLE
POST /api/v1/features - add feature endpoint

### DIFF
--- a/lib/flipper/api/v1/actions/features.rb
+++ b/lib/flipper/api/v1/actions/features.rb
@@ -19,6 +19,19 @@ module Flipper
               features: features
             })
           end
+
+          def post
+            feature_name = params.fetch('name') do
+              json_response({
+                errors: [{
+                  message: 'Missing post parameter: name',
+                }]
+              }, 422)
+            end
+
+            flipper.adapter.add(flipper[feature_name])
+            json_response({}, 200)
+          end
         end
       end
     end

--- a/spec/flipper/api/v1/actions/features_spec.rb
+++ b/spec/flipper/api/v1/actions/features_spec.rb
@@ -25,26 +25,26 @@ RSpec.describe Flipper::Api::V1::Actions::Features do
                   "name"=> "boolean",
                   "value" => true},
                   {
-                    "key" =>"groups",
-                    "name" => "group",
-                    "value" =>[],
-                  },
-                  {
-                    "key" => "actors",
-                    "name"=>"actor",
-                    "value"=>["10"],
-                  },
-                  {
-                    "key" => "percentage_of_actors",
-                    "name" => "percentage_of_actors",
-                    "value" => 0,
-                  },
-                  {
-                    "key"=> "percentage_of_time",
-                    "name"=> "percentage_of_time",
-                    "value"=> 0,
-                  },
-              ],
+                  "key" =>"groups",
+                  "name" => "group",
+                  "value" =>[],
+                },
+                {
+                  "key" => "actors",
+                  "name"=>"actor",
+                  "value"=>["10"],
+                },
+                {
+                  "key" => "percentage_of_actors",
+                  "name" => "percentage_of_actors",
+                  "value" => 0,
+                },
+                {
+                  "key"=> "percentage_of_time",
+                  "name"=> "percentage_of_time",
+                  "value"=> 0,
+                },
+            ],
             },
           ]
         }
@@ -64,6 +64,42 @@ RSpec.describe Flipper::Api::V1::Actions::Features do
         }
         expect(last_response.status).to eq(200)
         expect(json_response).to eq(expected_response)
+      end
+    end
+  end
+
+  describe 'post' do
+    context 'succesful request' do
+      before do
+        post 'api/v1/features', { name: 'my_feature' }
+      end
+
+      it 'responds 200 on success' do
+        expect(last_response.status).to eq(200)
+        expect(json_response).to eq({})
+      end
+
+      it 'adds feature' do
+        expect(flipper.features.map(&:key)).to include('my_feature')
+      end
+
+      it 'does not enable feature' do
+        expect(flipper['my_feature'].enabled?).to be_falsy
+      end
+    end
+
+    context 'bad request' do
+      before do
+        post 'api/v1/features'
+      end
+
+      it 'returns correct status code' do
+        expect(last_response.status).to eq(422)
+      end
+
+      it 'returns formatted error' do
+        errors = json_response['errors']
+        expect(errors.first['message']).to eq('Missing post parameter: name')
       end
     end
   end


### PR DESCRIPTION
Looks like master is failing, #154 should fix it. Once merged I can rebase

* endpoint to add a feature

I decided to make the parameter 'name' since that matches the signature for `Flipper::DSL#feature`, which takes a name as an argument.

I decided to use 422 because RFC 4918 describes it as:

   The 422 (Unprocessable Entity) status code means the server
   understands the content type of the request entity (hence a
   415(Unsupported Media Type) status code is inappropriate), and the
   syntax of the request entity is correct (thus a 400 (Bad Request)
   status code is inappropriate) but was unable to process the contained
   instructions.  For example, this error condition may occur if an XML
   request body contains well-formed (i.e., syntactically correct), but
   semantically erroneous, XML instructions.


I am curious if you think we should return something in the response body for 200s.  Maybe the decorated feature? 

I like the idea of having errors be an array in case we want to add multiple errors.  I'm not sure what thoughts are on the shape of the error response, but having looked at Github's and Twitter's I like a few things from each.  I think including a link to an explanation in the documentation is really rad (as Github does), and I think the possibility of custom error codes that map to some type of error is cool and can be really helpful.  For now I figured we'll just keep it a hash with the message key, and down the line we could possibly add more keys like those if we think its a good idea without breaking anything.

I'm thinking in the next PR I can make the 422 error a child of Flipper::Api::Error and define a to_s or to_json method or something so we can reuse this in other endpoints where we expect a 422


https://developer.github.com/v3/#client-errors
https://dev.twitter.com/overview/api/response-codes