### PR TITLE
Wait for ActiveSupport to tell us when active_record is loaded

### DIFF
--- a/lib/flipper-active_record.rb
+++ b/lib/flipper-active_record.rb
@@ -1,1 +1,3 @@
-require 'flipper/adapters/active_record'
+ActiveSupport.on_load(:active_record) do
+  require 'flipper/adapters/active_record'
+end


### PR DESCRIPTION
This prevents overwriting the `belongs_to_required_by_default` setting in Rails 5, as described in #129