### PR TITLE
display support for active_record adapter Rails 5

### DIFF
--- a/docs/Adapters.md
+++ b/docs/Adapters.md
@@ -8,7 +8,7 @@ I plan on supporting the adapters in the flipper repo. Other adapters are welcom
 * [PStore adapter](https://github.com/jnunemaker/flipper/blob/master/lib/flipper/adapters/pstore.rb) – great for when a local file is enough
 * [Mongo adapter](https://github.com/jnunemaker/flipper/blob/master/docs/mongo)
 * [Redis adapter](https://github.com/jnunemaker/flipper/blob/master/docs/redis)
-* [ActiveRecord adapter](https://github.com/jnunemaker/flipper/blob/master/docs/active_record) - Rails 3 and 4.
+* [ActiveRecord adapter](https://github.com/jnunemaker/flipper/blob/master/docs/active_record) - Rails 3, 4, and 5.
 * [Cassanity adapter](https://github.com/jnunemaker/flipper-cassanity)
 
 ## Community Supported


### PR DESCRIPTION
Looks like its safe to say active_record adapter is working with Rails 5 since active_record.gemspec now has dependency at ">= 3.2", "< 6" and Travis is testing Rails5 and changelog says support as of Flipper-0.9.1 🎉