### PR TITLE
Api v1 error docs and response messaging

### DIFF
--- a/docs/api/README.md
+++ b/docs/api/README.md
@@ -775,17 +775,16 @@ Successful disabling of a percentage of time will set the percentage to 0 and re
 ```
 
 ## Errors
-In the event of an error the Flipper API will return an error object.  The error object will contain a Flipper-specific error code, an error message, and a link to the documentation for the given error code.
+In the event of an error the Flipper API will return an error object.  The error object will contain a Flipper-specific error code, an error message, and a link to documentation providing more information about the error.
 
 *example error object*
 ```json
 {
     "code": 1,
     "message": "Feature not found",
-    "more_info": "https://github.com/jnunemaker/flipper/...",
+    "more_info": "https://github.com/jnunemaker/flipper/tree/master/docs/api#error-code-reference",
 }
 ```
-
 ### Error Code Reference
 
 #### 1: Feature Not Found
@@ -805,4 +804,5 @@ The `percentage` parameter is invalid or missing.  `percentage` must be an integ
 The `flipper_id` parameter is invalid or missing.  `flipper_id` cannot be empty.
 
 ####  5: Name Invalid
+
 The `name` parameter is missing.  Make sure your request's body contains a `name` parameter.

--- a/docs/api/README.md
+++ b/docs/api/README.md
@@ -773,3 +773,36 @@ Successful disabling of a percentage of time will set the percentage to 0 and re
   ]
 }
 ```
+
+## Errors
+In the event of an error the Flipper API will return an error object.  The error object will contain a Flipper-specific error code, an error message, and a link to the documentation for the given error code.
+
+*example error object*
+```json
+{
+    "code": 1,
+    "message": "Feature not found",
+    "more_info": "https://github.com/jnunemaker/flipper/...",
+}
+```
+
+### Error Code Reference
+
+#### 1: Feature Not Found
+
+The requested feature does not exist.  Make sure the feature name is spelled correctly and exists in your application's database.
+
+#### 2: Group Not Registered
+
+The requested group specified by the `name` parameter is not registered.  Information on registering groups can be found in the [Gates documentation](https://github.com/jnunemaker/flipper/blob/master/docs/Gates.md).
+
+#### 3: Percentage Invalid
+
+The `percentage` parameter is invalid or missing.  `percentage` must be an integer between 0-100 inclusive and cannot be blank.
+
+#### 4: Flipper ID Invalid
+
+The `flipper_id` parameter is invalid or missing.  `flipper_id` cannot be empty.
+
+####  5: Name Invalid
+The `name` parameter is missing.  Make sure your request's body contains a `name` parameter.

--- a/lib/flipper/api/error_response.rb
+++ b/lib/flipper/api/error_response.rb
@@ -4,10 +4,10 @@ module Flipper
       class Error
         attr_reader :http_status
 
-        def initialize(code, message, info, http_status)
+        def initialize(code, message, http_status)
           @code = code
           @message = message
-          @more_info = info
+          @more_info = "https://github.com/jnunemaker/flipper/tree/master/docs/api#error-code-reference"
           @http_status = http_status
         end
 
@@ -21,12 +21,13 @@ module Flipper
       end
 
       ERRORS = {
-        feature_not_found: Error.new(1, "Feature not found.", "", 404),
-        group_not_registered: Error.new(2, "Group not registered.", "", 404),
-        percentage_invalid: Error.new(3, "Percentage must be a positive number less than or equal to 100.", "", 422),
-        flipper_id_invalid: Error.new(4, "Required parameter flipper_id is missing.", "", 422),
-        name_invalid: Error.new(5, "Required parameter name is missing.", "", 422),
+        feature_not_found: Error.new(1, "Feature not found.", 404),
+        group_not_registered: Error.new(2, "Group not registered.", 404),
+        percentage_invalid: Error.new(3, "Percentage must be a positive number less than or equal to 100.", 422),
+        flipper_id_invalid: Error.new(4, "Required parameter flipper_id is missing.", 422),
+        name_invalid: Error.new(5, "Required parameter name is missing.", 422),
       }
+
     end
   end
 end

--- a/spec/flipper/api/action_spec.rb
+++ b/spec/flipper/api/action_spec.rb
@@ -74,7 +74,7 @@ RSpec.describe Flipper::Api::Action do
         expect(headers["Content-Type"]).to eq("application/json")
         expect(parsed_body["code"]).to eq(1)
         expect(parsed_body["message"]).to eq("Feature not found.")
-        expect(parsed_body["more_info"]).to eq("")
+        expect(parsed_body["more_info"]).to eq("https://github.com/jnunemaker/flipper/tree/master/docs/api#error-code-reference")
       end
     end
 
@@ -91,7 +91,7 @@ RSpec.describe Flipper::Api::Action do
         expect(headers["Content-Type"]).to eq("application/json")
         expect(parsed_body["code"]).to eq(2)
         expect(parsed_body["message"]).to eq("Group not registered.")
-        expect(parsed_body["more_info"]).to eq("")
+        expect(parsed_body["more_info"]).to eq("https://github.com/jnunemaker/flipper/tree/master/docs/api#error-code-reference")
       end
     end
 

--- a/spec/flipper/api/v1/actions/actors_gate_spec.rb
+++ b/spec/flipper/api/v1/actions/actors_gate_spec.rb
@@ -51,7 +51,7 @@ RSpec.describe Flipper::Api::V1::Actions::ActorsGate do
 
     it 'returns correct error response' do
       expect(last_response.status).to eq(422)
-      expect(json_response).to eq({ 'code' => 4, 'message' => 'Required parameter flipper_id is missing.', 'more_info' => '' })
+      expect(json_response).to eq({ 'code' => 4, 'message' => 'Required parameter flipper_id is missing.', 'more_info' => 'https://github.com/jnunemaker/flipper/tree/master/docs/api#error-code-reference' })
     end
   end
 
@@ -63,7 +63,7 @@ RSpec.describe Flipper::Api::V1::Actions::ActorsGate do
 
     it 'returns correct error response' do
       expect(last_response.status).to eq(422)
-      expect(json_response).to eq({ 'code' => 4, 'message' => 'Required parameter flipper_id is missing.', 'more_info' => '' })
+      expect(json_response).to eq({ 'code' => 4, 'message' => 'Required parameter flipper_id is missing.', 'more_info' => 'https://github.com/jnunemaker/flipper/tree/master/docs/api#error-code-reference' })
     end
   end
 
@@ -75,7 +75,7 @@ RSpec.describe Flipper::Api::V1::Actions::ActorsGate do
 
     it 'returns correct error response' do
       expect(last_response.status).to eq(422)
-      expect(json_response).to eq({ 'code' => 4, 'message' => 'Required parameter flipper_id is missing.', 'more_info' => '' })
+      expect(json_response).to eq({ 'code' => 4, 'message' => 'Required parameter flipper_id is missing.', 'more_info' => 'https://github.com/jnunemaker/flipper/tree/master/docs/api#error-code-reference' })
     end
   end
 
@@ -87,7 +87,7 @@ RSpec.describe Flipper::Api::V1::Actions::ActorsGate do
 
     it 'returns correct error response' do
       expect(last_response.status).to eq(422)
-      expect(json_response).to eq({ 'code' => 4, 'message' => 'Required parameter flipper_id is missing.', 'more_info' => '' })
+      expect(json_response).to eq({ 'code' => 4, 'message' => 'Required parameter flipper_id is missing.', 'more_info' => 'https://github.com/jnunemaker/flipper/tree/master/docs/api#error-code-reference' })
     end
   end
 
@@ -98,7 +98,7 @@ RSpec.describe Flipper::Api::V1::Actions::ActorsGate do
 
     it 'returns correct error response' do
       expect(last_response.status).to eq(404)
-      expect(json_response).to eq({ 'code' => 1, 'message' => 'Feature not found.', 'more_info' => '' })
+      expect(json_response).to eq({ 'code' => 1, 'message' => 'Feature not found.', 'more_info' => 'https://github.com/jnunemaker/flipper/tree/master/docs/api#error-code-reference' })
     end
   end
 
@@ -109,7 +109,7 @@ RSpec.describe Flipper::Api::V1::Actions::ActorsGate do
 
     it 'returns correct error response' do
       expect(last_response.status).to eq(404)
-      expect(json_response).to eq({ 'code' => 1, 'message' => 'Feature not found.', 'more_info' => '' })
+      expect(json_response).to eq({ 'code' => 1, 'message' => 'Feature not found.', 'more_info' => 'https://github.com/jnunemaker/flipper/tree/master/docs/api#error-code-reference' })
     end
   end
 end

--- a/spec/flipper/api/v1/actions/feature_spec.rb
+++ b/spec/flipper/api/v1/actions/feature_spec.rb
@@ -105,7 +105,7 @@ RSpec.describe Flipper::Api::V1::Actions::Feature do
       end
 
       it 'returns formatted error response body' do
-        expect(json_response).to eq({ "code" => 1, "message" => "Feature not found.", "more_info" => "" })
+        expect(json_response).to eq({ "code" => 1, "message" => "Feature not found.", "more_info" => "https://github.com/jnunemaker/flipper/tree/master/docs/api#error-code-reference" })
       end
     end
   end
@@ -131,7 +131,7 @@ RSpec.describe Flipper::Api::V1::Actions::Feature do
       end
 
       it 'returns formatted error response body' do
-        expect(json_response).to eq({ "code" => 1, "message" => "Feature not found.", "more_info" => "" })
+        expect(json_response).to eq({ "code" => 1, "message" => "Feature not found.", "more_info" => "https://github.com/jnunemaker/flipper/tree/master/docs/api#error-code-reference" })
       end
     end
   end

--- a/spec/flipper/api/v1/actions/features_spec.rb
+++ b/spec/flipper/api/v1/actions/features_spec.rb
@@ -134,7 +134,7 @@ RSpec.describe Flipper::Api::V1::Actions::Features do
       end
 
       it 'returns formatted error' do
-        expect(json_response).to eq({ 'code' => 5, 'message' => 'Required parameter name is missing.', 'more_info' => '' })
+        expect(json_response).to eq({ 'code' => 5, 'message' => 'Required parameter name is missing.', 'more_info' => 'https://github.com/jnunemaker/flipper/tree/master/docs/api#error-code-reference' })
       end
     end
   end

--- a/spec/flipper/api/v1/actions/groups_gate_spec.rb
+++ b/spec/flipper/api/v1/actions/groups_gate_spec.rb
@@ -57,7 +57,7 @@ RSpec.describe Flipper::Api::V1::Actions::GroupsGate do
 
     it  '404s with correct error response when feature does not exist' do
       expect(last_response.status).to eq(404)
-      expect(json_response).to eq({ 'code' => 1, 'message' => 'Feature not found.', 'more_info' => '' })
+      expect(json_response).to eq({ 'code' => 1, 'message' => 'Feature not found.', 'more_info' => 'https://github.com/jnunemaker/flipper/tree/master/docs/api#error-code-reference' })
     end
   end
 
@@ -69,7 +69,7 @@ RSpec.describe Flipper::Api::V1::Actions::GroupsGate do
 
     it '404s with correct error response when group not registered' do
       expect(last_response.status).to eq(404)
-      expect(json_response).to eq({ 'code' => 2, 'message' => 'Group not registered.', 'more_info' => '' })
+      expect(json_response).to eq({ 'code' => 2, 'message' => 'Group not registered.', 'more_info' => 'https://github.com/jnunemaker/flipper/tree/master/docs/api#error-code-reference' })
     end
   end
 end

--- a/spec/flipper/api/v1/actions/percentage_of_actors_gate_spec.rb
+++ b/spec/flipper/api/v1/actions/percentage_of_actors_gate_spec.rb
@@ -43,7 +43,7 @@ RSpec.describe Flipper::Api::V1::Actions::PercentageOfActorsGate do
 
     it  '404s with correct error response when feature does not exist' do
       expect(last_response.status).to eq(404)
-      expect(json_response).to eq({ 'code' => 1, 'message' => 'Feature not found.', 'more_info' => '' })
+      expect(json_response).to eq({ 'code' => 1, 'message' => 'Feature not found.', 'more_info' => 'https://github.com/jnunemaker/flipper/tree/master/docs/api#error-code-reference' })
     end
   end
 
@@ -55,7 +55,7 @@ RSpec.describe Flipper::Api::V1::Actions::PercentageOfActorsGate do
 
     it '422s with correct error response when percentage parameter is invalid' do
       expect(last_response.status).to eq(422)
-      expect(json_response).to eq({ 'code' => 3, 'message' => 'Percentage must be a positive number less than or equal to 100.', 'more_info' => '' })
+      expect(json_response).to eq({ 'code' => 3, 'message' => 'Percentage must be a positive number less than or equal to 100.', 'more_info' => 'https://github.com/jnunemaker/flipper/tree/master/docs/api#error-code-reference' })
     end
   end
 
@@ -67,7 +67,7 @@ RSpec.describe Flipper::Api::V1::Actions::PercentageOfActorsGate do
 
     it '422s with correct error response when percentage parameter is invalid' do
       expect(last_response.status).to eq(422)
-      expect(json_response).to eq({ 'code' => 3, 'message' => 'Percentage must be a positive number less than or equal to 100.', 'more_info' => '' })
+      expect(json_response).to eq({ 'code' => 3, 'message' => 'Percentage must be a positive number less than or equal to 100.', 'more_info' => 'https://github.com/jnunemaker/flipper/tree/master/docs/api#error-code-reference' })
     end
   end
 
@@ -79,7 +79,7 @@ RSpec.describe Flipper::Api::V1::Actions::PercentageOfActorsGate do
 
     it '422s with correct error response when percentage parameter is missing' do
       expect(last_response.status).to eq(422)
-      expect(json_response).to eq({ 'code' => 3, 'message' => 'Percentage must be a positive number less than or equal to 100.', 'more_info' => '' })
+      expect(json_response).to eq({ 'code' => 3, 'message' => 'Percentage must be a positive number less than or equal to 100.', 'more_info' => 'https://github.com/jnunemaker/flipper/tree/master/docs/api#error-code-reference' })
     end
   end
 end

--- a/spec/flipper/api/v1/actions/percentage_of_time_gate_spec.rb
+++ b/spec/flipper/api/v1/actions/percentage_of_time_gate_spec.rb
@@ -42,7 +42,7 @@ RSpec.describe Flipper::Api::V1::Actions::PercentageOfTimeGate do
 
     it  '404s with correct error response when feature does not exist' do
       expect(last_response.status).to eq(404)
-      expect(json_response).to eq({ 'code' => 1, 'message' => 'Feature not found.', 'more_info' => '' })
+      expect(json_response).to eq({ 'code' => 1, 'message' => 'Feature not found.', 'more_info' => 'https://github.com/jnunemaker/flipper/tree/master/docs/api#error-code-reference' })
     end
   end
 
@@ -54,7 +54,7 @@ RSpec.describe Flipper::Api::V1::Actions::PercentageOfTimeGate do
 
     it '422s with correct error response when percentage parameter is invalid' do
       expect(last_response.status).to eq(422)
-      expect(json_response).to eq({ 'code' => 3, 'message' => 'Percentage must be a positive number less than or equal to 100.', 'more_info' => '' })
+      expect(json_response).to eq({ 'code' => 3, 'message' => 'Percentage must be a positive number less than or equal to 100.', 'more_info' => 'https://github.com/jnunemaker/flipper/tree/master/docs/api#error-code-reference' })
     end
   end
 
@@ -66,7 +66,7 @@ RSpec.describe Flipper::Api::V1::Actions::PercentageOfTimeGate do
 
     it '422s with correct error response when percentage parameter is invalid' do
       expect(last_response.status).to eq(422)
-      expect(json_response).to eq({ 'code' => 3, 'message' => 'Percentage must be a positive number less than or equal to 100.', 'more_info' => '' })
+      expect(json_response).to eq({ 'code' => 3, 'message' => 'Percentage must be a positive number less than or equal to 100.', 'more_info' => 'https://github.com/jnunemaker/flipper/tree/master/docs/api#error-code-reference' })
     end
   end
 
@@ -78,7 +78,7 @@ RSpec.describe Flipper::Api::V1::Actions::PercentageOfTimeGate do
 
     it '422s with correct error response when percentage parameter is missing' do
       expect(last_response.status).to eq(422)
-      expect(json_response).to eq({ 'code' => 3, 'message' => 'Percentage must be a positive number less than or equal to 100.', 'more_info' => '' })
+      expect(json_response).to eq({ 'code' => 3, 'message' => 'Percentage must be a positive number less than or equal to 100.', 'more_info' => 'https://github.com/jnunemaker/flipper/tree/master/docs/api#error-code-reference' })
     end
   end
 end


### PR DESCRIPTION
Adds error documentation to the api v1 README completing #195 

For now the more_info link will link to https://github.com/jnunemaker/flipper/tree/master/docs/api#error-code-reference.  The anchor tags don't work in preview because user-content is prepended to the ids, but will work when merged.

I updated the ErrorResponse initialize function to just take `(code, message, http_status)` and no link to documentation since for now we only have a few error messages and they all live in one place so that instance variable is just set in the initializer.  Maybe in the future we'll change this if we add more info about errors and want to link to more specific sections of the docs

updates specs to account for adding the more_info in the response