### PR TITLE
Add Api V1 groups gate endpoint

### DIFF
--- a/lib/flipper/api/middleware.rb
+++ b/lib/flipper/api/middleware.rb
@@ -35,6 +35,7 @@ module Flipper
         end
 
         @action_collection = ActionCollection.new
+        @action_collection.add Api::V1::Actions::GroupsGate
         @action_collection.add Api::V1::Actions::BooleanGate
         @action_collection.add Api::V1::Actions::Feature
         @action_collection.add Api::V1::Actions::Features

--- a/lib/flipper/api/v1/actions/groups_gate.rb
+++ b/lib/flipper/api/v1/actions/groups_gate.rb
@@ -1,0 +1,49 @@
+require 'flipper/api/action'
+require 'flipper/api/v1/decorators/feature'
+
+module Flipper
+  module Api
+    module V1
+      module Actions
+        class GroupsGate < Api::Action
+          route %r{api/v1/features/[^/]*/groups/?\Z}
+
+          def post
+            ensure_valid_params
+            feature = flipper[feature_name]
+            feature.enable_group(group_name)
+            decorated_feature = Decorators::Feature.new(feature)
+            json_response(decorated_feature.as_json, 200)
+          end
+
+          def delete
+            ensure_valid_params
+            feature = flipper[feature_name]
+            feature.disable_group(group_name)
+            decorated_feature = Decorators::Feature.new(feature)
+            json_response(decorated_feature.as_json, 200)
+          end
+
+          private
+
+          def ensure_valid_params
+            json_response({ code: 1, message: 'Feature not found.', more_info: '' }, 404) unless feature_names.include?(feature_name)
+            json_response({ code: 2, message: 'Group not registered.', more_info: '' }, 404) unless Flipper.group_exists?(group_name)
+          end
+
+          def feature_name
+            @feature_name ||= Rack::Utils.unescape(path_parts[-2])
+          end
+
+          def group_name
+            @group_name ||= params['name']
+          end
+
+          def feature_names
+            @feature_names ||= flipper.adapter.features
+          end
+        end
+      end
+    end
+  end
+end

--- a/spec/flipper/api/v1/actions/groups_gate_spec.rb
+++ b/spec/flipper/api/v1/actions/groups_gate_spec.rb
@@ -1,0 +1,75 @@
+require 'helper'
+
+RSpec.describe Flipper::Api::V1::Actions::GroupsGate do
+  let(:app) { build_api(flipper) }
+
+  describe 'enable' do
+    before do
+      flipper[:my_feature].disable
+      Flipper.register(:admins) do |actor|
+        actor.respond_to?(:admin?) && actor.admin?
+      end
+      post '/api/v1/features/my_feature/groups', { name: 'admins' }
+    end
+
+    it 'enables feature for group' do
+      person = double
+      allow(person).to receive(:flipper_id).and_return(1)
+      allow(person).to receive(:admin?).and_return(true)
+      expect(last_response.status).to eq(200)
+      expect(flipper[:my_feature].enabled?(person)).to be_truthy
+    end
+
+    it 'returns decorated feature with group enabled' do
+      group_gate = json_response['gates'].find { |m| m['name'] == 'group' }
+      expect(group_gate['value']).to eq(['admins'])
+    end
+  end
+
+  describe 'disable' do
+    before do
+      flipper[:my_feature].disable
+      Flipper.register(:admins) do |actor|
+        actor.respond_to?(:admin?) && actor.admin?
+      end
+      flipper[:my_feature].enable_group(:admins)
+      delete '/api/v1/features/my_feature/groups', { name: 'admins' }
+    end
+
+    it 'disables feature for group' do
+      person = double
+      allow(person).to receive(:flipper_id).and_return(1)
+      allow(person).to receive(:admin?).and_return(true)
+      expect(last_response.status).to eq(200)
+      expect(flipper[:my_feature].enabled?(person)).to be_falsey
+    end
+
+    it 'returns decorated feature with group disabled' do
+      group_gate = json_response['gates'].find { |m| m['name'] == 'group' }
+      expect(group_gate['value']).to eq([])
+    end
+  end
+
+  describe 'non-existent feature' do
+    before do
+      delete '/api/v1/features/my_feature/groups', { name:  'admins' }
+    end
+
+    it  '404s with correct error response when feature does not exist' do
+      expect(last_response.status).to eq(404)
+      expect(json_response).to eq({ 'code' => 1, 'message' => 'Feature not found.', 'more_info' => '' })
+    end
+  end
+
+  describe 'group not registered' do
+    before do
+      flipper[:my_feature].disable
+      delete '/api/v1/features/my_feature/groups', { name: 'admins' }
+    end
+
+    it '404s with correct error response when group not registered' do
+      expect(last_response.status).to eq(404)
+      expect(json_response).to eq({ 'code' => 2, 'message' => 'Group not registered.', 'more_info' => '' })
+    end
+  end
+end


### PR DESCRIPTION
References #165 
Endpoint for enabling/disabling feature for a given group. I'm thinking we follow the naming convention with Boolean gate of using *route*/(enable | disable).

*api/v1/features/:feature_name/groups/:group_name/enable*
*api/v1/features/:feature_name/groups/:group_name/disable*

Given a feature *logging* and a group *admins*

`PUT api/v1/features/logging/groups/admins/enable # enables logging feature for admins group`
`PUT api/v1/features/logging/groups/admins/disable # disables logging feature for admins group`

I'm trying to think about how to handle errors:

it would be nice to know if you requested an unknown feature or non-registered group rather than just a generic 404.  Still haven't decided on an exception api for the api, but maybe:

{status: *http_code*, message: *error_mssage*}

i.e. {"status": 404,  message: "feature not found"}
      {"status": 404,  message: "group not registered"}

Also I'm checking if the group name is in `Flipper.groups` over rescuing *Flipper::GroupNotRegistered* since exception handling is slow. But it could be nice to rescue it since we get access to the Flipper Error messages such as "Group :group_name has not been registered", what do you think?


Also maybe this should be a post over put since its actually creating a Gate resource?