### PR TITLE
Api Flipper from Env

### DIFF
--- a/lib/flipper/api.rb
+++ b/lib/flipper/api.rb
@@ -2,18 +2,20 @@ require 'rack'
 require 'flipper'
 require 'flipper/api/middleware'
 require 'flipper/api/json_params'
+require 'flipper/api/setup_env'
 require 'flipper/api/actor'
 
 module Flipper
   module Api
     CONTENT_TYPE = 'application/json'.freeze
 
-    def self.app(flipper)
+    def self.app(flipper = nil)
       app = App.new(200, { 'Content-Type' => CONTENT_TYPE }, [''])
       builder = Rack::Builder.new
       yield builder if block_given?
+      builder.use Flipper::Api::SetupEnv, flipper
       builder.use Flipper::Api::JsonParams
-      builder.use Flipper::Api::Middleware, flipper
+      builder.use Flipper::Api::Middleware
       builder.run app
       builder
     end

--- a/lib/flipper/api.rb
+++ b/lib/flipper/api.rb
@@ -17,6 +17,8 @@ module Flipper
       builder.use Flipper::Api::JsonParams
       builder.use Flipper::Api::Middleware
       builder.run app
+      klass = self
+      builder.define_singleton_method(:inspect) { klass.inspect } # pretty rake routes output
       builder
     end
 

--- a/lib/flipper/api/middleware.rb
+++ b/lib/flipper/api/middleware.rb
@@ -9,30 +9,8 @@ end
 module Flipper
   module Api
     class Middleware
-      # Public: Initializes an instance of the API middleware.
-      #
-      # app - The app this middleware is included in.
-      # flipper_or_block - The Flipper::DSL instance or a block that yields a
-      #                    Flipper::DSL instance to use for all operations.
-      #
-      # Examples
-      #
-      #   flipper = Flipper.new(...)
-      #
-      #   # using with a normal flipper instance
-      #   use Flipper::Api::Middleware, flipper
-      #
-      #   # using with a block that yields a flipper instance
-      #   use Flipper::Api::Middleware, lambda { Flipper.new(...) }
-      #
-      def initialize(app, flipper_or_block)
+      def initialize(app)
         @app = app
-
-        if flipper_or_block.respond_to?(:call)
-          @flipper_block = flipper_or_block
-        else
-          @flipper = flipper_or_block
-        end
 
         @action_collection = ActionCollection.new
         @action_collection.add Api::V1::Actions::PercentageOfTimeGate
@@ -42,10 +20,6 @@ module Flipper
         @action_collection.add Api::V1::Actions::BooleanGate
         @action_collection.add Api::V1::Actions::Feature
         @action_collection.add Api::V1::Actions::Features
-      end
-
-      def flipper
-        @flipper ||= @flipper_block.call
       end
 
       def call(env)
@@ -59,6 +33,7 @@ module Flipper
           @app.status = 404
           @app.call(env)
         else
+          flipper = env.fetch("flipper")
           action_class.run(flipper, request)
         end
       end

--- a/lib/flipper/api/middleware.rb
+++ b/lib/flipper/api/middleware.rb
@@ -33,7 +33,7 @@ module Flipper
           @app.status = 404
           @app.call(env)
         else
-          flipper = env.fetch("flipper")
+          flipper = env.fetch('flipper')
           action_class.run(flipper, request)
         end
       end

--- a/lib/flipper/api/setup_env.rb
+++ b/lib/flipper/api/setup_env.rb
@@ -1,0 +1,44 @@
+module Flipper
+  module Api
+    class SetupEnv
+      # Public: Initializes an instance of the SetEnv middleware. Allows for
+      # lazy initialization of the flipper instance being set in the env by
+      # providing a block.
+      #
+      # app - The app this middleware is included in.
+      # flipper_or_block - The Flipper::DSL instance or a block that yields a
+      #                    Flipper::DSL instance to use for all operations.
+      #
+      # Examples
+      #
+      #   flipper = Flipper.new(...)
+      #
+      #   # using with a normal flipper instance
+      #   use Flipper::Api::SetEnv, flipper
+      #
+      #   # using with a block that yields a flipper instance
+      #   use Flipper::Api::SetEnv, lambda { Flipper.new(...) }
+      #
+      def initialize(app, flipper_or_block)
+        @app = app
+
+        if flipper_or_block.respond_to?(:call)
+          @flipper_block = flipper_or_block
+        else
+          @flipper = flipper_or_block
+        end
+      end
+
+      def call(env)
+        env["flipper".freeze] ||= flipper
+        @app.call(env)
+      end
+
+      private
+
+      def flipper
+        @flipper ||= @flipper_block.call
+      end
+    end
+  end
+end

--- a/lib/flipper/api/setup_env.rb
+++ b/lib/flipper/api/setup_env.rb
@@ -30,7 +30,7 @@ module Flipper
       end
 
       def call(env)
-        env["flipper".freeze] ||= flipper
+        env['flipper'.freeze] ||= flipper
         @app.call(env)
       end
 

--- a/spec/flipper/api/setup_env_spec.rb
+++ b/spec/flipper/api/setup_env_spec.rb
@@ -1,0 +1,58 @@
+require 'helper'
+
+RSpec.describe Flipper::Api::SetupEnv do
+  context "with flipper instance" do
+    let(:app) do
+      app = lambda do |env|
+        [200, { 'Content-Type' => 'text/html' }, [env["flipper"].object_id.to_s]]
+      end
+      builder = Rack::Builder.new
+      builder.use described_class, flipper
+      builder.run app
+      builder
+    end
+
+    it "sets flipper in env" do
+      get "/"
+      expect(last_response.body).to eq(flipper.object_id.to_s)
+    end
+  end
+
+  context "with block that returns flipper instance" do
+    let(:flipper_block) {
+      ->{ flipper }
+    }
+    let(:app) do
+      app = lambda do |env|
+        [200, { 'Content-Type' => 'text/html' }, [env["flipper"].object_id.to_s]]
+      end
+      builder = Rack::Builder.new
+      builder.use described_class, flipper_block
+      builder.run app
+      builder
+    end
+
+    it "sets flipper in env" do
+      get "/"
+      expect(last_response.body).to eq(flipper.object_id.to_s)
+    end
+  end
+
+  context "when env already has flipper setup" do
+    let(:app) do
+      app = lambda do |env|
+        [200, { 'Content-Type' => 'text/html' }, [env["flipper"].object_id.to_s]]
+      end
+      builder = Rack::Builder.new
+      builder.use described_class, flipper
+      builder.run app
+      builder
+    end
+
+    it "leaves env flipper alone" do
+      env_flipper = build_flipper
+      get "/", {}, {"flipper" => env_flipper}
+      expect(last_response.body).to eq(env_flipper.object_id.to_s)
+    end
+  end
+end

--- a/spec/flipper/api/setup_env_spec.rb
+++ b/spec/flipper/api/setup_env_spec.rb
@@ -1,10 +1,10 @@
 require 'helper'
 
 RSpec.describe Flipper::Api::SetupEnv do
-  context "with flipper instance" do
+  context 'with flipper instance' do
     let(:app) do
       app = lambda do |env|
-        [200, { 'Content-Type' => 'text/html' }, [env["flipper"].object_id.to_s]]
+        [200, { 'Content-Type' => 'text/html' }, [env['flipper'].object_id.to_s]]
       end
       builder = Rack::Builder.new
       builder.use described_class, flipper
@@ -12,19 +12,19 @@ RSpec.describe Flipper::Api::SetupEnv do
       builder
     end
 
-    it "sets flipper in env" do
-      get "/"
+    it 'sets flipper in env' do
+      get '/'
       expect(last_response.body).to eq(flipper.object_id.to_s)
     end
   end
 
-  context "with block that returns flipper instance" do
-    let(:flipper_block) {
-      ->{ flipper }
-    }
+  context 'with block that returns flipper instance' do
+    let(:flipper_block) do
+      -> { flipper }
+    end
     let(:app) do
       app = lambda do |env|
-        [200, { 'Content-Type' => 'text/html' }, [env["flipper"].object_id.to_s]]
+        [200, { 'Content-Type' => 'text/html' }, [env['flipper'].object_id.to_s]]
       end
       builder = Rack::Builder.new
       builder.use described_class, flipper_block
@@ -32,16 +32,16 @@ RSpec.describe Flipper::Api::SetupEnv do
       builder
     end
 
-    it "sets flipper in env" do
-      get "/"
+    it 'sets flipper in env' do
+      get '/'
       expect(last_response.body).to eq(flipper.object_id.to_s)
     end
   end
 
-  context "when env already has flipper setup" do
+  context 'when env already has flipper setup' do
     let(:app) do
       app = lambda do |env|
-        [200, { 'Content-Type' => 'text/html' }, [env["flipper"].object_id.to_s]]
+        [200, { 'Content-Type' => 'text/html' }, [env['flipper'].object_id.to_s]]
       end
       builder = Rack::Builder.new
       builder.use described_class, flipper
@@ -49,17 +49,17 @@ RSpec.describe Flipper::Api::SetupEnv do
       builder
     end
 
-    it "leaves env flipper alone" do
+    it 'leaves env flipper alone' do
       env_flipper = build_flipper
-      get "/", {}, {"flipper" => env_flipper}
+      get '/', {}, 'flipper' => env_flipper
       expect(last_response.body).to eq(env_flipper.object_id.to_s)
     end
   end
 
-  context "when flipper instance is nil" do
+  context 'when flipper instance is nil' do
     let(:app) do
       app = lambda do |env|
-        [200, { 'Content-Type' => 'text/html' }, [env["flipper"].object_id.to_s]]
+        [200, { 'Content-Type' => 'text/html' }, [env['flipper'].object_id.to_s]]
       end
       builder = Rack::Builder.new
       builder.use described_class, nil
@@ -67,9 +67,9 @@ RSpec.describe Flipper::Api::SetupEnv do
       builder
     end
 
-    it "leaves env flipper alone" do
+    it 'leaves env flipper alone' do
       env_flipper = build_flipper
-      get "/", {}, {"flipper" => env_flipper}
+      get '/', {}, 'flipper' => env_flipper
       expect(last_response.body).to eq(env_flipper.object_id.to_s)
     end
   end

--- a/spec/flipper/api/setup_env_spec.rb
+++ b/spec/flipper/api/setup_env_spec.rb
@@ -55,4 +55,22 @@ RSpec.describe Flipper::Api::SetupEnv do
       expect(last_response.body).to eq(env_flipper.object_id.to_s)
     end
   end
+
+  context "when flipper instance is nil" do
+    let(:app) do
+      app = lambda do |env|
+        [200, { 'Content-Type' => 'text/html' }, [env["flipper"].object_id.to_s]]
+      end
+      builder = Rack::Builder.new
+      builder.use described_class, nil
+      builder.run app
+      builder
+    end
+
+    it "leaves env flipper alone" do
+      env_flipper = build_flipper
+      get "/", {}, {"flipper" => env_flipper}
+      expect(last_response.body).to eq(env_flipper.object_id.to_s)
+    end
+  end
 end

--- a/spec/flipper/api_spec.rb
+++ b/spec/flipper/api_spec.rb
@@ -1,10 +1,10 @@
 require 'helper'
 
 RSpec.describe Flipper::Api do
-  context "when initialized with flipper instance and flipper instance in env" do
+  context 'when initialized with flipper instance and flipper instance in env' do
     let(:app) { build_api(flipper) }
 
-    it "uses env instance over initialized instance" do
+    it 'uses env instance over initialized instance' do
       flipper[:built_a].enable
       flipper[:built_b].disable
 
@@ -14,31 +14,31 @@ RSpec.describe Flipper::Api do
 
       params = {}
       env = {
-        "flipper" => env_flipper,
+        'flipper' => env_flipper,
       }
       get 'api/v1/features', params, env
 
       expect(last_response.status).to eq(200)
-      feature_names = json_response.fetch("features").map { |feature| feature.fetch("key") }
+      feature_names = json_response.fetch('features').map { |feature| feature.fetch('key') }
       expect(feature_names).to eq(%w(env_a env_b))
     end
   end
 
-  context "when initialized without flipper instance but flipper instance in env" do
-    let(:app) { Flipper::Api.app }
+  context 'when initialized without flipper instance but flipper instance in env' do
+    let(:app) { described_class.app }
 
-    it "uses env instance" do
+    it 'uses env instance' do
       flipper[:a].enable
       flipper[:b].disable
 
       params = {}
       env = {
-        "flipper" => flipper,
+        'flipper' => flipper,
       }
       get 'api/v1/features', params, env
 
       expect(last_response.status).to eq(200)
-      feature_names = json_response.fetch("features").map { |feature| feature.fetch("key") }
+      feature_names = json_response.fetch('features').map { |feature| feature.fetch('key') }
       expect(feature_names).to eq(%w(a b))
     end
   end

--- a/spec/flipper/api_spec.rb
+++ b/spec/flipper/api_spec.rb
@@ -1,0 +1,45 @@
+require 'helper'
+
+RSpec.describe Flipper::Api do
+  context "when initialized with flipper instance and flipper instance in env" do
+    let(:app) { build_api(flipper) }
+
+    it "uses env instance over initialized instance" do
+      flipper[:built_a].enable
+      flipper[:built_b].disable
+
+      env_flipper = build_flipper
+      env_flipper[:env_a].enable
+      env_flipper[:env_b].disable
+
+      params = {}
+      env = {
+        "flipper" => env_flipper,
+      }
+      get 'api/v1/features', params, env
+
+      expect(last_response.status).to eq(200)
+      feature_names = json_response.fetch("features").map { |feature| feature.fetch("key") }
+      expect(feature_names).to eq(%w(env_a env_b))
+    end
+  end
+
+  context "when initialized without flipper instance but flipper instance in env" do
+    let(:app) { Flipper::Api.app }
+
+    it "uses env instance" do
+      flipper[:a].enable
+      flipper[:b].disable
+
+      params = {}
+      env = {
+        "flipper" => flipper,
+      }
+      get 'api/v1/features', params, env
+
+      expect(last_response.status).to eq(200)
+      feature_names = json_response.fetch("features").map { |feature| feature.fetch("key") }
+      expect(feature_names).to eq(%w(a b))
+    end
+  end
+end


### PR DESCRIPTION
This makes it so that the API can use flipper from the request env instead of having to pass an instance in. One benefit is that the middleware is more simple. It now just reads `env["flipper"]`. Another benefit is that the flipper instance can be dynamically determined in upstream middleware. This allows the API to be mounted with a prefix or something and a little bit of middleware that sets the flipper instance based on that prefix.

This is all backwards compatible, it just adds a bit more flexiblity for something I have up my sleeve unrelated to this. 😁 @AlexWheeler any thoughts on this either way?