### PR TITLE
Makes Api V1 error responses reusable and standardized

### DIFF
--- a/lib/flipper/api/action.rb
+++ b/lib/flipper/api/action.rb
@@ -1,5 +1,6 @@
 require 'forwardable'
 require 'flipper/api/error'
+require 'flipper/api/error_response'
 require 'json'
 
 module Flipper
@@ -88,11 +89,27 @@ module Flipper
         throw :halt, response
       end
 
+      # Public: Call this with a json serializable object (i.e. Hash)
+      # to serialize object and respond to request
+      #
+      # object - json serializable object
+      # status - http status code
+
       def json_response(object, status = 200)
         header 'Content-Type', Api::CONTENT_TYPE
         status(status)
         body = JSON.dump(object)
         halt [@code, @headers, [body]]
+      end
+
+      # Public: Call this with an ErrorResponse::ERRORS key to respond
+      # with the serialized error object as response body
+      #
+      # error_key - key to lookup error object
+
+      def json_error_response(error_key)
+        error = ErrorResponse::ERRORS.fetch(error_key.to_sym)
+        json_response(error.as_json, error.http_status)
       end
 
       # Public: Set the status code for the response.

--- a/lib/flipper/api/error_response.rb
+++ b/lib/flipper/api/error_response.rb
@@ -1,0 +1,29 @@
+module Flipper
+  module Api
+    module ErrorResponse
+      class Error
+        attr_reader :http_status
+
+        def initialize(code, message, info, http_status)
+          @code = code
+          @message = message
+          @more_info = info
+          @http_status = http_status
+        end
+
+        def as_json
+          {
+            code: @code,
+            message: @message,
+            more_info: @more_info,
+          }
+        end
+      end
+
+      ERRORS = {
+        feature_not_found: Error.new(1, "Feature not found.", "", 404),
+        group_not_registered: Error.new(2, "Group not registered.", "", 404),
+      }
+    end
+  end
+end

--- a/lib/flipper/api/v1/actions/groups_gate.rb
+++ b/lib/flipper/api/v1/actions/groups_gate.rb
@@ -27,8 +27,8 @@ module Flipper
           private
 
           def ensure_valid_params
-            json_response({ code: 1, message: 'Feature not found.', more_info: '' }, 404) unless feature_names.include?(feature_name)
-            json_response({ code: 2, message: 'Group not registered.', more_info: '' }, 404) unless Flipper.group_exists?(group_name)
+            json_error_response(:feature_not_found) unless feature_names.include?(feature_name)
+            json_error_response(:group_not_registered) unless Flipper.group_exists?(group_name)
           end
 
           def feature_name


### PR DESCRIPTION
* moves error codes / as_json logic into descriptive module and provides `json_error_response` method to all actions

* `json_error_response` is very clear you're rendering an error as opposed to a successful response

* adds specs

* updates Groups Gate endpoint to use this error response format

we get to take advantage of Ruby's `fetch` so a KeyError will be raised if pass in an invalid error key, and also I like this approach because we get an api on top of directly accessing the hash, just use json_error_response(:error_key, status) and everything just works