### PR TITLE
changes boolean gate route to api/v1/features/boolean

### DIFF
--- a/lib/flipper/api/v1/actions/boolean_gate.rb
+++ b/lib/flipper/api/v1/actions/boolean_gate.rb
@@ -5,13 +5,19 @@ module Flipper
     module V1
       module Actions
         class BooleanGate < Api::Action
-          route %r{api/v1/features/[^/]*/(enable|disable)/?\Z}
-          
-          def put
+          route %r{api/v1/features/[^/]*/boolean/?\Z}
+
+          def post
             feature_name = Rack::Utils.unescape(path_parts[-2])
             feature = flipper[feature_name.to_sym]
-            action = Rack::Utils.unescape(path_parts.last)
-            feature.send(action)
+            feature.enable
+            json_response({}, 204)
+          end
+
+          def delete
+            feature_name = Rack::Utils.unescape(path_parts[-2])
+            feature = flipper[feature_name.to_sym]
+            feature.disable
             json_response({}, 204)
           end
         end

--- a/spec/flipper/api/v1/actions/boolean_gate_spec.rb
+++ b/spec/flipper/api/v1/actions/boolean_gate_spec.rb
@@ -6,7 +6,7 @@ RSpec.describe Flipper::Api::V1::Actions::BooleanGate do
   describe 'enable' do
     before do
       flipper[:my_feature].disable
-      put '/api/v1/features/my_feature/enable'
+      post '/api/v1/features/my_feature/boolean'
     end
 
     it 'enables feature' do
@@ -18,22 +18,12 @@ RSpec.describe Flipper::Api::V1::Actions::BooleanGate do
   describe 'disable' do
     before do
       flipper[:my_feature].enable
-      put '/api/v1/features/my_feature/disable'
+      delete '/api/v1/features/my_feature/boolean'
     end
 
     it 'disables feature' do
       expect(last_response.status).to eq(204)
       expect(flipper[:my_feature].off?).to be_truthy
-    end
-  end
-
-  describe 'invalid paremeter' do
-    before do
-      put '/api/v1/features/my_feature/invalid_param'
-    end
-
-    it 'responds with 404 when not sent enable or disable parameter' do
-      expect(last_response.status).to eq(404)
     end
   end
 end


### PR DESCRIPTION
* this is convention we're going for with api gates

`POST api/v1/features/:feature_name/:gate_name # enable`

`DELETE api/v1/features/:feature_name/:gate_name # disable`

discussion about this can be found at #166 