### PR TITLE
Add JsonParams to Api to add JSON request body to rack params

### DIFF
--- a/lib/flipper/api.rb
+++ b/lib/flipper/api.rb
@@ -1,6 +1,7 @@
 require 'rack'
 require 'flipper'
 require 'flipper/api/middleware'
+require 'flipper/api/json_params'
 require 'flipper/api/actor'
 
 module Flipper
@@ -11,6 +12,7 @@ module Flipper
       app = App.new(200, { 'Content-Type' => CONTENT_TYPE }, [''])
       builder = Rack::Builder.new
       yield builder if block_given?
+      builder.use Flipper::Api::JsonParams
       builder.use Flipper::Api::Middleware, flipper
       builder.run app
       builder

--- a/lib/flipper/api/json_params.rb
+++ b/lib/flipper/api/json_params.rb
@@ -1,0 +1,45 @@
+require 'rack/utils'
+
+module Flipper
+  module Api
+    class JsonParams
+      include Rack::Utils
+
+      def initialize(app)
+        @app = app
+      end
+
+      CONTENT_TYPE = 'CONTENT_TYPE'.freeze
+      QUERY_STRING = 'QUERY_STRING'.freeze
+      REQUEST_BODY = 'rack.input'.freeze
+
+      # Public: Merge request body params with query string params
+      # This way can access all params with Rack::Request#params
+      # Rack does not add application/json params to Rack::Request#params
+      # Allows app to handle x-www-url-form-encoded / application/json request
+      # parameters the same way
+      def call(env)
+        if env[CONTENT_TYPE] == 'application/json'
+          body = env[REQUEST_BODY].read
+          env[REQUEST_BODY].rewind
+          update_params(env, body)
+        end
+        @app.call(env)
+      end
+
+      private
+
+      # Rails 3.2.2.1 Rack version does not have Rack::Request#update_param
+      # Rack 1.5.0 adds update_param
+      # This method accomplishes similar functionality
+      def update_params(env, data)
+        return if data.empty?
+        parsed_request_body = JSON.parse(data)
+        parsed_query_string = parse_query(env[QUERY_STRING])
+        parsed_query_string.merge!(parsed_request_body)
+        parameters = build_query(parsed_query_string)
+        env[QUERY_STRING] = parameters
+      end
+    end
+  end
+end

--- a/spec/flipper/api/json_params_spec.rb
+++ b/spec/flipper/api/json_params_spec.rb
@@ -1,0 +1,81 @@
+require 'helper'
+
+RSpec.describe Flipper::Api::JsonParams do
+  let(:app) do
+    app = lambda do |env|
+      request = Rack::Request.new(env)
+      [200, { 'Content-Type' => 'application/json' }, [request.params.to_json]]
+    end
+    builder = Rack::Builder.new
+    builder.use described_class
+    builder.run app
+    builder
+  end
+
+  describe 'json post request' do
+    it 'adds request body to params' do
+      response = post '/',
+                      { flipper_id: 'user:2' }.to_json,
+                      'CONTENT_TYPE' => 'application/json'
+
+      params = JSON.parse(response.body)
+      expect(params).to eq('flipper_id' => 'user:2')
+    end
+
+    it 'handles request bodies with multiple params' do
+      response = post '/',
+                      { flipper_id: 'user:2', language: 'ruby' }.to_json,
+                      'CONTENT_TYPE' => 'application/json'
+
+      params = JSON.parse(response.body)
+      expect(params).to eq('flipper_id' => 'user:2', 'language' => 'ruby')
+    end
+
+    it 'handles request bodies and single query string params' do
+      response = post '/?language=ruby',
+                      { flipper_id: 'user:2' }.to_json,
+                      'CONTENT_TYPE' => 'application/json'
+
+      params = JSON.parse(response.body)
+      expect(params).to eq('flipper_id' => 'user:2', 'language' => 'ruby')
+    end
+
+    it 'handles request bodies and multiple query string params' do
+      response = post '/?language=ruby&framework=rails',
+                      { flipper_id: 'user:2' }.to_json,
+                      'CONTENT_TYPE' => 'application/json'
+
+      params = JSON.parse(response.body)
+      expect(params).to eq('flipper_id' => 'user:2', 'language' => 'ruby', 'framework' => 'rails')
+    end
+
+    it 'favors request body params' do
+      response = post '/?language=javascript',
+                      { flipper_id: 'user:2', language: 'ruby' }.to_json,
+                      'CONTENT_TYPE' => 'application/json'
+
+      params = JSON.parse(response.body)
+      expect(params).to eq('flipper_id' => 'user:2', 'language' => 'ruby')
+    end
+  end
+
+  describe 'url-encoded request' do
+    it 'handles params the same as a json request' do
+      response = post '/', flipper_id: 'user:2'
+      params = JSON.parse(response.body)
+      expect(params).to eq('flipper_id' => 'user:2')
+    end
+
+    it 'handles single query string params' do
+      response = post '/?language=ruby', flipper_id: 'user:2'
+      params = JSON.parse(response.body)
+      expect(params).to eq('flipper_id' => 'user:2', 'language' => 'ruby')
+    end
+
+    it 'handles multiple query string params' do
+      response = post '/?language=ruby&framework=rails', flipper_id: 'user:2'
+      params = JSON.parse(response.body)
+      expect(params).to eq('flipper_id' => 'user:2', 'language' => 'ruby', 'framework' => 'rails')
+    end
+  end
+end

--- a/spec/flipper/api/v1/actions/percentage_of_actors_gate_spec.rb
+++ b/spec/flipper/api/v1/actions/percentage_of_actors_gate_spec.rb
@@ -4,18 +4,38 @@ RSpec.describe Flipper::Api::V1::Actions::PercentageOfActorsGate do
   let(:app) { build_api(flipper) }
 
   describe 'enable' do
-    before do
-      flipper[:my_feature].disable
-      post '/api/v1/features/my_feature/percentage_of_actors', percentage: '10'
+    context 'url-encoded request' do
+      before do
+        flipper[:my_feature].disable
+        post '/api/v1/features/my_feature/percentage_of_actors', percentage: '10'
+      end
+
+      it 'enables gate for feature' do
+        expect(flipper[:my_feature].enabled_gate_names).to include(:percentage_of_actors)
+      end
+
+      it 'returns decorated feature with gate enabled for 10 percent of actors' do
+        gate = json_response['gates'].find { |gate| gate['name'] == 'percentage_of_actors' }
+        expect(gate['value']).to eq(10)
+      end
     end
 
-    it 'enables gate for feature' do
-      expect(flipper[:my_feature].enabled_gate_names).to include(:percentage_of_actors)
-    end
+    context 'json request' do
+      before do
+        flipper[:my_feature].disable
+        post '/api/v1/features/my_feature/percentage_of_actors',
+             { percentage: '10' }.to_json,
+             'CONTENT_TYPE' => 'application/json'
+      end
 
-    it 'returns decorated feature with gate enabled for 10 percent of actors' do
-      gate = json_response['gates'].find { |gate| gate['name'] == 'percentage_of_actors' }
-      expect(gate['value']).to eq(10)
+      it 'enables gate for feature' do
+        expect(flipper[:my_feature].enabled_gate_names).to include(:percentage_of_actors)
+      end
+
+      it 'returns decorated feature with gate enabled for 10 percent of actors' do
+        gate = json_response['gates'].find { |gate| gate['name'] == 'percentage_of_actors' }
+        expect(gate['value']).to eq(10)
+      end
     end
   end
 


### PR DESCRIPTION
This is an interesting issue uncovered from some work I've been doing on the api client.  RSpec sends post requests as x-www-form-urlencoded and rack adds any parameters to the Rack::Request#params hash.  The api actions look at params for the request data.  The problem is that for application/json requests rack does not add the parsed body to the params hash.  This PR adds simple custom middleware that for request with content-type application/json will parse the body and add the key/values to the params hash so that the api can handle both x-www-form-urlencoded and application/json requests.

I added a spec for the middleware and also to one of the api action specs to ensure the api middleware stack is working as expected.  The middleware spec keeps me confident the middleware works as expected, but wondering if there's a better way to test that the Flipper Api rack app uses the middleware other than testing every action that looks at the request body?  Maybe just testing JsonParams is included in the stack + the middleware test would be solid?
