### PR TITLE
Make shared_adapter_specs work with disable_monkey_patching setting

### DIFF
--- a/lib/flipper/spec/shared_adapter_specs.rb
+++ b/lib/flipper/spec/shared_adapter_specs.rb
@@ -1,6 +1,6 @@
 # Requires the following methods:
 # * subject - The instance of the adapter
-shared_examples_for 'a flipper adapter' do
+RSpec.shared_examples_for 'a flipper adapter' do
   let(:actor_class) { Struct.new(:flipper_id) }
 
   let(:flipper) { Flipper.new(subject) }


### PR DESCRIPTION
RSpec ships with disable_monkey_patching! set to true these days, so it's a good practice to prefix top-level blocks with the RSpec namespace. In my case, I have a custom adapter that tries to pull these shared examples in, but because of my RSpec config, it blows up.

See https://www.relishapp.com/rspec/rspec-core/v/3-0/docs/configuration/zero-monkey-patching-mode