### PR TITLE
Api V1 percentage_of_actors gate endpoint

### DIFF
--- a/lib/flipper/api/error_response.rb
+++ b/lib/flipper/api/error_response.rb
@@ -23,6 +23,7 @@ module Flipper
       ERRORS = {
         feature_not_found: Error.new(1, "Feature not found.", "", 404),
         group_not_registered: Error.new(2, "Group not registered.", "", 404),
+        percentage_invalid: Error.new(3, "Percentage must be a positive number less than or equal to 100.", "", 400),
       }
     end
   end

--- a/lib/flipper/api/middleware.rb
+++ b/lib/flipper/api/middleware.rb
@@ -35,6 +35,7 @@ module Flipper
         end
 
         @action_collection = ActionCollection.new
+        @action_collection.add Api::V1::Actions::PercentageOfActorsGate
         @action_collection.add Api::V1::Actions::GroupsGate
         @action_collection.add Api::V1::Actions::BooleanGate
         @action_collection.add Api::V1::Actions::Feature

--- a/lib/flipper/api/v1/actions/percentage_of_actors_gate.rb
+++ b/lib/flipper/api/v1/actions/percentage_of_actors_gate.rb
@@ -1,0 +1,57 @@
+require 'flipper/api/action'
+require 'flipper/api/v1/decorators/feature'
+
+module Flipper
+  module Api
+    module V1
+      module Actions
+        class PercentageOfActorsGate < Api::Action
+          route %r{api/v1/features/[^/]*/percentage_of_actors/?\Z}
+
+          def post
+            ensure_valid_enable_params
+            feature = flipper[feature_name]
+            feature.enable_percentage_of_actors(percentage)
+            decorated_feature = Decorators::Feature.new(feature)
+            json_response(decorated_feature.as_json, 200)
+          end
+
+          def delete
+            ensure_valid_disable_params
+            feature = flipper[feature_name]
+            feature.disable_percentage_of_actors
+            decorated_feature = Decorators::Feature.new(feature)
+            json_response(decorated_feature.as_json, 200)
+          end
+
+          private
+
+          def ensure_valid_enable_params
+            json_error_response(:feature_not_found) unless feature_names.include?(feature_name)
+            json_error_response(:percentage_invalid) unless percentage >= 0 && percentage <= 100
+          end
+
+          def ensure_valid_disable_params
+            json_error_response(:feature_not_found) unless feature_names.include?(feature_name)
+          end
+
+          def feature_name
+            @feature_name ||= Rack::Utils.unescape(path_parts[-2])
+          end
+
+          def percentage
+            @percentage ||= begin
+                              Integer(params['percentage'])
+                            rescue ArgumentError, TypeError
+                              -1
+                            end
+          end
+
+            def feature_names
+              @feature_names ||= flipper.adapter.features
+            end
+          end
+        end
+      end
+    end
+  end

--- a/spec/flipper/api/v1/actions/percentage_of_actors_gate_spec.rb
+++ b/spec/flipper/api/v1/actions/percentage_of_actors_gate_spec.rb
@@ -1,0 +1,85 @@
+require 'helper'
+
+RSpec.describe Flipper::Api::V1::Actions::PercentageOfActorsGate do
+  let(:app) { build_api(flipper) }
+
+  describe 'enable' do
+    before do
+      flipper[:my_feature].disable
+      post '/api/v1/features/my_feature/percentage_of_actors', { percentage: '10' }
+    end
+
+    it 'enables gate for feature' do
+      expect(flipper[:my_feature].enabled_gate_names).to include(:percentage_of_actors)
+    end
+
+    it 'returns decorated feature with gate enabled for 10 percent of actors' do
+      gate = json_response['gates'].find { |gate| gate['name'] == 'percentage_of_actors' }
+      expect(gate['value']).to eq(10)
+    end
+
+  end
+
+  describe 'disable' do
+    before do
+      flipper[:my_feature].disable
+      delete '/api/v1/features/my_feature/percentage_of_actors'
+    end
+
+    it 'disables gate for feature' do
+      expect(flipper[:my_feature].enabled_gates).to be_empty
+    end
+
+    it 'returns decorated feature with gate disabled' do
+      gate = json_response['gates'].find { |gate| gate['name'] == 'percentage_of_actors' }
+      expect(gate['value']).to eq(0)
+    end
+  end
+
+  describe 'non-existent feature' do
+    before do
+      delete '/api/v1/features/my_feature/percentage_of_actors'
+    end
+
+    it  '404s with correct error response when feature does not exist' do
+      expect(last_response.status).to eq(404)
+      expect(json_response).to eq({ 'code' => 1, 'message' => 'Feature not found.', 'more_info' => '' })
+    end
+  end
+
+  describe 'out of range parameter percentage parameter' do
+    before do
+      flipper[:my_feature].disable
+      post '/api/v1/features/my_feature/percentage_of_actors', { percentage: '300' }
+    end
+
+    it '400s with correct error response when percentage parameter is invalid' do
+      expect(last_response.status).to eq(400)
+      expect(json_response).to eq({ 'code' => 3, 'message' => 'Percentage must be a positive number less than or equal to 100.', 'more_info' => '' })
+    end
+  end
+
+  describe 'percentage parameter not an integer' do
+    before do
+      flipper[:my_feature].disable
+      post '/api/v1/features/my_feature/percentage_of_actors', { percentage: 'foo' }
+    end
+
+    it '400s with correct error response when percentage parameter is invalid' do
+      expect(last_response.status).to eq(400)
+      expect(json_response).to eq({ 'code' => 3, 'message' => 'Percentage must be a positive number less than or equal to 100.', 'more_info' => '' })
+    end
+  end
+
+  describe 'missing percentage parameter' do
+    before do
+      flipper[:my_feature].disable
+      post '/api/v1/features/my_feature/percentage_of_actors'
+    end
+
+    it '400s with correct error response when percentage parameter is missing' do
+      expect(last_response.status).to eq(400)
+      expect(json_response).to eq({ 'code' => 3, 'message' => 'Percentage must be a positive number less than or equal to 100.', 'more_info' => '' })
+    end
+  end
+end


### PR DESCRIPTION
* POST / DELETE request to enable / disable

* *send parameter 'percentage' to request percentage to enable 

* only POST requires a percentage parameter to be passed with request

* percentage_invalid raised and returned if percentage param is missing or not <= 100.  I like the name because it keeps with the convention:

:{ thing } _ { error_description }
i.e.
:{feature} _ {not_found}
:{group} _ {not_registered}
:{percentage } _ {invalid}

* uses regex to make sure percentage parameter is a number <= 100.  This is powerful because it handles all the edge cases, and we can keep it in the ensure_valid_post_params method

1. parameter is missing
2. parameter is empty string or nil
3. parameter is out of range

* adds specs