### PR TITLE
updates api v1 docs

### DIFF
--- a/docs/api/README.md
+++ b/docs/api/README.md
@@ -212,11 +212,25 @@ curl -X DELETE http://example.com/flipper-api/api/v1/features/reports
 
 Successful deletion of a feature will return a 204 No Content response.
 
-### Enable a feature
+## Gates
+
+The API supports enabling / disabling any of the Flipper [gates](https://github.com/jnunemaker/flipper/blob/master/docs/Gates.md). Gate endpoints follow the url convention:
+
+**enable**
+
+`POST /api/v1/{feature_name}/{gate_name}`
+
+**disable**
+
+`DELETE /api/v1/{feature_name}/{gate_name}`
+
+and on a succesful request return a 200 HTTP status and the feature object as the response body.
+
+### Boolean enable a feature
 
 **URL**
 
-`PUT /api/v1/feature/{feature_name}/enable`
+`POST /api/v1/feature/{feature_name}/boolean`
 
 **Parameters**
 
@@ -225,18 +239,51 @@ Successful deletion of a feature will return a 204 No Content response.
 **Request**
 
 ```
-curl -X PUT http://example.com/flipper-api/api/v1/features/reports/enable
+curl -X POST http://example.com/flipper-api/api/v1/features/reports/boolean
 ```
 
 **Response**
 
-Successful enabling of a feature will return a 204 No Content response.
+Successful enabling of the boolean gate will return a 200 HTTP status and the feature object as the response body.
 
-### Disable a feature
+{
+  "key": "reports",
+  "state": "on",
+  "gates": [
+    {
+      "key": "boolean",
+      "name": "boolean",
+      "value": true
+    },
+    {
+      "key": "groups",
+      "name": "group",
+      "value": []
+    },
+    {
+      "key": "actors",
+      "name": "actor",
+      "value": []
+    },
+    {
+      "key": "percentage_of_actors",
+      "name": "percentage_of_actors",
+      "value": 0
+    },
+    {
+      "key": "percentage_of_time",
+      "name": "percentage_of_time",
+      "value": 0
+    }
+  ]
+}
+
+
+### Boolean disable a feature
 
 **URL**
 
-`PUT /api/v1/feature/{feature_name}/disable`
+`DELETE /api/v1/feature/{feature_name}/boolean`
 
 **Parameters**
 
@@ -245,9 +292,41 @@ Successful enabling of a feature will return a 204 No Content response.
 **Request**
 
 ```
-curl -X PUT http://example.com/flipper-api/api/v1/features/reports/disable
+curl -X DELETE http://example.com/flipper-api/api/v1/features/reports/boolean
 ```
 
 **Response**
 
-Successful disabling of a feature will return a 204 No Content response.
+Successful disabling of the boolean gate will return a 200 HTTP status and the feature object.
+
+{
+  "key": "reports",
+  "state": "off",
+  "gates": [
+    {
+      "key": "boolean",
+      "name": "boolean",
+      "value": false
+    },
+    {
+      "key": "groups",
+      "name": "group",
+      "value": []
+    },
+    {
+      "key": "actors",
+      "name": "actor",
+      "value": []
+    },
+    {
+      "key": "percentage_of_actors",
+      "name": "percentage_of_actors",
+      "value": 0
+    },
+    {
+      "key": "percentage_of_time",
+      "name": "percentage_of_time",
+      "value": 0
+    }
+  ]
+}


### PR DESCRIPTION
since the first docs created we've updated how we're structuring gate endpoints. For example `PUT /features/:name/enable` is now `POST features/:name/boolean`.  And #183 if you like it will have adding a feature return a 200 and a decorated feature over no content so this just makes sure docs are up to date.

This is just first step to make sure docs are up to date with the current state of the api.  Would like to continue to improve them.