### PR TITLE
Strip whitespace out of feature/actor/group values posted by UI

### DIFF
--- a/lib/flipper/ui/actions/actors_gate.rb
+++ b/lib/flipper/ui/actions/actors_gate.rb
@@ -24,7 +24,7 @@ module Flipper
         def post
           feature_name = Rack::Utils.unescape(request.path.split('/')[-2])
           feature = flipper[feature_name.to_sym]
-          value = params["value"].strip
+          value = params["value"].to_s.strip
 
           if Util.blank?(value)
             error = Rack::Utils.escape("#{value.inspect} is not a valid actor value.")

--- a/lib/flipper/ui/actions/actors_gate.rb
+++ b/lib/flipper/ui/actions/actors_gate.rb
@@ -24,7 +24,7 @@ module Flipper
         def post
           feature_name = Rack::Utils.unescape(request.path.split('/')[-2])
           feature = flipper[feature_name.to_sym]
-          value = params["value"]
+          value = params["value"].strip
 
           if Util.blank?(value)
             error = Rack::Utils.escape("#{value.inspect} is not a valid actor value.")

--- a/lib/flipper/ui/actions/features.rb
+++ b/lib/flipper/ui/actions/features.rb
@@ -34,7 +34,7 @@ module Flipper
             halt view_response(:feature_creation_disabled)
           end
 
-          value = params["value"].strip
+          value = params["value"].to_s.strip
 
           if Util.blank?(value)
             error = Rack::Utils.escape("#{value.inspect} is not a valid feature name.")

--- a/lib/flipper/ui/actions/features.rb
+++ b/lib/flipper/ui/actions/features.rb
@@ -34,7 +34,7 @@ module Flipper
             halt view_response(:feature_creation_disabled)
           end
 
-          value = params["value"]
+          value = params["value"].strip
 
           if Util.blank?(value)
             error = Rack::Utils.escape("#{value.inspect} is not a valid feature name.")

--- a/lib/flipper/ui/actions/groups_gate.rb
+++ b/lib/flipper/ui/actions/groups_gate.rb
@@ -23,7 +23,7 @@ module Flipper
         def post
           feature_name = Rack::Utils.unescape(request.path.split('/')[-2])
           feature = flipper[feature_name.to_sym]
-          value = params["value"].strip
+          value = params["value"].to_s.strip
 
           case params["operation"]
           when "enable"

--- a/lib/flipper/ui/actions/groups_gate.rb
+++ b/lib/flipper/ui/actions/groups_gate.rb
@@ -23,7 +23,7 @@ module Flipper
         def post
           feature_name = Rack::Utils.unescape(request.path.split('/')[-2])
           feature = flipper[feature_name.to_sym]
-          value = params["value"]
+          value = params["value"].strip
 
           case params["operation"]
           when "enable"

--- a/spec/flipper/ui/actions/actors_gate_spec.rb
+++ b/spec/flipper/ui/actions/actors_gate_spec.rb
@@ -56,6 +56,26 @@ RSpec.describe Flipper::UI::Actions::ActorsGate do
           expect(flipper[:search].actors_value).to include("User:6")
         end
       end
+
+      context "for an invalid actor value" do
+        context "empty value" do
+          let(:value) { "" }
+
+          it "redirects back to feature" do
+            expect(last_response.status).to be(302)
+            expect(last_response.headers["Location"]).to eq("/features/search/actors?error=%22%22+is+not+a+valid+actor+value.")
+          end
+        end
+
+        context "nil value" do
+          let(:value) { nil }
+
+          it "redirects back to feature" do
+            expect(last_response.status).to be(302)
+            expect(last_response.headers["Location"]).to eq("/features/search/actors?error=%22%22+is+not+a+valid+actor+value.")
+          end
+        end
+      end
     end
 
     context "disabling an actor" do
@@ -83,19 +103,6 @@ RSpec.describe Flipper::UI::Actions::ActorsGate do
         it "removes item whitout whitespace" do
           expect(flipper[:search].actors_value).not_to include("User:6")
         end
-      end
-    end
-
-    context "for an invalid actor value" do
-      before do
-        post "features/search/actors",
-          {"value" => "", "operation" => "enable", "authenticity_token" => token},
-          "rack.session" => session
-      end
-
-      it "redirects back to feature" do
-        expect(last_response.status).to be(302)
-        expect(last_response.headers["Location"]).to eq("/features/search/actors?error=%22%22+is+not+a+valid+actor+value.")
       end
     end
   end

--- a/spec/flipper/ui/actions/actors_gate_spec.rb
+++ b/spec/flipper/ui/actions/actors_gate_spec.rb
@@ -32,9 +32,11 @@ RSpec.describe Flipper::UI::Actions::ActorsGate do
 
   describe "POST /features/:feature/actors" do
     context "enabling an actor" do
+      let(:value) { "User:6" }
+
       before do
         post "features/search/actors",
-          {"value" => "User:6", "operation" => "enable", "authenticity_token" => token},
+          {"value" => value, "operation" => "enable", "authenticity_token" => token},
           "rack.session" => session
       end
 
@@ -46,13 +48,23 @@ RSpec.describe Flipper::UI::Actions::ActorsGate do
         expect(last_response.status).to be(302)
         expect(last_response.headers["Location"]).to eq("/features/search")
       end
+
+      context 'value contains whitespace' do
+        let(:value) { "  User:6  " }
+
+        it "adds item without whitespace" do
+          expect(flipper[:search].actors_value).to include("User:6")
+        end
+      end
     end
 
     context "disabling an actor" do
+      let(:value) { "User:6" }
+
       before do
         flipper[:search].enable_actor Flipper::UI::Actor.new("User:6")
         post "features/search/actors",
-          {"value" => "User:6", "operation" => "disable", "authenticity_token" => token},
+          {"value" => value, "operation" => "disable", "authenticity_token" => token},
           "rack.session" => session
       end
 
@@ -63,6 +75,14 @@ RSpec.describe Flipper::UI::Actions::ActorsGate do
       it "redirects back to feature" do
         expect(last_response.status).to be(302)
         expect(last_response.headers["Location"]).to eq("/features/search")
+      end
+
+      context 'value contains whitespace' do
+        let(:value) { "  User:6  " }
+
+        it "removes item whitout whitespace" do
+          expect(flipper[:search].actors_value).not_to include("User:6")
+        end
       end
     end
 

--- a/spec/flipper/ui/actions/features_spec.rb
+++ b/spec/flipper/ui/actions/features_spec.rb
@@ -67,6 +67,34 @@ RSpec.describe Flipper::UI::Actions::Features do
           expect(flipper.features.map(&:key)).to include("notifications_next")
         end
       end
+
+      context "for an invalid feature name" do
+        context "empty feature name" do
+          let(:feature_name) { "" }
+
+          it "does not add feature" do
+            expect(flipper.features.map(&:key)).to eq([])
+          end
+
+          it "redirects back to feature" do
+            expect(last_response.status).to be(302)
+            expect(last_response.headers["Location"]).to eq("/features/new?error=%22%22+is+not+a+valid+feature+name.")
+          end
+        end
+
+        context "nil feature name" do
+          let(:feature_name) { nil }
+
+          it "does not add feature" do
+            expect(flipper.features.map(&:key)).to eq([])
+          end
+
+          it "redirects back to feature" do
+            expect(last_response.status).to be(302)
+            expect(last_response.headers["Location"]).to eq("/features/new?error=%22%22+is+not+a+valid+feature+name.")
+          end
+        end
+      end
     end
 
     context 'feature_creation_enabled set to false' do

--- a/spec/flipper/ui/actions/features_spec.rb
+++ b/spec/flipper/ui/actions/features_spec.rb
@@ -33,12 +33,14 @@ RSpec.describe Flipper::UI::Actions::Features do
     end
   end
 
-  describe "POST /features with feature_creation_enabled set to true" do
+  describe "POST /features" do
+    let(:feature_name) { "notifications_next" }
+
     before do
       @original_feature_creation_enabled = Flipper::UI.feature_creation_enabled
-      Flipper::UI.feature_creation_enabled = true
+      Flipper::UI.feature_creation_enabled = feature_creation_enabled
       post "/features",
-        {"value" => "notifications_next", "authenticity_token" => token},
+        {"value" => feature_name, "authenticity_token" => token},
         "rack.session" => session
     end
 
@@ -46,39 +48,41 @@ RSpec.describe Flipper::UI::Actions::Features do
       Flipper::UI.feature_creation_enabled = @original_feature_creation_enabled
     end
 
-    it "adds feature" do
-      expect(flipper.features.map(&:key)).to include("notifications_next")
+    context 'feature_creation_enabled set to true' do
+      let(:feature_creation_enabled) { true }
+
+      it "adds feature" do
+        expect(flipper.features.map(&:key)).to include("notifications_next")
+      end
+
+      it "redirects to feature" do
+        expect(last_response.status).to be(302)
+        expect(last_response.headers["Location"]).to eq("/features/notifications_next")
+      end
+
+      context 'feature name contains whitespace' do
+        let(:feature_name) { "  notifications_next   " }
+
+        it "adds feature without whitespace" do
+          expect(flipper.features.map(&:key)).to include("notifications_next")
+        end
+      end
     end
 
-    it "redirects to feature" do
-      expect(last_response.status).to be(302)
-      expect(last_response.headers["Location"]).to eq("/features/notifications_next")
-    end
-  end
+    context 'feature_creation_enabled set to false' do
+      let(:feature_creation_enabled) { false }
 
-  describe "POST /features with feature_creation_enabled set to false" do
-    before do
-      @original_feature_creation_enabled = Flipper::UI.feature_creation_enabled
-      Flipper::UI.feature_creation_enabled = false
-      post "/features",
-        {"value" => "notifications_next", "authenticity_token" => token},
-        "rack.session" => session
-    end
+      it "does not add feature" do
+        expect(flipper.features.map(&:key)).to_not include("notifications_next")
+      end
 
-    after do
-      Flipper::UI.feature_creation_enabled = @original_feature_creation_enabled
-    end
+      it "returns 403" do
+        expect(last_response.status).to be(403)
+      end
 
-    it "does not add feature" do
-      expect(flipper.features.map(&:key)).to_not include("notifications_next")
-    end
-
-    it "returns 403" do
-      expect(last_response.status).to be(403)
-    end
-
-    it "renders feature creation disabled template" do
-      expect(last_response.body).to include("Feature creation is disabled.")
+      it "renders feature creation disabled template" do
+        expect(last_response.body).to include("Feature creation is disabled.")
+      end
     end
   end
 end

--- a/spec/flipper/ui/actions/groups_gate_spec.rb
+++ b/spec/flipper/ui/actions/groups_gate_spec.rb
@@ -69,6 +69,35 @@ RSpec.describe Flipper::UI::Actions::GroupsGate do
           expect(flipper[:search].groups_value).to include("admins")
         end
       end
+
+      context "for an unregistered group" do
+        context "unknown group name" do
+          let(:group_name) { "not_here" }
+
+          it "redirects back to feature" do
+            expect(last_response.status).to be(302)
+            expect(last_response.headers["Location"]).to eq("/features/search/groups?error=The+group+named+%22not_here%22+has+not+been+registered.")
+          end
+        end
+
+        context "empty group name" do
+          let(:group_name) { "" }
+
+          it "redirects back to feature" do
+            expect(last_response.status).to be(302)
+            expect(last_response.headers["Location"]).to eq("/features/search/groups?error=The+group+named+%22%22+has+not+been+registered.")
+          end
+        end
+
+        context "nil group name" do
+          let(:group_name) { nil }
+
+          it "redirects back to feature" do
+            expect(last_response.status).to be(302)
+            expect(last_response.headers["Location"]).to eq("/features/search/groups?error=The+group+named+%22%22+has+not+been+registered.")
+          end
+        end
+      end
     end
 
     context "disabling a group" do
@@ -96,19 +125,6 @@ RSpec.describe Flipper::UI::Actions::GroupsGate do
         it "removes item without whitespace" do
           expect(flipper[:search].groups_value).not_to include("admins")
         end
-      end
-    end
-
-    context "for an unregistered group" do
-      before do
-        post "features/search/groups",
-          {"value" => "not_here", "operation" => "enable", "authenticity_token" => token},
-          "rack.session" => session
-      end
-
-      it "redirects back to feature" do
-        expect(last_response.status).to be(302)
-        expect(last_response.headers["Location"]).to eq("/features/search/groups?error=The+group+named+%22not_here%22+has+not+been+registered.")
       end
     end
   end


### PR DESCRIPTION
Fix https://github.com/jnunemaker/flipper/issues/204

By investigating the initial issue, I was able to identify several areas impacted by it.

1. Using the UI to create two features with similar names but different whitespace:

```ruby
> $flipper.features
=> #<Set: {#<Flipper::Feature:70136261075520 name="   whitespace", state=:conditional, enabled_gate_names=[:actor], adapter=:memoizable>,
 #<Flipper::Feature:70136261217520 name="   whitespace   ", state=:conditional, enabled_gate_names=[:actor], adapter=:memoizable>}>
```

2. Still via the UI, adding an actor to the second one seemed to have actually added it to the first one.

3. Both links in the UI leads to the same feature:

![screen shot 2016-11-23 at 11 01 10 am](https://cloud.githubusercontent.com/assets/154600/20570666/856cc352-b172-11e6-863c-27394def4a9e.png)

4. Copy-pasting actor values from one Flipper UI to another adds some whitespace which ends up in Flipper:

```ruby
> $flipper["   whitespace"].actors_value
=> #<Set: {"    test@blueapron.com\t"}>
```

This PR fixes all of these issues above by applying [`String#strip`](http://ruby-doc.org/core-2.3.3/String.html#method-i-strip) to the params send from the front-end to the back-end of Flipper UI.

cc @jnunemaker & @AlexWheeler for review/feedback, and @susanblueapron for finding the bug in the first place