### PR TITLE
rack-protection 2.0.0 support

### DIFF
--- a/flipper-ui.gemspec
+++ b/flipper-ui.gemspec
@@ -20,7 +20,7 @@ Gem::Specification.new do |gem|
   gem.version       = Flipper::VERSION
 
   gem.add_dependency 'rack', '>= 1.4', '< 3'
-  gem.add_dependency 'rack-protection', '~> 1.5.3'
+  gem.add_dependency 'rack-protection', '>= 1.5.3', '< 2.1.0'
   gem.add_dependency 'flipper', "~> #{Flipper::VERSION}"
   gem.add_dependency 'erubis', '~> 2.7.0'
 end

--- a/spec/flipper/ui/actions/actors_gate_spec.rb
+++ b/spec/flipper/ui/actions/actors_gate_spec.rb
@@ -1,6 +1,15 @@
 require 'helper'
 
 RSpec.describe Flipper::UI::Actions::ActorsGate do
+  let(:token) {
+    if Rack::Protection::AuthenticityToken.respond_to?(:random_token)
+      Rack::Protection::AuthenticityToken.random_token
+    else
+      "a"
+    end
+  }
+  let(:session) { {:csrf => token} }
+
   describe "GET /features/:feature/actors" do
     before do
       get "features/search/actors"
@@ -19,8 +28,8 @@ RSpec.describe Flipper::UI::Actions::ActorsGate do
     context "enabling an actor" do
       before do
         post "features/search/actors",
-          {"value" => "User:6", "operation" => "enable", "authenticity_token" => "a"},
-          "rack.session" => {"_csrf_token" => "a"}
+          {"value" => "User:6", "operation" => "enable", "authenticity_token" => token},
+          "rack.session" => session
       end
 
       it "adds item to members" do
@@ -37,8 +46,8 @@ RSpec.describe Flipper::UI::Actions::ActorsGate do
       before do
         flipper[:search].enable_actor Flipper::UI::Actor.new("User:6")
         post "features/search/actors",
-          {"value" => "User:6", "operation" => "disable", "authenticity_token" => "a"},
-          "rack.session" => {"_csrf_token" => "a"}
+          {"value" => "User:6", "operation" => "disable", "authenticity_token" => token},
+          "rack.session" => session
       end
 
       it "removes item from members" do
@@ -54,8 +63,8 @@ RSpec.describe Flipper::UI::Actions::ActorsGate do
     context "for an invalid actor value" do
       before do
         post "features/search/actors",
-          {"value" => "", "operation" => "enable", "authenticity_token" => "a"},
-          "rack.session" => {"_csrf_token" => "a"}
+          {"value" => "", "operation" => "enable", "authenticity_token" => token},
+          "rack.session" => session
       end
 
       it "redirects back to feature" do

--- a/spec/flipper/ui/actions/actors_gate_spec.rb
+++ b/spec/flipper/ui/actions/actors_gate_spec.rb
@@ -8,7 +8,13 @@ RSpec.describe Flipper::UI::Actions::ActorsGate do
       "a"
     end
   }
-  let(:session) { {:csrf => token} }
+  let(:session) {
+    if Rack::Protection::AuthenticityToken.respond_to?(:random_token)
+      {:csrf => token}
+    else
+      {"_csrf_token" => token}
+    end
+  }
 
   describe "GET /features/:feature/actors" do
     before do

--- a/spec/flipper/ui/actions/boolean_gate_spec.rb
+++ b/spec/flipper/ui/actions/boolean_gate_spec.rb
@@ -8,7 +8,13 @@ RSpec.describe Flipper::UI::Actions::BooleanGate do
       "a"
     end
   }
-  let(:session) { {:csrf => token} }
+  let(:session) {
+    if Rack::Protection::AuthenticityToken.respond_to?(:random_token)
+      {:csrf => token}
+    else
+      {"_csrf_token" => token}
+    end
+  }
 
   describe "POST /features/:feature/boolean" do
     context "with enable" do

--- a/spec/flipper/ui/actions/boolean_gate_spec.rb
+++ b/spec/flipper/ui/actions/boolean_gate_spec.rb
@@ -1,13 +1,22 @@
 require 'helper'
 
 RSpec.describe Flipper::UI::Actions::BooleanGate do
+  let(:token) {
+  if Rack::Protection::AuthenticityToken.respond_to?(:random_token)
+    Rack::Protection::AuthenticityToken.random_token
+  else
+    "a"
+  end
+}
+  let(:session) { {:csrf => token} }
+
   describe "POST /features/:feature/boolean" do
     context "with enable" do
       before do
         flipper.disable :search
         post "features/search/boolean",
-          {"action" => "Enable", "authenticity_token" => "a"},
-          "rack.session" => {"_csrf_token" => "a"}
+          {"action" => "Enable", "authenticity_token" => token},
+          "rack.session" => session
       end
 
       it "enables the feature" do
@@ -24,8 +33,8 @@ RSpec.describe Flipper::UI::Actions::BooleanGate do
       before do
         flipper.enable :search
         post "features/search/boolean",
-          {"action" => "Disable", "authenticity_token" => "a"},
-          "rack.session" => {"_csrf_token" => "a"}
+          {"action" => "Disable", "authenticity_token" => token},
+          "rack.session" => session
       end
 
       it "disables the feature" do

--- a/spec/flipper/ui/actions/boolean_gate_spec.rb
+++ b/spec/flipper/ui/actions/boolean_gate_spec.rb
@@ -2,12 +2,12 @@ require 'helper'
 
 RSpec.describe Flipper::UI::Actions::BooleanGate do
   let(:token) {
-  if Rack::Protection::AuthenticityToken.respond_to?(:random_token)
-    Rack::Protection::AuthenticityToken.random_token
-  else
-    "a"
-  end
-}
+    if Rack::Protection::AuthenticityToken.respond_to?(:random_token)
+      Rack::Protection::AuthenticityToken.random_token
+    else
+      "a"
+    end
+  }
   let(:session) { {:csrf => token} }
 
   describe "POST /features/:feature/boolean" do

--- a/spec/flipper/ui/actions/feature_spec.rb
+++ b/spec/flipper/ui/actions/feature_spec.rb
@@ -1,12 +1,21 @@
 require 'helper'
 
 RSpec.describe Flipper::UI::Actions::Feature do
+  let(:token) {
+  if Rack::Protection::AuthenticityToken.respond_to?(:random_token)
+    Rack::Protection::AuthenticityToken.random_token
+  else
+    "a"
+  end
+}
+  let(:session) { {:csrf => token} }
+
   describe "DELETE /features/:feature" do
     before do
       flipper.enable :search
       delete "/features/search",
-        {"authenticity_token" => "a"},
-        "rack.session" => {"_csrf_token" => "a"}
+        {"authenticity_token" => token},
+        "rack.session" => session
     end
 
     it "removes feature" do
@@ -23,8 +32,8 @@ RSpec.describe Flipper::UI::Actions::Feature do
     before do
       flipper.enable :search
       post "/features/search",
-        {"_method" => "DELETE", "authenticity_token" => "a"},
-        "rack.session" => {"_csrf_token" => "a"}
+        {"_method" => "DELETE", "authenticity_token" => token},
+        "rack.session" => session
     end
 
     it "removes feature" do

--- a/spec/flipper/ui/actions/feature_spec.rb
+++ b/spec/flipper/ui/actions/feature_spec.rb
@@ -2,12 +2,12 @@ require 'helper'
 
 RSpec.describe Flipper::UI::Actions::Feature do
   let(:token) {
-  if Rack::Protection::AuthenticityToken.respond_to?(:random_token)
-    Rack::Protection::AuthenticityToken.random_token
-  else
-    "a"
-  end
-}
+    if Rack::Protection::AuthenticityToken.respond_to?(:random_token)
+      Rack::Protection::AuthenticityToken.random_token
+    else
+      "a"
+    end
+  }
   let(:session) { {:csrf => token} }
 
   describe "DELETE /features/:feature" do

--- a/spec/flipper/ui/actions/feature_spec.rb
+++ b/spec/flipper/ui/actions/feature_spec.rb
@@ -8,7 +8,13 @@ RSpec.describe Flipper::UI::Actions::Feature do
       "a"
     end
   }
-  let(:session) { {:csrf => token} }
+  let(:session) {
+    if Rack::Protection::AuthenticityToken.respond_to?(:random_token)
+      {:csrf => token}
+    else
+      {"_csrf_token" => token}
+    end
+  }
 
   describe "DELETE /features/:feature" do
     before do

--- a/spec/flipper/ui/actions/features_spec.rb
+++ b/spec/flipper/ui/actions/features_spec.rb
@@ -1,6 +1,15 @@
 require 'helper'
 
 RSpec.describe Flipper::UI::Actions::Features do
+  let(:token) {
+  if Rack::Protection::AuthenticityToken.respond_to?(:random_token)
+    Rack::Protection::AuthenticityToken.random_token
+  else
+    "a"
+  end
+}
+  let(:session) { {:csrf => token} }
+
   describe "GET /features" do
     before do
       flipper[:stats].enable
@@ -23,8 +32,8 @@ RSpec.describe Flipper::UI::Actions::Features do
       @original_feature_creation_enabled = Flipper::UI.feature_creation_enabled
       Flipper::UI.feature_creation_enabled = true
       post "/features",
-        {"value" => "notifications_next", "authenticity_token" => "a"},
-        "rack.session" => {"_csrf_token" => "a"}
+        {"value" => "notifications_next", "authenticity_token" => token},
+        "rack.session" => session
     end
 
     after do
@@ -46,8 +55,8 @@ RSpec.describe Flipper::UI::Actions::Features do
       @original_feature_creation_enabled = Flipper::UI.feature_creation_enabled
       Flipper::UI.feature_creation_enabled = false
       post "/features",
-        {"value" => "notifications_next", "authenticity_token" => "a"},
-        "rack.session" => {"_csrf_token" => "a"}
+        {"value" => "notifications_next", "authenticity_token" => token},
+        "rack.session" => session
     end
 
     after do

--- a/spec/flipper/ui/actions/features_spec.rb
+++ b/spec/flipper/ui/actions/features_spec.rb
@@ -8,7 +8,13 @@ RSpec.describe Flipper::UI::Actions::Features do
       "a"
     end
   }
-  let(:session) { {:csrf => token} }
+  let(:session) {
+    if Rack::Protection::AuthenticityToken.respond_to?(:random_token)
+      {:csrf => token}
+    else
+      {"_csrf_token" => token}
+    end
+  }
 
   describe "GET /features" do
     before do

--- a/spec/flipper/ui/actions/features_spec.rb
+++ b/spec/flipper/ui/actions/features_spec.rb
@@ -2,12 +2,12 @@ require 'helper'
 
 RSpec.describe Flipper::UI::Actions::Features do
   let(:token) {
-  if Rack::Protection::AuthenticityToken.respond_to?(:random_token)
-    Rack::Protection::AuthenticityToken.random_token
-  else
-    "a"
-  end
-}
+    if Rack::Protection::AuthenticityToken.respond_to?(:random_token)
+      Rack::Protection::AuthenticityToken.random_token
+    else
+      "a"
+    end
+  }
   let(:session) { {:csrf => token} }
 
   describe "GET /features" do

--- a/spec/flipper/ui/actions/gate_spec.rb
+++ b/spec/flipper/ui/actions/gate_spec.rb
@@ -8,7 +8,13 @@ RSpec.describe Flipper::UI::Actions::Gate do
       "a"
     end
   }
-  let(:session) { {:csrf => token} }
+  let(:session) {
+    if Rack::Protection::AuthenticityToken.respond_to?(:random_token)
+      {:csrf => token}
+    else
+      {"_csrf_token" => token}
+    end
+  }
 
   describe "POST /features/:feature/non-existent-gate" do
     before do

--- a/spec/flipper/ui/actions/gate_spec.rb
+++ b/spec/flipper/ui/actions/gate_spec.rb
@@ -1,11 +1,20 @@
 require 'helper'
 
 RSpec.describe Flipper::UI::Actions::Gate do
+  let(:token) {
+  if Rack::Protection::AuthenticityToken.respond_to?(:random_token)
+    Rack::Protection::AuthenticityToken.random_token
+  else
+    "a"
+  end
+}
+  let(:session) { {:csrf => token} }
+
   describe "POST /features/:feature/non-existent-gate" do
     before do
       post "/features/search/non-existent-gate",
-        {"authenticity_token" => "a"},
-        "rack.session" => {"_csrf_token" => "a"}
+        {"authenticity_token" => token},
+        "rack.session" => session
     end
 
     it "responds with redirect" do

--- a/spec/flipper/ui/actions/gate_spec.rb
+++ b/spec/flipper/ui/actions/gate_spec.rb
@@ -2,12 +2,12 @@ require 'helper'
 
 RSpec.describe Flipper::UI::Actions::Gate do
   let(:token) {
-  if Rack::Protection::AuthenticityToken.respond_to?(:random_token)
-    Rack::Protection::AuthenticityToken.random_token
-  else
-    "a"
-  end
-}
+    if Rack::Protection::AuthenticityToken.respond_to?(:random_token)
+      Rack::Protection::AuthenticityToken.random_token
+    else
+      "a"
+    end
+  }
   let(:session) { {:csrf => token} }
 
   describe "POST /features/:feature/non-existent-gate" do

--- a/spec/flipper/ui/actions/groups_gate_spec.rb
+++ b/spec/flipper/ui/actions/groups_gate_spec.rb
@@ -8,7 +8,13 @@ RSpec.describe Flipper::UI::Actions::GroupsGate do
       "a"
     end
   }
-  let(:session) { {:csrf => token} }
+  let(:session) {
+    if Rack::Protection::AuthenticityToken.respond_to?(:random_token)
+      {:csrf => token}
+    else
+      {"_csrf_token" => token}
+    end
+  }
 
   describe "GET /features/:feature/groups" do
     before do

--- a/spec/flipper/ui/actions/groups_gate_spec.rb
+++ b/spec/flipper/ui/actions/groups_gate_spec.rb
@@ -1,6 +1,15 @@
 require 'helper'
 
 RSpec.describe Flipper::UI::Actions::GroupsGate do
+  let(:token) {
+  if Rack::Protection::AuthenticityToken.respond_to?(:random_token)
+    Rack::Protection::AuthenticityToken.random_token
+  else
+    "a"
+  end
+}
+  let(:session) { {:csrf => token} }
+
   describe "GET /features/:feature/groups" do
     before do
       Flipper.register(:admins) { |user| user.admin? }
@@ -32,8 +41,8 @@ RSpec.describe Flipper::UI::Actions::GroupsGate do
     context "enabling a group" do
       before do
         post "features/search/groups",
-          {"value" => "admins", "operation" => "enable", "authenticity_token" => "a"},
-          "rack.session" => {"_csrf_token" => "a"}
+          {"value" => "admins", "operation" => "enable", "authenticity_token" => token},
+          "rack.session" => session
       end
 
       it "adds item to members" do
@@ -50,8 +59,8 @@ RSpec.describe Flipper::UI::Actions::GroupsGate do
       before do
         flipper[:search].enable_group :admins
         post "features/search/groups",
-          {"value" => "admins", "operation" => "disable", "authenticity_token" => "a"},
-          "rack.session" => {"_csrf_token" => "a"}
+          {"value" => "admins", "operation" => "disable", "authenticity_token" => token},
+          "rack.session" => session
       end
 
       it "removes item from members" do
@@ -67,8 +76,8 @@ RSpec.describe Flipper::UI::Actions::GroupsGate do
     context "for an unregistered group" do
       before do
         post "features/search/groups",
-          {"value" => "not_here", "operation" => "enable", "authenticity_token" => "a"},
-          "rack.session" => {"_csrf_token" => "a"}
+          {"value" => "not_here", "operation" => "enable", "authenticity_token" => token},
+          "rack.session" => session
       end
 
       it "redirects back to feature" do

--- a/spec/flipper/ui/actions/groups_gate_spec.rb
+++ b/spec/flipper/ui/actions/groups_gate_spec.rb
@@ -2,12 +2,12 @@ require 'helper'
 
 RSpec.describe Flipper::UI::Actions::GroupsGate do
   let(:token) {
-  if Rack::Protection::AuthenticityToken.respond_to?(:random_token)
-    Rack::Protection::AuthenticityToken.random_token
-  else
-    "a"
-  end
-}
+    if Rack::Protection::AuthenticityToken.respond_to?(:random_token)
+      Rack::Protection::AuthenticityToken.random_token
+    else
+      "a"
+    end
+  }
   let(:session) { {:csrf => token} }
 
   describe "GET /features/:feature/groups" do

--- a/spec/flipper/ui/actions/percentage_of_actors_gate_spec.rb
+++ b/spec/flipper/ui/actions/percentage_of_actors_gate_spec.rb
@@ -2,12 +2,12 @@ require 'helper'
 
 RSpec.describe Flipper::UI::Actions::PercentageOfActorsGate do
   let(:token) {
-  if Rack::Protection::AuthenticityToken.respond_to?(:random_token)
-    Rack::Protection::AuthenticityToken.random_token
-  else
-    "a"
-  end
-}
+    if Rack::Protection::AuthenticityToken.respond_to?(:random_token)
+      Rack::Protection::AuthenticityToken.random_token
+    else
+      "a"
+    end
+  }
   let(:session) { {:csrf => token} }
 
   describe "POST /features/:feature/percentage_of_actors" do

--- a/spec/flipper/ui/actions/percentage_of_actors_gate_spec.rb
+++ b/spec/flipper/ui/actions/percentage_of_actors_gate_spec.rb
@@ -8,7 +8,13 @@ RSpec.describe Flipper::UI::Actions::PercentageOfActorsGate do
       "a"
     end
   }
-  let(:session) { {:csrf => token} }
+  let(:session) {
+    if Rack::Protection::AuthenticityToken.respond_to?(:random_token)
+      {:csrf => token}
+    else
+      {"_csrf_token" => token}
+    end
+  }
 
   describe "POST /features/:feature/percentage_of_actors" do
     context "with valid value" do

--- a/spec/flipper/ui/actions/percentage_of_actors_gate_spec.rb
+++ b/spec/flipper/ui/actions/percentage_of_actors_gate_spec.rb
@@ -1,12 +1,21 @@
 require 'helper'
 
 RSpec.describe Flipper::UI::Actions::PercentageOfActorsGate do
+  let(:token) {
+  if Rack::Protection::AuthenticityToken.respond_to?(:random_token)
+    Rack::Protection::AuthenticityToken.random_token
+  else
+    "a"
+  end
+}
+  let(:session) { {:csrf => token} }
+
   describe "POST /features/:feature/percentage_of_actors" do
     context "with valid value" do
       before do
         post "features/search/percentage_of_actors",
-          {"value" => "24", "authenticity_token" => "a"},
-          "rack.session" => {"_csrf_token" => "a"}
+          {"value" => "24", "authenticity_token" => token},
+          "rack.session" => session
       end
 
       it "enables the feature" do
@@ -22,8 +31,8 @@ RSpec.describe Flipper::UI::Actions::PercentageOfActorsGate do
     context "with invalid value" do
       before do
         post "features/search/percentage_of_actors",
-          {"value" => "555", "authenticity_token" => "a"},
-          "rack.session" => {"_csrf_token" => "a"}
+          {"value" => "555", "authenticity_token" => token},
+          "rack.session" => session
       end
 
       it "does not change value" do

--- a/spec/flipper/ui/actions/percentage_of_time_gate_spec.rb
+++ b/spec/flipper/ui/actions/percentage_of_time_gate_spec.rb
@@ -1,12 +1,21 @@
 require 'helper'
 
 RSpec.describe Flipper::UI::Actions::PercentageOfTimeGate do
+  let(:token) {
+  if Rack::Protection::AuthenticityToken.respond_to?(:random_token)
+    Rack::Protection::AuthenticityToken.random_token
+  else
+    "a"
+  end
+}
+  let(:session) { {:csrf => token} }
+
   describe "POST /features/:feature/percentage_of_time" do
     context "with valid value" do
       before do
         post "features/search/percentage_of_time",
-          {"value" => "24", "authenticity_token" => "a"},
-          "rack.session" => {"_csrf_token" => "a"}
+          {"value" => "24", "authenticity_token" => token},
+          "rack.session" => session
       end
 
       it "enables the feature" do
@@ -22,8 +31,8 @@ RSpec.describe Flipper::UI::Actions::PercentageOfTimeGate do
     context "with invalid value" do
       before do
         post "features/search/percentage_of_time",
-          {"value" => "555", "authenticity_token" => "a"},
-          "rack.session" => {"_csrf_token" => "a"}
+          {"value" => "555", "authenticity_token" => token},
+          "rack.session" => session
       end
 
       it "does not change value" do

--- a/spec/flipper/ui/actions/percentage_of_time_gate_spec.rb
+++ b/spec/flipper/ui/actions/percentage_of_time_gate_spec.rb
@@ -8,7 +8,13 @@ RSpec.describe Flipper::UI::Actions::PercentageOfTimeGate do
       "a"
     end
   }
-  let(:session) { {:csrf => token} }
+  let(:session) {
+    if Rack::Protection::AuthenticityToken.respond_to?(:random_token)
+      {:csrf => token}
+    else
+      {"_csrf_token" => token}
+    end
+  }
 
   describe "POST /features/:feature/percentage_of_time" do
     context "with valid value" do

--- a/spec/flipper/ui/actions/percentage_of_time_gate_spec.rb
+++ b/spec/flipper/ui/actions/percentage_of_time_gate_spec.rb
@@ -2,12 +2,12 @@ require 'helper'
 
 RSpec.describe Flipper::UI::Actions::PercentageOfTimeGate do
   let(:token) {
-  if Rack::Protection::AuthenticityToken.respond_to?(:random_token)
-    Rack::Protection::AuthenticityToken.random_token
-  else
-    "a"
-  end
-}
+    if Rack::Protection::AuthenticityToken.respond_to?(:random_token)
+      Rack::Protection::AuthenticityToken.random_token
+    else
+      "a"
+    end
+  }
   let(:session) { {:csrf => token} }
 
   describe "POST /features/:feature/percentage_of_time" do

--- a/spec/flipper/ui_spec.rb
+++ b/spec/flipper/ui_spec.rb
@@ -8,7 +8,13 @@ RSpec.describe Flipper::UI do
       "a"
     end
   }
-  let(:session) { {:csrf => token} }
+  let(:session) {
+    if Rack::Protection::AuthenticityToken.respond_to?(:random_token)
+      {:csrf => token}
+    else
+      {"_csrf_token" => token}
+    end
+  }
 
   describe "Initializing middleware with flipper instance" do
     let(:app) { build_app(flipper) }

--- a/spec/flipper/ui_spec.rb
+++ b/spec/flipper/ui_spec.rb
@@ -1,6 +1,15 @@
 require 'helper'
 
 RSpec.describe Flipper::UI do
+  let(:token) {
+    if Rack::Protection::AuthenticityToken.respond_to?(:random_token)
+      Rack::Protection::AuthenticityToken.random_token
+    else
+      "a"
+    end
+  }
+  let(:session) { {:csrf => token} }
+
   describe "Initializing middleware with flipper instance" do
     let(:app) { build_app(flipper) }
 
@@ -36,8 +45,8 @@ RSpec.describe Flipper::UI do
   # See https://github.com/jnunemaker/flipper/issues/80
   it "can route features with names that match static directories" do
     post "features/refactor-images/actors",
-      {"value" => "User:6", "operation" => "enable", "authenticity_token" => "a"},
-      "rack.session" => {"_csrf_token" => "a"}
+      {"value" => "User:6", "operation" => "enable", "authenticity_token" => token},
+      "rack.session" => session
     expect(last_response.status).to be(302)
     expect(last_response.headers["Location"]).to eq("/features/refactor-images")
   end


### PR DESCRIPTION
rack-protection no longer works with session["_csrf_token"], but does work with session[:csrf] in both 1.5.3 and 2.0.0.beta2 so I'm switching to :csrf. This also uses the random key method if it exists. Probably didn't need to do that, but it doesn't hurt anything.

refs #153 