### PR TITLE
API Get Multi Support

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -24,6 +24,9 @@ Style/Encoding:
 Style/NumericLiterals:
   Enabled: false
 
+Style/StringLiterals:
+  Enabled: false
+
 Metrics/LineLength:
   Max: 100
   Exclude:

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -9,6 +9,7 @@ AllCops:
     - 'docker-compose/**/*'
     - 'examples/**/*'
     - 'tmp/**/*'
+    - 'bin/**/*'
   TargetRubyVersion: 2.0
   # DefaultFormatter: fuubar
 Style/Alias:
@@ -33,4 +34,3 @@ Style/RegexpLiteral:
 
 Style/TrailingCommaInLiteral:
   EnforcedStyleForMultiline: consistent_comma
-

--- a/lib/flipper/api/v1/actions/features.rb
+++ b/lib/flipper/api/v1/actions/features.rb
@@ -10,11 +10,23 @@ module Flipper
           route %r{api/v1/features\Z}
 
           def get
-            features = flipper.features.map do |feature|
+            keys = params['keys']
+            features = if keys
+                         names = keys.split(',')
+                         if names.empty?
+                           []
+                         else
+                           flipper.preload(names)
+                         end
+                       else
+                         flipper.features
+                       end
+
+            decorated_features = features.map do |feature|
               Decorators::Feature.new(feature).as_json
             end
 
-            json_response(features: features)
+            json_response(features: decorated_features)
           end
 
           def post

--- a/spec/flipper/api/v1/actions/features_spec.rb
+++ b/spec/flipper/api/v1/actions/features_spec.rb
@@ -54,6 +54,22 @@ RSpec.describe Flipper::Api::V1::Actions::Features do
       end
     end
 
+    context 'with keys specified' do
+      before do
+        flipper[:audit_log].enable
+        flipper[:issues].enable
+        flipper[:search].enable
+        flipper[:stats].disable
+        get 'api/v1/features', 'keys' => 'search,stats'
+      end
+
+      it 'responds with correct attributes' do
+        expect(last_response.status).to eq(200)
+        keys = json_response.fetch('features').map { |feature| feature.fetch('key') }.sort
+        expect(keys).to eq(%w(search stats))
+      end
+    end
+
     context 'with no flipper features' do
       before do
         get 'api/v1/features'


### PR DESCRIPTION
This makes it so that by specifying `keys` (comma separated list of keys) parameter to `/features` limits the output to the requested keys. Should make https://github.com/jnunemaker/flipper/pull/221#discussion_r98196015 easy to do.