### PR TITLE
Show confirmation dialog when deleting a feature

### DIFF
--- a/lib/flipper/ui/views/feature.erb
+++ b/lib/flipper/ui/views/feature.erb
@@ -201,7 +201,7 @@
       Deleting a feature removes it from the list of features and disables it for everyone.
     </p>
 
-    <form action="<%= script_name %>/features/<%= @feature.key %>" method="post">
+    <form action="<%= script_name %>/features/<%= @feature.key %>" method="post" onsubmit="return confirm('Are you sure you want to remove <%= @feature.key %> from the list of features and disable it for everyone?')">
       <%== csrf_input_tag %>
       <input type="hidden" name="_method" value="DELETE">
       <button type="submit" name="action" value="Delete" class="btn btn-danger tooltipped tooltipped-ne" aria-label="Remove feature from list of features and disable it.">Delete</button>


### PR DESCRIPTION
Hi! Thanks so much for working on this. We just set it up internally and are loving it.

Although the Delete button is red and scary, I still found myself a bit surprised when clicking "Delete" didn't require an extra confirmation step. This adds a simple JavaScript dialog to be confirmed before the delete form is submitted.