### PR TITLE
Make Flipper::UI.app.inspect return a String

### DIFF
--- a/lib/flipper/ui.rb
+++ b/lib/flipper/ui.rb
@@ -45,7 +45,7 @@ module Flipper
       builder.use Middleware, flipper
       builder.run app
       klass = self
-      builder.define_singleton_method(:inspect) { klass } # pretty rake routes output
+      builder.define_singleton_method(:inspect) { klass.inspect } # pretty rake routes output
       builder
     end
   end

--- a/spec/flipper/ui_spec.rb
+++ b/spec/flipper/ui_spec.rb
@@ -48,6 +48,12 @@ RSpec.describe Flipper::UI do
     end
   end
 
+  describe "Inspecting the built Rack app" do
+    it "returns a String" do
+      expect(build_app(flipper).inspect).to be_a(String)
+    end
+  end
+
   # See https://github.com/jnunemaker/flipper/issues/80
   it "can route features with names that match static directories" do
     post "features/refactor-images/actors",


### PR DESCRIPTION
Mounting a v0.9.2 `Flipper::UI.app` `Rack::Builder` instance in a
v4.2.7.1 Rails `config/routes.rb` file and running `bin/rake routes` was
resulting in the following error.

    rake aborted!
    NoMethodError: undefined method `+' for Flipper::UI:Module
    /gems/actionpack-4.2.7.1/lib/action_dispatch/routing/inspector.rb:54:in `reqs'
    /gems/actionpack-4.2.7.1/lib/action_dispatch/routing/inspector.rb:128:in `block in collect_routes'
    /gems/actionpack-4.2.7.1/lib/action_dispatch/routing/inspector.rb:122:in `collect'
    /gems/actionpack-4.2.7.1/lib/action_dispatch/routing/inspector.rb:122:in `collect_routes'
    /gems/actionpack-4.2.7.1/lib/action_dispatch/routing/inspector.rb:89:in `format'
    /gems/railties-4.2.7.1/lib/rails/tasks/routes.rake:6:in `block in <top (required)>'

This was because the `Rack::Builder` instance returned by
`Flipper::UI.app` responded to the `inspect` call with a `Module`
instead of a `String`.

In order to make the `Rack::Builder` instance returned behave like most
other Ruby objects, fixing the broken invocation of `bin/rake routes`
mentioned above, we make `inspect` return a `String` again.

Ref: https://github.com/jnunemaker/flipper/pull/148
Ref: http://ruby-doc.org/core-2.3.1/Object.html#method-i-inspect