### PR TITLE
disables RSpec monkey patching

### DIFF
--- a/lib/flipper/spec/shared_adapter_specs.rb
+++ b/lib/flipper/spec/shared_adapter_specs.rb
@@ -1,6 +1,6 @@
 # Requires the following methods:
 # * subject - The instance of the adapter
-shared_examples_for 'a flipper adapter' do
+RSpec.shared_examples_for 'a flipper adapter' do
   let(:actor_class) { Struct.new(:flipper_id) }
 
   let(:flipper) { Flipper.new(subject) }

--- a/spec/flipper/middleware/memoizer_spec.rb
+++ b/spec/flipper/middleware/memoizer_spec.rb
@@ -17,7 +17,7 @@ RSpec.describe Flipper::Middleware::Memoizer do
     flipper.adapter.memoize = nil
   end
 
-  shared_examples_for "flipper middleware" do
+  RSpec.shared_examples_for "flipper middleware" do
     it "delegates" do
       called = false
       app = lambda { |env|

--- a/spec/helper.rb
+++ b/spec/helper.rb
@@ -19,6 +19,8 @@ RSpec.configure do |config|
     Flipper.unregister_groups
   end
 
+  config.disable_monkey_patching!
+
   config.filter_run focus: true
   config.run_all_when_everything_filtered = true
 end
@@ -52,7 +54,7 @@ RSpec.shared_examples_for 'a percentage' do
   end
 end
 
-shared_examples_for 'a DSL feature' do
+RSpec.shared_examples_for 'a DSL feature' do
   it "returns instance of feature" do
     expect(feature).to be_instance_of(Flipper::Feature)
   end
@@ -80,7 +82,7 @@ shared_examples_for 'a DSL feature' do
   end
 end
 
-shared_examples_for "a DSL boolean method" do
+RSpec.shared_examples_for "a DSL boolean method" do
   it "returns boolean with value set" do
     result = subject.send(method_name, true)
     expect(result).to be_instance_of(Flipper::Types::Boolean)


### PR DESCRIPTION
As pointed out in #188 RSpec >= 3.0 wants to avoid monkey patching.  This will help guide filpper spec code in the right direction by not allowing monkey patched methods 