### PR TITLE
Add redis cache adapter

### DIFF
--- a/docs/DockerCompose.md
+++ b/docs/DockerCompose.md
@@ -7,9 +7,11 @@ new contributor could start working on code with a minumum efforts.
 ## Steps:
 
 1. Install Docker Compose https://docs.docker.com/compose/install
-2. Install gems `docker-compose run --rm app bundle install`
-3. Run specs `docker-compose run --rm app bundle exec rspec`
-4. Optional: log in to container an using a bash for running specs
+1. Build the app container `docker-compose build`
+1. Install gems `docker-compose run --rm app bundle install`
+1. Run specs `docker-compose run --rm app bundle exec rspec`
+1. Run tests `docker-compose run --rm app bundle exec rake test`
+1. Optional: log in to container an using a bash for running specs
 ```sh
 docker-compose run --rm app bash
 bundle exec rspec

--- a/lib/flipper/adapters/redis_cache.rb
+++ b/lib/flipper/adapters/redis_cache.rb
@@ -47,8 +47,8 @@ module Flipper
       # Public
       def remove(feature)
         result = @adapter.remove(feature)
-        @cache.delete(FeaturesKey)
-        @cache.delete(key_for(feature.key))
+        @cache.del(FeaturesKey)
+        @cache.del(key_for(feature.key))
         result
       end
 

--- a/lib/flipper/adapters/redis_cache.rb
+++ b/lib/flipper/adapters/redis_cache.rb
@@ -1,0 +1,106 @@
+require 'redis'
+
+module Flipper
+  module Adapters
+    # Public: Adapter that wraps another adapter with the ability to cache
+    # adapter calls in Redis
+    class RedisCache
+      include ::Flipper::Adapter
+
+      Version = "v1".freeze
+      Namespace = "flipper/#{Version}".freeze
+      FeaturesKey = "#{Namespace}/features".freeze
+
+      # Private
+      def self.key_for(key)
+        "#{Namespace}/feature/#{key}"
+      end
+
+      # Internal
+      attr_reader :cache
+
+      # Public: The name of the adapter.
+      attr_reader :name
+
+      # Public
+      def initialize(adapter, cache, ttl = 0)
+        @adapter = adapter
+        @name = :redis
+        @cache = cache
+        @ttl = ttl
+      end
+
+      # Public
+      def features
+        @cache.fetch(FeaturesKey, @ttl) do
+          @adapter.features
+        end
+      end
+
+      # Public
+      def add(feature)
+        result = @adapter.add(feature)
+        @cache.delete(FeaturesKey)
+        result
+      end
+
+      # Public
+      def remove(feature)
+        result = @adapter.remove(feature)
+        @cache.delete(FeaturesKey)
+        @cache.delete(key_for(feature.key))
+        result
+      end
+
+      # Public
+      def clear(feature)
+        result = @adapter.clear(feature)
+        @cache.delete(key_for(feature.key))
+        result
+      end
+
+      # Public
+      def get(feature)
+        @cache.fetch(key_for(feature.key), @ttl) do
+          @adapter.get(feature)
+        end
+      end
+
+      def get_multi(features)
+        keys = features.map { |feature| key_for(feature.key) }
+        result = @cache.get_multi(keys)
+        uncached_features = features.reject { |feature| result[key_for(feature.key)] }
+
+        if uncached_features.any?
+          response = @adapter.get_multi(uncached_features)
+          response.each do |key, value|
+            @cache.set(key_for(key), value, @ttl)
+            result[key] = value
+          end
+        end
+
+        result
+      end
+
+      # Public
+      def enable(feature, gate, thing)
+        result = @adapter.enable(feature, gate, thing)
+        @cache.delete(key_for(feature.key))
+        result
+      end
+
+      # Public
+      def disable(feature, gate, thing)
+        result = @adapter.disable(feature, gate, thing)
+        @cache.delete(key_for(feature.key))
+        result
+      end
+
+      private
+
+      def key_for(key)
+        self.class.key_for(key)
+      end
+    end
+  end
+end

--- a/lib/flipper/adapters/redis_cache.rb
+++ b/lib/flipper/adapters/redis_cache.rb
@@ -23,7 +23,7 @@ module Flipper
       attr_reader :name
 
       # Public
-      def initialize(adapter, cache, ttl = 0)
+      def initialize(adapter, cache, ttl = 3600)
         @adapter = adapter
         @name = :redis
         @cache = cache

--- a/spec/flipper/adapters/dalli_spec.rb
+++ b/spec/flipper/adapters/dalli_spec.rb
@@ -9,7 +9,7 @@ RSpec.describe Flipper::Adapters::Dalli do
   let(:adapter) { Flipper::Adapters::Dalli.new(memory_adapter, cache) }
   let(:flipper) { Flipper.new(adapter) }
 
-  subject { described_class.new(adapter, cache) }
+  subject { adapter }
 
   before do
     cache.flush

--- a/spec/flipper/adapters/redis_cache_spec.rb
+++ b/spec/flipper/adapters/redis_cache_spec.rb
@@ -14,7 +14,7 @@ RSpec.describe Flipper::Adapters::RedisCache do
   }
 
   let(:memory_adapter) { Flipper::Adapters::Memory.new }
-  let(:cache)   { Redis.new({url: ENV.fetch('BOXEN_REDIS_URL', 'localhost:6379')}) }
+  let(:cache)   { Redis.new({url: ENV.fetch('BOXEN_REDIS_URL', 'redis://localhost:6379')}) }
   let(:adapter) { Flipper::Adapters::RedisCache.new(memory_adapter, cache) }
   let(:flipper) { Flipper.new(adapter) }
 

--- a/spec/flipper/adapters/redis_cache_spec.rb
+++ b/spec/flipper/adapters/redis_cache_spec.rb
@@ -14,11 +14,11 @@ RSpec.describe Flipper::Adapters::RedisCache do
   }
 
   let(:memory_adapter) { Flipper::Adapters::Memory.new }
-  let(:cache)   { Redis.new({url: ENV.fetch('BOXEN_REDIS_URL', 'localhost:6379')})}
+  let(:cache)   { Redis.new({url: ENV.fetch('BOXEN_REDIS_URL', 'localhost:6379')}) }
   let(:adapter) { Flipper::Adapters::RedisCache.new(memory_adapter, cache) }
   let(:flipper) { Flipper.new(adapter) }
 
-  subject { described_class.new(adapter, cache) }
+  subject { adapter }
 
   before do
     client.flushdb
@@ -26,7 +26,7 @@ RSpec.describe Flipper::Adapters::RedisCache do
 
   it_should_behave_like 'a flipper adapter'
 
-  describe "#remove", :focus do
+  describe "#remove" do
     it "expires feature" do
       feature = flipper[:stats]
       adapter.get(feature)
@@ -49,14 +49,17 @@ RSpec.describe Flipper::Adapters::RedisCache do
 
       adapter.get_multi([stats, search, other])
 
-      expect(cache.get(described_class.key_for(search))[:boolean]).to eq("true")
-      expect(cache.get(described_class.key_for(other))[:boolean]).to be(nil)
+      search_cache_value, other_cache_value = [search, other].map do |f|
+        Marshal.load(cache.get(described_class.key_for(f)))
+      end
+      expect(search_cache_value[:boolean]).to eq("true")
+      expect(other_cache_value[:boolean]).to be(nil)
     end
   end
 
   describe "#name" do
-    it "is dalli" do
-      expect(subject.name).to be(:dalli)
+    it "is redis_cache" do
+      expect(subject.name).to be(:redis_cache)
     end
   end
 end

--- a/spec/flipper/adapters/redis_cache_spec.rb
+++ b/spec/flipper/adapters/redis_cache_spec.rb
@@ -1,0 +1,62 @@
+require 'helper'
+require 'flipper/adapters/redis_cache'
+require 'flipper/spec/shared_adapter_specs'
+
+RSpec.describe Flipper::Adapters::RedisCache do
+  let(:client) {
+    options = {}
+
+    if ENV['BOXEN_REDIS_URL']
+      options[:url] = ENV['BOXEN_REDIS_URL']
+    end
+
+    Redis.new(options)
+  }
+
+  let(:memory_adapter) { Flipper::Adapters::Memory.new }
+  let(:cache)   { Redis.new({url: ENV.fetch('BOXEN_REDIS_URL', 'localhost:6379')})}
+  let(:adapter) { Flipper::Adapters::RedisCache.new(memory_adapter, cache) }
+  let(:flipper) { Flipper.new(adapter) }
+
+  subject { described_class.new(adapter, cache) }
+
+  before do
+    client.flushdb
+  end
+
+  it_should_behave_like 'a flipper adapter'
+
+  describe "#remove", :focus do
+    it "expires feature" do
+      feature = flipper[:stats]
+      adapter.get(feature)
+      adapter.remove(feature)
+      expect(cache.get(described_class.key_for(feature))).to be(nil)
+    end
+  end
+
+  describe "#get_multi" do
+    it "warms uncached features" do
+      stats = flipper[:stats]
+      search = flipper[:search]
+      other = flipper[:other]
+      stats.enable
+      search.enable
+
+      adapter.get(stats)
+      expect(cache.get(described_class.key_for(search))).to be(nil)
+      expect(cache.get(described_class.key_for(other))).to be(nil)
+
+      adapter.get_multi([stats, search, other])
+
+      expect(cache.get(described_class.key_for(search))[:boolean]).to eq("true")
+      expect(cache.get(described_class.key_for(other))[:boolean]).to be(nil)
+    end
+  end
+
+  describe "#name" do
+    it "is dalli" do
+      expect(subject.name).to be(:dalli)
+    end
+  end
+end

--- a/spec/helper.rb
+++ b/spec/helper.rb
@@ -6,7 +6,6 @@ FlipperRoot = Pathname(__FILE__).dirname.join('..').expand_path
 
 require 'rubygems'
 require 'bundler'
-require 'pry'
 
 Bundler.setup(:default)
 

--- a/spec/helper.rb
+++ b/spec/helper.rb
@@ -6,6 +6,7 @@ FlipperRoot = Pathname(__FILE__).dirname.join('..').expand_path
 
 require 'rubygems'
 require 'bundler'
+require 'pry'
 
 Bundler.setup(:default)
 

--- a/test/adapters/dalli_test.rb
+++ b/test/adapters/dalli_test.rb
@@ -6,7 +6,8 @@ class DalliTest < MiniTest::Test
   prepend Flipper::Test::SharedAdapterTests
 
   def setup
-    @cache = Dalli::Client.new('localhost:11211')
+    url = ENV.fetch('BOXEN_MEMCACHED_URL', 'localhost:11211')
+    @cache = Dalli::Client.new(url)
     @cache.flush
     memory_adapter = Flipper::Adapters::Memory.new
     @adapter = Flipper::Adapters::Dalli.new(memory_adapter, @cache)

--- a/test/adapters/mongo_test.rb
+++ b/test/adapters/mongo_test.rb
@@ -5,7 +5,7 @@ class MongoTest < MiniTest::Test
   prepend Flipper::Test::SharedAdapterTests
 
   def setup
-    host = '127.0.0.1'
+    host = ENV.fetch('BOXEN_MONGODB_HOST', '127.0.0.1')
     port = '27017'
     logger = Logger.new("/dev/null")
     collection = Mongo::Client.new(["#{host}:#{port}"], server_selection_timeout: 1, database: 'testing', logger: logger)['testing']

--- a/test/adapters/redis_cache_test.rb
+++ b/test/adapters/redis_cache_test.rb
@@ -1,0 +1,18 @@
+require 'test_helper'
+require 'flipper/adapters/memory'
+require 'flipper/adapters/redis_cache'
+
+class DalliTest < MiniTest::Test
+  prepend Flipper::Test::SharedAdapterTests
+
+  def setup
+    url = ENV.fetch('BOXEN_REDIS_URL', 'localhost:6379')
+    @cache = Redis.new({url: url}).tap { |c| c.flushdb }
+    memory_adapter = Flipper::Adapters::Memory.new
+    @adapter = Flipper::Adapters::RedisCache.new(memory_adapter, @cache)
+  end
+
+  def teardown
+    @cache.flushdb
+  end
+end

--- a/test/adapters/redis_cache_test.rb
+++ b/test/adapters/redis_cache_test.rb
@@ -6,7 +6,7 @@ class DalliTest < MiniTest::Test
   prepend Flipper::Test::SharedAdapterTests
 
   def setup
-    url = ENV.fetch('BOXEN_REDIS_URL', 'localhost:6379')
+    url = ENV.fetch('BOXEN_REDIS_URL', 'redis://localhost:6379')
     @cache = Redis.new({url: url}).tap { |c| c.flushdb }
     memory_adapter = Flipper::Adapters::Memory.new
     @adapter = Flipper::Adapters::RedisCache.new(memory_adapter, @cache)

--- a/test/adapters/redis_test.rb
+++ b/test/adapters/redis_test.rb
@@ -5,7 +5,7 @@ class RedisTest < MiniTest::Test
   prepend Flipper::Test::SharedAdapterTests
 
   def setup
-    url = ENV.fetch('BOXEN_REDIS_URL', 'localhost:6379')
+    url = ENV.fetch('BOXEN_REDIS_URL', 'redis://localhost:6379')
     client = Redis.new({url: url}).tap { |c| c.flushdb }
     @adapter = Flipper::Adapters::Redis.new(client)
   end

--- a/test/adapters/redis_test.rb
+++ b/test/adapters/redis_test.rb
@@ -6,7 +6,7 @@ class RedisTest < MiniTest::Test
 
   def setup
     url = ENV.fetch('BOXEN_REDIS_URL', 'localhost:6379')
-   client = Redis.new({url: url}).tap { |c| c.flushdb }
-   @adapter = Flipper::Adapters::Redis.new(client)
+    client = Redis.new({url: url}).tap { |c| c.flushdb }
+    @adapter = Flipper::Adapters::Redis.new(client)
   end
 end

--- a/test/adapters/redis_test.rb
+++ b/test/adapters/redis_test.rb
@@ -5,7 +5,8 @@ class RedisTest < MiniTest::Test
   prepend Flipper::Test::SharedAdapterTests
 
   def setup
-   client = Redis.new({}).tap { |c| c.flushdb }
+    url = ENV.fetch('BOXEN_REDIS_URL', 'localhost:6379')
+   client = Redis.new({url: url}).tap { |c| c.flushdb }
    @adapter = Flipper::Adapters::Redis.new(client)
   end
 end


### PR DESCRIPTION
closes #142 - first attempt at adding a redis cache adapter. I've added some testing setup that was broken and documented running them via docker-compose.

I mimicked the dalli cache adapter almost entirely, i think the only choices i had to make were is this included in the flipper-redis gem and how to use the setex cmd (ttl) with redis. I chose yes and to marshal objects when storing / retrieving, limited testing on this show the features serializing in and out of redis ok.  Happy to change the implementation if you want.

Side note: when testing in the pry debugger, the inspect method on a feature would call the `adapter.get`[here](https://github.com/jnunemaker/flipper/blob/cb7ba8f9bc0c69671978d3f28d212b893b01323b/lib/flipper/feature.rb#L219) and warm the cache which took me a while to figure out. Maybe i should just make a note of this in the readme / wiki...?