### PR TITLE
do not use mass assignment anymore for active record adapter

### DIFF
--- a/lib/flipper/adapters/active_record.rb
+++ b/lib/flipper/adapters/active_record.rb
@@ -45,10 +45,11 @@ module Flipper
 
       # Public: Adds a feature to the set of known features.
       def add(feature)
-        attributes = {key: feature.key}
         # race condition, but add is only used by enable/disable which happen
         # super rarely, so it shouldn't matter in practice
-        @feature_class.where(attributes).first || @feature_class.create!(attributes)
+        unless @feature_class.where(key: feature.key).first
+          @feature_class.create! { |f| f.key = feature.key }
+        end
         true
       end
 
@@ -111,18 +112,18 @@ module Flipper
               key: gate.key
             ).delete_all
 
-            @gate_class.create!({
-              feature_key: feature.key,
-              key: gate.key,
-              value: thing.value.to_s,
-            })
+            @gate_class.create! do |g|
+              g.feature_key = feature.key
+              g.key = gate.key
+              g.value = thing.value.to_s
+            end
           end
         when :set
-          @gate_class.create!({
-            feature_key: feature.key,
-            key: gate.key,
-            value: thing.value.to_s,
-          })
+          @gate_class.create! do |g|
+            g.feature_key = feature.key
+            g.key = gate.key
+            g.value = thing.value.to_s
+          end
         else
           unsupported_data_type gate.data_type
         end
@@ -148,11 +149,11 @@ module Flipper
               key: gate.key
             ).delete_all
 
-            @gate_class.create!({
-              feature_key: feature.key,
-              key: gate.key,
-              value: thing.value.to_s,
-            })
+            @gate_class.create! do |g|
+              g.feature_key = feature.key
+              g.key = gate.key
+              g.value = thing.value.to_s
+            end
           end
         when :set
           @gate_class.where(feature_key: feature.key, key: gate.key, value: thing.value).delete_all


### PR DESCRIPTION
fixes #161 
* rails 3 does not allow mass assignment.  This makes sure the active record adapter does not mass assign attributes