### PR TITLE
use json_error_response for /feature /features

### DIFF
--- a/lib/flipper/api/error_response.rb
+++ b/lib/flipper/api/error_response.rb
@@ -25,6 +25,7 @@ module Flipper
         group_not_registered: Error.new(2, "Group not registered.", "", 404),
         percentage_invalid: Error.new(3, "Percentage must be a positive number less than or equal to 100.", "", 422),
         flipper_id_invalid: Error.new(4, "Required parameter flipper_id is missing.", "", 422),
+        name_invalid: Error.new(5, "Required parameter name is missing.", "", 422),
       }
     end
   end

--- a/lib/flipper/api/v1/actions/feature.rb
+++ b/lib/flipper/api/v1/actions/feature.rb
@@ -14,17 +14,16 @@ module Flipper
               feature = Decorators::Feature.new(flipper[feature_name])
               json_response(feature.as_json)
             else
-              json_response({}, 404)
+              json_error_response(:feature_not_found)
             end
           end
 
           def delete
             if feature_names.include?(feature_name)
               flipper.remove(feature_name)
-
               json_response({}, 204)
             else
-              json_response({}, 404)
+              json_error_response(:feature_not_found)
             end
           end
 

--- a/lib/flipper/api/v1/actions/features.rb
+++ b/lib/flipper/api/v1/actions/features.rb
@@ -21,16 +21,11 @@ module Flipper
           end
 
           def post
-            feature_name = params.fetch('name') do
-              json_response({
-                errors: [{
-                  message: 'Missing post parameter: name',
-                }]
-              }, 422)
-            end
-
-            flipper.adapter.add(flipper[feature_name])
-            json_response({}, 200)
+            feature_name = params.fetch('name') { json_error_response(:name_invalid) }
+            feature = flipper[feature_name]
+            flipper.adapter.add(feature)
+            decorated_feature = Decorators::Feature.new(feature)
+            json_response(decorated_feature.as_json, 200)
           end
         end
       end

--- a/spec/flipper/api/v1/actions/feature_spec.rb
+++ b/spec/flipper/api/v1/actions/feature_spec.rb
@@ -103,16 +103,36 @@ RSpec.describe Flipper::Api::V1::Actions::Feature do
       it 'returns 404' do
         expect(last_response.status).to eq(404)
       end
+
+      it 'returns formatted error response body' do
+        expect(json_response).to eq({ "code" => 1, "message" => "Feature not found.", "more_info" => "" })
+      end
     end
   end
 
   describe 'delete' do
-    it 'deletes feature' do
-      flipper[:my_feature].enable
-      expect(flipper.features.map(&:key)).to include('my_feature')
-      delete 'api/v1/features/my_feature'
-      expect(last_response.status).to eq(204)
-      expect(flipper.features.map(&:key)).not_to include('my_feature')
+    context 'succesful request' do
+      it 'deletes feature' do
+        flipper[:my_feature].enable
+        expect(flipper.features.map(&:key)).to include('my_feature')
+        delete 'api/v1/features/my_feature'
+        expect(last_response.status).to eq(204)
+        expect(flipper.features.map(&:key)).not_to include('my_feature')
+      end
+    end
+
+    context 'feature not found' do
+      before do
+        delete 'api/v1/features/my_feature'
+      end
+
+      it 'returns 404' do
+        expect(last_response.status).to eq(404)
+      end
+
+      it 'returns formatted error response body' do
+        expect(json_response).to eq({ "code" => 1, "message" => "Feature not found.", "more_info" => "" })
+      end
     end
   end
 end

--- a/spec/flipper/api/v1/actions/features_spec.rb
+++ b/spec/flipper/api/v1/actions/features_spec.rb
@@ -17,22 +17,23 @@ RSpec.describe Flipper::Api::V1::Actions::Features do
         expected_response = {
           "features" => [
             {
-              "key" =>"my_feature",
+              "key" => "my_feature",
               "state" => "on",
               "gates" => [
                 {
                   "key"=> "boolean",
                   "name"=> "boolean",
-                  "value" => true},
-                  {
-                  "key" =>"groups",
+                  "value" => true
+                },
+                {
+                  "key" => "groups",
                   "name" => "group",
-                  "value" =>[],
+                  "value" => [],
                 },
                 {
                   "key" => "actors",
-                  "name"=>"actor",
-                  "value"=>["10"],
+                  "name" => "actor",
+                  "value" => ["10"],
                 },
                 {
                   "key" => "percentage_of_actors",
@@ -44,7 +45,7 @@ RSpec.describe Flipper::Api::V1::Actions::Features do
                   "name"=> "percentage_of_time",
                   "value"=> 0,
                 },
-            ],
+              ],
             },
           ]
         }
@@ -74,9 +75,44 @@ RSpec.describe Flipper::Api::V1::Actions::Features do
         post 'api/v1/features', { name: 'my_feature' }
       end
 
-      it 'responds 200 on success' do
+      it 'responds 200 ' do
         expect(last_response.status).to eq(200)
-        expect(json_response).to eq({})
+      end
+
+      it 'returns decorated feature' do
+        expected_response = {
+
+          "key" => "my_feature",
+          "state" => "off",
+          "gates" => [
+            {
+              "key"=> "boolean",
+              "name"=> "boolean",
+              "value" => false,
+            },
+            {
+              "key" => "groups",
+              "name" => "group",
+              "value" => [],
+            },
+            {
+              "key" => "actors",
+              "name" => "actor",
+              "value" => [],
+            },
+            {
+              "key" => "percentage_of_actors",
+              "name" => "percentage_of_actors",
+              "value" => 0,
+            },
+            {
+              "key"=> "percentage_of_time",
+              "name"=> "percentage_of_time",
+              "value"=> 0,
+            },
+          ],
+        }
+        expect(json_response).to eq(expected_response)
       end
 
       it 'adds feature' do
@@ -98,8 +134,7 @@ RSpec.describe Flipper::Api::V1::Actions::Features do
       end
 
       it 'returns formatted error' do
-        errors = json_response['errors']
-        expect(errors.first['message']).to eq('Missing post parameter: name')
+        expect(json_response).to eq({ 'code' => 5, 'message' => 'Required parameter name is missing.', 'more_info' => '' })
       end
     end
   end


### PR DESCRIPTION
/feature, /features endpoints were built before ErrorResponse so now instead of `json_response({}, 404)` we can use `json_error_response(:feature_not_found)`.  With this change any api error handling code uses json_error_response.

POST /features will now return a 200 response (was 204) with the decorated feature as the body.  I think this is more useful for any clients and is similar to what we're doing for enabling / disabling gates

DELETE /features still returns a 204, was thinking it might be nice to return the same response as GET /features, but it might be unnecessary to query/serialize all that every time you just want to delete something

Adds new ErrorResponse `:name_invalid`.  Thought about calling it `:feature_name_invalid`, but I figure `:name_invalid` is generic enough where it can be used for some other endpoints in the future if have an invalid name param.

*reformats expected_response in features_spec


