### PR TITLE
Use primary keys with Sequel

### DIFF
--- a/lib/flipper/adapters/sequel.rb
+++ b/lib/flipper/adapters/sequel.rb
@@ -9,11 +9,15 @@ module Flipper
 
       # Private: Do not use outside of this adapter.
       class Feature < ::Sequel::Model(:flipper_features)
+        unrestrict_primary_key
+
         plugin :timestamps, update_on_create: true
       end
 
       # Private: Do not use outside of this adapter.
       class Gate < ::Sequel::Model(:flipper_gates)
+        unrestrict_primary_key
+
         plugin :timestamps, update_on_create: true
       end
 

--- a/lib/generators/flipper/templates/sequel_migration.rb
+++ b/lib/generators/flipper/templates/sequel_migration.rb
@@ -1,11 +1,10 @@
 class CreateFlipperTablesSequel < Sequel::Migration
   def up
     create_table :flipper_features do |t|
-      String :key, null: false
+      String :key, primary_key: true, null: false
       DateTime :created_at, null: false
       DateTime :updated_at, null: false
     end
-    add_index :flipper_features, :key, unique: true
 
     create_table :flipper_gates do |t|
       String :feature_key, null: false
@@ -13,8 +12,8 @@ class CreateFlipperTablesSequel < Sequel::Migration
       String :value
       DateTime :created_at, null: false
       DateTime :updated_at, null: false
+      primary_key [:feature_key, :key, :value]
     end
-    add_index :flipper_gates, [:feature_key, :key, :value], unique: true
   end
 
   def down


### PR DESCRIPTION
Use primary keys with Sequel, which are usually more practically that simple indexes.

It appears the current implementation does not require a feature to exists when creating a gate, so a foreign key on ``flipper_gates.feature_key`` cannot be used. 