### PR TITLE
update api v1 boolean gate endpoint responses to follow conventions for gate endpoints

### DIFF
--- a/lib/flipper/api/v1/actions/boolean_gate.rb
+++ b/lib/flipper/api/v1/actions/boolean_gate.rb
@@ -1,4 +1,5 @@
 require 'flipper/api/action'
+require 'flipper/api/v1/decorators/feature'
 
 module Flipper
   module Api
@@ -9,16 +10,18 @@ module Flipper
 
           def post
             feature_name = Rack::Utils.unescape(path_parts[-2])
-            feature = flipper[feature_name.to_sym]
+            feature = flipper[feature_name]
             feature.enable
-            json_response({}, 204)
+            decorated_feature = Decorators::Feature.new(feature)
+            json_response(decorated_feature.as_json, 200)
           end
 
           def delete
             feature_name = Rack::Utils.unescape(path_parts[-2])
             feature = flipper[feature_name.to_sym]
             feature.disable
-            json_response({}, 204)
+            decorated_feature = Decorators::Feature.new(feature)
+            json_response(decorated_feature.as_json, 200)
           end
         end
       end

--- a/spec/flipper/api/v1/actions/boolean_gate_spec.rb
+++ b/spec/flipper/api/v1/actions/boolean_gate_spec.rb
@@ -10,8 +10,13 @@ RSpec.describe Flipper::Api::V1::Actions::BooleanGate do
     end
 
     it 'enables feature' do
-      expect(last_response.status).to eq(204)
+      expect(last_response.status).to eq(200)
       expect(flipper[:my_feature].on?).to be_truthy
+    end
+
+    it 'returns decorated feature with boolean gate enabled' do
+      boolean_gate = json_response['gates'].find { |gate| gate['key'] == 'boolean' }
+      expect(boolean_gate['value']).to be_truthy
     end
   end
 
@@ -22,8 +27,13 @@ RSpec.describe Flipper::Api::V1::Actions::BooleanGate do
     end
 
     it 'disables feature' do
-      expect(last_response.status).to eq(204)
+      expect(last_response.status).to eq(200)
       expect(flipper[:my_feature].off?).to be_truthy
+    end
+
+    it 'returns decorated feature with boolean gate disabled' do
+      boolean_gate = json_response['gates'].find { |gate| gate['key'] == 'boolean' }
+      expect(boolean_gate['value']).to be_falsy
     end
   end
 end


### PR DESCRIPTION
All successful gate endpoint actions will return:

1.  200 http status code
2. decorated feature

* this is the convention that all gates (enable/disable) endpoints will follow