### PR TITLE
Remove link to deprecated Rails 4 ActiveRecord  Adapter

### DIFF
--- a/docs/Adapters.md
+++ b/docs/Adapters.md
@@ -14,7 +14,6 @@ I plan on supporting the adapters in the flipper repo. Other adapters are welcom
 
 ## Community Supported
 
-* [Active Record 4 adapter](https://github.com/bgentry/flipper-activerecord)
 * [Active Record 3 adapter](https://github.com/blueboxjesse/flipper-activerecord)
 * [Consul adapter](https://github.com/gdavison/flipper-consul)
 


### PR DESCRIPTION
* no longer supported so we shouldn't point users there

![screen shot 2017-01-21 at 4 23 27 pm](https://cloud.githubusercontent.com/assets/3260042/22177892/ec0ea646-dff5-11e6-8c46-9222f40fa9cb.png)
