### PR TITLE
add api v1 actors gate endpoint

### DIFF
--- a/lib/flipper/api.rb
+++ b/lib/flipper/api.rb
@@ -1,6 +1,7 @@
 require 'rack'
 require 'flipper'
 require 'flipper/api/middleware'
+require 'flipper/api/actor'
 
 module Flipper
   module Api

--- a/lib/flipper/api/actor.rb
+++ b/lib/flipper/api/actor.rb
@@ -1,0 +1,13 @@
+module Flipper
+  module Api
+    # Internal: Shim for turning a string flipper id into something that responds to
+    # flipper_id for Flipper::Types::Actor.
+    class Actor
+      attr_reader :flipper_id
+
+      def initialize(flipper_id)
+        @flipper_id = flipper_id
+      end
+    end
+  end
+end

--- a/lib/flipper/api/error_response.rb
+++ b/lib/flipper/api/error_response.rb
@@ -24,6 +24,7 @@ module Flipper
         feature_not_found: Error.new(1, "Feature not found.", "", 404),
         group_not_registered: Error.new(2, "Group not registered.", "", 404),
         percentage_invalid: Error.new(3, "Percentage must be a positive number less than or equal to 100.", "", 400),
+        flipper_id_invalid: Error.new(4, "Required parameter flipper_id is missing.", "", 400),
       }
     end
   end

--- a/lib/flipper/api/middleware.rb
+++ b/lib/flipper/api/middleware.rb
@@ -37,6 +37,7 @@ module Flipper
         @action_collection = ActionCollection.new
         @action_collection.add Api::V1::Actions::PercentageOfTimeGate
         @action_collection.add Api::V1::Actions::PercentageOfActorsGate
+        @action_collection.add Api::V1::Actions::ActorsGate
         @action_collection.add Api::V1::Actions::GroupsGate
         @action_collection.add Api::V1::Actions::BooleanGate
         @action_collection.add Api::V1::Actions::Feature

--- a/lib/flipper/api/v1/actions/actors_gate.rb
+++ b/lib/flipper/api/v1/actions/actors_gate.rb
@@ -1,0 +1,54 @@
+require 'flipper/api/action'
+require 'flipper/api/v1/decorators/feature'
+
+module Flipper
+  module Api
+    module V1
+      module Actions
+        class ActorsGate < Api::Action
+          route %r{api/v1/features/[^/]*/actors/?\Z}
+
+          def post
+            ensure_valid_params
+            feature = flipper[feature_name]
+            actor = Actor.new(flipper_id)
+            feature.enable_actor(actor)
+            decorated_feature = Decorators::Feature.new(feature)
+            json_response(decorated_feature.as_json, 200)
+          end
+
+          def delete
+            ensure_valid_params
+            feature = flipper[feature_name]
+            actor = Actor.new(flipper_id)
+            feature.disable_actor(actor)
+            decorated_feature = Decorators::Feature.new(feature)
+            json_response(decorated_feature.as_json, 200)
+          end
+
+          private
+
+          def ensure_valid_params
+            unless feature_names.include?(feature_name)
+              json_error_response(:feature_not_found)
+            end
+
+            json_error_response(:flipper_id_invalid) if flipper_id.nil?
+          end
+
+          def feature_name
+            @feature_name ||= Rack::Utils.unescape(path_parts[-2])
+          end
+
+          def flipper_id
+            @flipper_id ||= params['flipper_id']
+          end
+
+          def feature_names
+            @feature_names ||= flipper.adapter.features
+          end
+        end
+      end
+    end
+  end
+end

--- a/spec/flipper/api/v1/actions/actors_gate_spec.rb
+++ b/spec/flipper/api/v1/actions/actors_gate_spec.rb
@@ -1,0 +1,115 @@
+require 'helper'
+
+RSpec.describe Flipper::Api::V1::Actions::ActorsGate do
+  let(:app) { build_api(flipper) }
+
+  describe 'enable' do
+    let(:actor) { Flipper::Api::Actor.new("1") }
+
+    before do
+      flipper[:my_feature].disable_actor(actor)
+      post '/api/v1/features/my_feature/actors', { flipper_id: actor.flipper_id }
+    end
+
+    it 'enables feature for actor' do
+      expect(last_response.status).to eq(200)
+      expect(flipper[:my_feature].enabled?(actor)).to be_truthy
+      expect(flipper[:my_feature].enabled_gate_names).to eq([:actor])
+    end
+
+    it 'returns decorated feature with actor enabled' do
+      gate = json_response['gates'].find { |gate| gate['key'] == 'actors' }
+      expect(gate['value']).to eq(["1"])
+    end
+  end
+
+  describe 'disable' do
+    let(:actor) { Flipper::Api::Actor.new("1") }
+
+    before do
+      flipper[:my_feature].enable_actor(actor)
+      delete '/api/v1/features/my_feature/actors', { flipper_id: actor.flipper_id }
+    end
+
+    it 'disables feature' do
+      expect(last_response.status).to eq(200)
+      expect(flipper[:my_feature].enabled?(actor)).to be_falsy
+      expect(flipper[:my_feature].enabled_gate_names).to be_empty
+    end
+
+    it 'returns decorated feature with boolean gate disabled' do
+      gate = json_response['gates'].find { |gate| gate['key'] == 'actors' }
+      expect(gate['value']).to be_empty
+    end
+  end
+
+  describe 'enable missing flipper_id parameter' do
+    before do
+      flipper[:my_feature].enable
+      post '/api/v1/features/my_feature/actors'
+    end
+
+    it 'returns correct error response' do
+      expect(last_response.status).to eq(400)
+      expect(json_response).to eq({ 'code' => 4, 'message' => 'Required parameter flipper_id is missing.', 'more_info' => '' })
+    end
+  end
+
+  describe 'disable missing flipper_id parameter' do
+    before do
+      flipper[:my_feature].enable
+      delete '/api/v1/features/my_feature/actors'
+    end
+
+    it 'returns correct error response' do
+      expect(last_response.status).to eq(400)
+      expect(json_response).to eq({ 'code' => 4, 'message' => 'Required parameter flipper_id is missing.', 'more_info' => '' })
+    end
+  end
+
+  describe 'enable nil flipper_id parameter' do
+    before do
+      flipper[:my_feature].enable
+      post '/api/v1/features/my_feature/actors', { flipper_id: nil }
+    end
+
+    it 'returns correct error response' do
+      expect(last_response.status).to eq(400)
+      expect(json_response).to eq({ 'code' => 4, 'message' => 'Required parameter flipper_id is missing.', 'more_info' => '' })
+    end
+  end
+
+  describe 'disable nil flipper_id parameter' do
+    before do
+      flipper[:my_feature].enable
+      delete '/api/v1/features/my_feature/actors', { flipper_id: nil }
+    end
+
+    it 'returns correct error response' do
+      expect(last_response.status).to eq(400)
+      expect(json_response).to eq({ 'code' => 4, 'message' => 'Required parameter flipper_id is missing.', 'more_info' => '' })
+    end
+  end
+
+  describe 'enable missing feature' do
+    before do
+      post '/api/v1/features/my_feature/actors'
+    end
+
+    it 'returns correct error response' do
+      expect(last_response.status).to eq(404)
+      expect(json_response).to eq({ 'code' => 1, 'message' => 'Feature not found.', 'more_info' => '' })
+    end
+  end
+
+  describe 'disable missing feature' do
+    before do
+      delete '/api/v1/features/my_feature/actors'
+    end
+
+    it 'returns correct error response' do
+      expect(last_response.status).to eq(404)
+      expect(json_response).to eq({ 'code' => 1, 'message' => 'Feature not found.', 'more_info' => '' })
+    end
+  end
+end


### PR DESCRIPTION
completes #169 
* POST / DELETE to enable disable with 'flipper_id' parameter
* adds specs
* adds Fliper::Api::Actor shim just like UI

Returns error if flipper_id parameter is missing or nil.  Flipper allows enabling an actor with a nil flipper_id, and I thought about allowing this and only rendering error on missing flipper_id parameter, but the more I think about it I don't think its ideal for a user to do this.  A flipper id should ideally be unique.  It opens the door for accidentally enabling a feature for anything with a nil flipper_id and users wanting to do this are better off using the group gate right?  Let me know your thoughts

Figured its easier to review small PRs so will update invalid error responses to 422, or can do it in this PR as a separate commit if you'd like