### PR TITLE
add flipper-api documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,6 +72,7 @@ Of course there are more [examples for you to peruse](examples/). You could also
 * [Instrumentation](docs/Instrumentation.md) - ActiveSupport::Notifications, Statsd and Metriks
 * [Optimization](docs/Optimization.md) - Memoization middleware and Cache adapters
 * [Web Interface](docs/ui/README.md) - Point and click...
+* [API](docs/api/README.md) - HTTP API interface
 * [Caveats](docs/Caveats.md) - Flipper beware! (see what I did there)
 
 ## Contributing

--- a/docs/api/README.md
+++ b/docs/api/README.md
@@ -1,0 +1,190 @@
+# Flipper::Api
+
+API for the [Flipper](https://github.com/jnunemaker/flipper) gem.
+
+## Installation
+
+Add this line to your application's Gemfile:
+
+    gem 'flipper-api'
+
+And then execute:
+
+    $ bundle
+
+Or install it yourself as:
+
+    $ gem install flipper-api
+
+## Endpoints
+
+### Get all features
+
+`GET /flipper-api/api/v1/features`
+
+**Response**
+
+Returns an array of feature objects:
+
+```json
+{
+  "features": [
+    {
+      "key": "search",
+      "state": "on",
+      "gates": [
+        {
+          "key": "boolean",
+          "name": "boolean",
+          "value": false
+        },
+        {
+          "key": "groups",
+          "name": "group",
+          "value": []
+        },
+        {
+          "key": "actors",
+          "name": "actor",
+          "value": []
+        },
+        {
+          "key": "percentage_of_actors",
+          "name": "percentage_of_actors",
+          "value": 0
+        },
+        {
+          "key": "percentage_of_time",
+          "name": "percentage_of_time",
+          "value": 0
+        }
+      ]
+    },
+    {
+      "key": "history",
+      "state": "off",
+      "gates": [
+        {
+          "key": "boolean",
+          "name": "boolean",
+          "value": false
+        },
+        {
+          "key": "groups",
+          "name": "group",
+          "value": []
+        },
+        {
+          "key": "actors",
+          "name": "actor",
+          "value": []
+        },
+        {
+          "key": "percentage_of_actors",
+          "name": "percentage_of_actors",
+          "value": 0
+        },
+        {
+          "key": "percentage_of_time",
+          "name": "percentage_of_time",
+          "value": 0
+        }
+      ]
+    }
+  ]
+}
+```
+
+### Create a new feature
+
+`POST /flipper-api/api/v1/features`
+
+**Parameters**
+
+* `name` - The name of the feature (Recommended naming conventions: lower case, snake case, underscores over dashes. Good: foo_bar, foo. Bad: FooBar, Foo Bar, foo bar, foo-bar.)
+
+**Response**
+
+On successful creation, the API will respond with an empty JSON response.
+
+### Retrieve a feature
+
+`GET /flipper-api/api/v1/features/{feature_name}`
+
+**Parameters**
+
+* `feature_name` - The name of the feature to retrieve
+
+**Response**
+
+Returns an individual feature object:
+
+```json
+{
+  "key": "search",
+  "state": "off",
+  "gates": [
+    {
+      "key": "boolean",
+      "name": "boolean",
+      "value": false
+    },
+    {
+      "key": "groups",
+      "name": "group",
+      "value": []
+    },
+    {
+      "key": "actors",
+      "name": "actor",
+      "value": []
+    },
+    {
+      "key": "percentage_of_actors",
+      "name": "percentage_of_actors",
+      "value": 0
+    },
+    {
+      "key": "percentage_of_time",
+      "name": "percentage_of_time",
+      "value": 0
+    }
+  ]
+}
+```
+
+### Delete a feature
+
+`DELETE /flipper-api/api/v1/features/{feature_name}`
+
+**Parameters**
+
+* `feature_name` - The name of the feature to delete
+
+**Response**
+
+Successful deletion of a feature will return a 204 No Content response.
+
+### Enable a feature
+
+`PUT /flipper-api/api/v1/feature/{feature_name}/enable`
+
+**Parameters**
+
+* `feature_name` - The name of the feature to enable
+
+**Response**
+
+Successful enabling of a feature will return a 204 No Content response.
+
+### Disable a feature
+
+`PUT /flipper-api/api/v1/feature/{feature_name}/disable`
+
+**Parameters**
+
+* `feature_name` - The name of the feature to disable
+
+**Response**
+
+Successful disabling of a feature will return a 204 No Content response.

--- a/docs/api/README.md
+++ b/docs/api/README.md
@@ -16,11 +16,34 @@ Or install it yourself as:
 
     $ gem install flipper-api
 
+## Usage
+
+`Flipper::Api` is a mountable application that can be included in your Rails/Ruby apps. In a Rails application, you can mount `Flipper::Api` to a route of your choice:
+
+```ruby
+# config/routes.rb
+YourRailsApp::Application.routes.draw do
+  mount Flipper::Api.app(flipper) => '/flipper-api'
+end
+```
+
+For more advanced mounting techniques and for suggestions on how to mount in a non-Rails application, it is recommend that you review the [`Flipper::UI` usage documentation](https://github.com/jnunemaker/flipper/blob/master/docs/ui/README.md#usage) as the same approaches apply to `Flipper::Api`.
+
 ## Endpoints
+
+**Note:** Example CURL requests below assume a mount point of `/flipper-api`.
 
 ### Get all features
 
-`GET /flipper-api/api/v1/features`
+**URL**
+
+`GET /api/v1/features`
+
+**Request**
+
+```
+curl http://example.com/flipper-api/api/v1/features
+```
 
 **Response**
 
@@ -97,11 +120,19 @@ Returns an array of feature objects:
 
 ### Create a new feature
 
-`POST /flipper-api/api/v1/features`
+**URL**
+
+`POST /api/v1/features`
 
 **Parameters**
 
 * `name` - The name of the feature (Recommended naming conventions: lower case, snake case, underscores over dashes. Good: foo_bar, foo. Bad: FooBar, Foo Bar, foo bar, foo-bar.)
+
+**Request**
+
+```
+curl -X POST -d "name=reports" http://example.com/flipper-api/api/v1/features
+```
 
 **Response**
 
@@ -109,11 +140,19 @@ On successful creation, the API will respond with an empty JSON response.
 
 ### Retrieve a feature
 
-`GET /flipper-api/api/v1/features/{feature_name}`
+**URL**
+
+`GET /api/v1/features/{feature_name}`
 
 **Parameters**
 
 * `feature_name` - The name of the feature to retrieve
+
+**Request**
+
+```
+curl http://example.com/flipper-api/api/v1/features/reports
+```
 
 **Response**
 
@@ -155,11 +194,19 @@ Returns an individual feature object:
 
 ### Delete a feature
 
-`DELETE /flipper-api/api/v1/features/{feature_name}`
+**URL**
+
+`DELETE /api/v1/features/{feature_name}`
 
 **Parameters**
 
 * `feature_name` - The name of the feature to delete
+
+**Request**
+
+```
+curl -X DELETE http://example.com/flipper-api/api/v1/features/reports
+```
 
 **Response**
 
@@ -167,11 +214,19 @@ Successful deletion of a feature will return a 204 No Content response.
 
 ### Enable a feature
 
-`PUT /flipper-api/api/v1/feature/{feature_name}/enable`
+**URL**
+
+`PUT /api/v1/feature/{feature_name}/enable`
 
 **Parameters**
 
 * `feature_name` - The name of the feature to enable
+
+**Request**
+
+```
+curl -X PUT http://example.com/flipper-api/api/v1/features/reports/enable
+```
 
 **Response**
 
@@ -179,11 +234,19 @@ Successful enabling of a feature will return a 204 No Content response.
 
 ### Disable a feature
 
-`PUT /flipper-api/api/v1/feature/{feature_name}/disable`
+**URL**
+
+`PUT /api/v1/feature/{feature_name}/disable`
 
 **Parameters**
 
 * `feature_name` - The name of the feature to disable
+
+**Request**
+
+```
+curl -X PUT http://example.com/flipper-api/api/v1/features/reports/disable
+```
 
 **Response**
 


### PR DESCRIPTION
I was looking at using the `flipper-api` but found that it lacked documentation so while documenting it for my own purposes, I decided it'd be better to contribute upstream. I've documented all of the API endpoints that currently exist.

Note: I wasn't sure if a `Usage` section was necessary or not as it'd be virtually the same as that of `flipper-ui` in terms of mounting, etc. so I left that out for now. But it is probably worth noting in some way as the `/flipper-api` path used in the documentation examples assumes a mount point so I'm curious what your thoughts are on that.

Thanks!