### PR TITLE
use 422 status code for flipper_id_invalid, perecentage_invalid

### DIFF
--- a/lib/flipper/api/error_response.rb
+++ b/lib/flipper/api/error_response.rb
@@ -23,8 +23,8 @@ module Flipper
       ERRORS = {
         feature_not_found: Error.new(1, "Feature not found.", "", 404),
         group_not_registered: Error.new(2, "Group not registered.", "", 404),
-        percentage_invalid: Error.new(3, "Percentage must be a positive number less than or equal to 100.", "", 400),
-        flipper_id_invalid: Error.new(4, "Required parameter flipper_id is missing.", "", 400),
+        percentage_invalid: Error.new(3, "Percentage must be a positive number less than or equal to 100.", "", 422),
+        flipper_id_invalid: Error.new(4, "Required parameter flipper_id is missing.", "", 422),
       }
     end
   end

--- a/spec/flipper/api/v1/actions/actors_gate_spec.rb
+++ b/spec/flipper/api/v1/actions/actors_gate_spec.rb
@@ -50,7 +50,7 @@ RSpec.describe Flipper::Api::V1::Actions::ActorsGate do
     end
 
     it 'returns correct error response' do
-      expect(last_response.status).to eq(400)
+      expect(last_response.status).to eq(422)
       expect(json_response).to eq({ 'code' => 4, 'message' => 'Required parameter flipper_id is missing.', 'more_info' => '' })
     end
   end
@@ -62,7 +62,7 @@ RSpec.describe Flipper::Api::V1::Actions::ActorsGate do
     end
 
     it 'returns correct error response' do
-      expect(last_response.status).to eq(400)
+      expect(last_response.status).to eq(422)
       expect(json_response).to eq({ 'code' => 4, 'message' => 'Required parameter flipper_id is missing.', 'more_info' => '' })
     end
   end
@@ -74,7 +74,7 @@ RSpec.describe Flipper::Api::V1::Actions::ActorsGate do
     end
 
     it 'returns correct error response' do
-      expect(last_response.status).to eq(400)
+      expect(last_response.status).to eq(422)
       expect(json_response).to eq({ 'code' => 4, 'message' => 'Required parameter flipper_id is missing.', 'more_info' => '' })
     end
   end
@@ -86,7 +86,7 @@ RSpec.describe Flipper::Api::V1::Actions::ActorsGate do
     end
 
     it 'returns correct error response' do
-      expect(last_response.status).to eq(400)
+      expect(last_response.status).to eq(422)
       expect(json_response).to eq({ 'code' => 4, 'message' => 'Required parameter flipper_id is missing.', 'more_info' => '' })
     end
   end

--- a/spec/flipper/api/v1/actions/percentage_of_actors_gate_spec.rb
+++ b/spec/flipper/api/v1/actions/percentage_of_actors_gate_spec.rb
@@ -53,8 +53,8 @@ RSpec.describe Flipper::Api::V1::Actions::PercentageOfActorsGate do
       post '/api/v1/features/my_feature/percentage_of_actors', { percentage: '300' }
     end
 
-    it '400s with correct error response when percentage parameter is invalid' do
-      expect(last_response.status).to eq(400)
+    it '422s with correct error response when percentage parameter is invalid' do
+      expect(last_response.status).to eq(422)
       expect(json_response).to eq({ 'code' => 3, 'message' => 'Percentage must be a positive number less than or equal to 100.', 'more_info' => '' })
     end
   end
@@ -65,8 +65,8 @@ RSpec.describe Flipper::Api::V1::Actions::PercentageOfActorsGate do
       post '/api/v1/features/my_feature/percentage_of_actors', { percentage: 'foo' }
     end
 
-    it '400s with correct error response when percentage parameter is invalid' do
-      expect(last_response.status).to eq(400)
+    it '422s with correct error response when percentage parameter is invalid' do
+      expect(last_response.status).to eq(422)
       expect(json_response).to eq({ 'code' => 3, 'message' => 'Percentage must be a positive number less than or equal to 100.', 'more_info' => '' })
     end
   end
@@ -77,8 +77,8 @@ RSpec.describe Flipper::Api::V1::Actions::PercentageOfActorsGate do
       post '/api/v1/features/my_feature/percentage_of_actors'
     end
 
-    it '400s with correct error response when percentage parameter is missing' do
-      expect(last_response.status).to eq(400)
+    it '422s with correct error response when percentage parameter is missing' do
+      expect(last_response.status).to eq(422)
       expect(json_response).to eq({ 'code' => 3, 'message' => 'Percentage must be a positive number less than or equal to 100.', 'more_info' => '' })
     end
   end

--- a/spec/flipper/api/v1/actions/percentage_of_time_gate_spec.rb
+++ b/spec/flipper/api/v1/actions/percentage_of_time_gate_spec.rb
@@ -52,8 +52,8 @@ RSpec.describe Flipper::Api::V1::Actions::PercentageOfTimeGate do
       post '/api/v1/features/my_feature/percentage_of_time', { percentage: '300' }
     end
 
-    it '400s with correct error response when percentage parameter is invalid' do
-      expect(last_response.status).to eq(400)
+    it '422s with correct error response when percentage parameter is invalid' do
+      expect(last_response.status).to eq(422)
       expect(json_response).to eq({ 'code' => 3, 'message' => 'Percentage must be a positive number less than or equal to 100.', 'more_info' => '' })
     end
   end
@@ -64,8 +64,8 @@ RSpec.describe Flipper::Api::V1::Actions::PercentageOfTimeGate do
       post '/api/v1/features/my_feature/percentage_of_time', { percentage: 'foo' }
     end
 
-    it '400s with correct error response when percentage parameter is invalid' do
-      expect(last_response.status).to eq(400)
+    it '422s with correct error response when percentage parameter is invalid' do
+      expect(last_response.status).to eq(422)
       expect(json_response).to eq({ 'code' => 3, 'message' => 'Percentage must be a positive number less than or equal to 100.', 'more_info' => '' })
     end
   end
@@ -76,8 +76,8 @@ RSpec.describe Flipper::Api::V1::Actions::PercentageOfTimeGate do
       post '/api/v1/features/my_feature/percentage_of_time'
     end
 
-    it '400s with correct error response when percentage parameter is missing' do
-      expect(last_response.status).to eq(400)
+    it '422s with correct error response when percentage parameter is missing' do
+      expect(last_response.status).to eq(422)
       expect(json_response).to eq({ 'code' => 3, 'message' => 'Percentage must be a positive number less than or equal to 100.', 'more_info' => '' })
     end
   end


### PR DESCRIPTION
Prefer 422 to 400 http status code for some errors
- flipper_id_invalid
- percentage_invalid

Was using 400, but 422 is much more specific and describes an error in
the request message as opposed to a syntax error

RFC describing 422
https://tools.ietf.org/html/rfc4918#section-11.2
"For example, this error condition may occur if an XML
   request body contains well-formed (i.e., syntactically correct), but
   semantically erroneous, XML instructions"
