### PR TITLE
Shorten API Routes

### DIFF
--- a/docs/api/README.md
+++ b/docs/api/README.md
@@ -23,7 +23,7 @@ Or install it yourself as:
 ```ruby
 # config/routes.rb
 YourRailsApp::Application.routes.draw do
-  mount Flipper::Api.app(flipper) => '/flipper-api'
+  mount Flipper::Api.app(flipper) => '/flipper/api'
 end
 ```
 
@@ -35,15 +35,16 @@ There can be more than one router in your application. Make sure if you choose a
 ```ruby
 YourRailsApp::Application.routes.draw do
   mount Flipper::UI.app(flipper) => '/flipper'
-  mount Flipper::Api.app(flipper) => '/flipper-api'
+  mount Flipper::Api.app(flipper) => '/flipper/api'
 end
-````
-In this case any requests to /flipper\* will be routed to Flipper::UI - including /flipper-api* requests.  Simply swap these two to make sure that any requests that don't match /flipper-api\* will be routed to Flipper::UI.
+```
+
+In this case any requests to /flipper\* will be routed to Flipper::UI - including /flipper/api* requests.  Simply swap these two to make sure that any requests that don't match /flipper/api\* will be routed to Flipper::UI.
 
 *good:*
 ```ruby
 YourRailsApp::Application.routes.draw do
-  mount Flipper::Api.app(flipper) => '/flipper-api'
+  mount Flipper::Api.app(flipper) => '/flipper/api'
   mount Flipper::UI.app(flipper) => '/flipper'
 end
 ````
@@ -51,7 +52,7 @@ For more advanced mounting techniques and for suggestions on how to mount in a n
 
 ## Endpoints
 
-**Note:** Example CURL requests below assume a mount point of `/flipper-api`.
+**Note:** Example CURL requests below assume a mount point of `/flipper/api`.
 
 ### Get all features
 
@@ -62,7 +63,7 @@ For more advanced mounting techniques and for suggestions on how to mount in a n
 **Request**
 
 ```
-curl http://example.com/flipper-api/features
+curl http://example.com/flipper/api/features
 ```
 
 **Response**
@@ -151,7 +152,7 @@ Returns an array of feature objects:
 **Request**
 
 ```
-curl -X POST -d "name=reports" http://example.com/flipper-api/features
+curl -X POST -d "name=reports" http://example.com/flipper/api/features
 ```
 
 **Response**
@@ -171,7 +172,7 @@ On successful creation, the API will respond with an empty JSON response.
 **Request**
 
 ```
-curl http://example.com/flipper-api/features/reports
+curl http://example.com/flipper/api/features/reports
 ```
 
 **Response**
@@ -225,7 +226,7 @@ Returns an individual feature object:
 **Request**
 
 ```
-curl -X DELETE http://example.com/flipper-api/features/reports
+curl -X DELETE http://example.com/flipper/api/features/reports
 ```
 
 **Response**
@@ -259,7 +260,7 @@ and on a succesful request return a 200 HTTP status and the feature object as th
 **Request**
 
 ```
-curl -X POST http://example.com/flipper-api/features/reports/boolean
+curl -X POST http://example.com/flipper/api/features/reports/boolean
 ```
 
 **Response**
@@ -314,7 +315,7 @@ Successful enabling of the boolean gate will return a 200 HTTP status and the fe
 **Request**
 
 ```
-curl -X DELETE http://example.com/flipper-api/features/reports/boolean
+curl -X DELETE http://example.com/flipper/api/features/reports/boolean
 ```
 
 **Response**
@@ -370,7 +371,7 @@ Successful disabling of the boolean gate will return a 200 HTTP status and the f
 **Request**
 
 ```
-curl -X POST -d "name=admins" http://example.com/flipper-api/features/reports/groups
+curl -X POST -d "name=admins" http://example.com/flipper/api/features/reports/groups
 ```
 
 **Response**
@@ -426,7 +427,7 @@ Successful enabling of the group will return a 200 HTTP status and the feature o
 **Request**
 
 ```
-curl -X DELETE -d "name=admins" http://example.com/flipper-api/features/reports/groups
+curl -X DELETE -d "name=admins" http://example.com/flipper/api/features/reports/groups
 ```
 
 **Response**
@@ -481,7 +482,7 @@ Successful disabling of the group will return a 200 HTTP status and the feature 
 **Request**
 
 ```
-curl -X POST -d "flipper_id=User:1" http://example.com/flipper-api/features/reports/actors
+curl -X POST -d "flipper_id=User:1" http://example.com/flipper/api/features/reports/actors
 ```
 
 **Response**
@@ -536,7 +537,7 @@ Successful enabling of the actor will return a 200 HTTP status and the feature o
 **Request**
 
 ```
-curl -X DELETE -d "flipper_id=User:1" http://example.com/flipper-api/features/reports/actors
+curl -X DELETE -d "flipper_id=User:1" http://example.com/flipper/api/features/reports/actors
 ```
 
 **Response**
@@ -592,7 +593,7 @@ Successful disabling of the actor will return a 200 HTTP status and the feature 
 **Request**
 
 ```
-curl -X POST -d "percentage=20" http://example.com/flipper-api/features/reports/percentage_of_actors
+curl -X POST -d "percentage=20" http://example.com/flipper/api/features/reports/percentage_of_actors
 ```
 
 **Response**
@@ -645,7 +646,7 @@ Successful enabling of a percentage of actors will return a 200 HTTP status and 
 **Request**
 
 ```
-curl -X DELETE http://example.com/flipper-api/features/reports/percentage_of_actors
+curl -X DELETE http://example.com/flipper/api/features/reports/percentage_of_actors
 ```
 
 **Response**
@@ -700,7 +701,7 @@ Successful disabling of a percentage of actors will set the percentage to 0 and 
 **Request**
 
 ```
-curl -X POST -d "percentage=20" http://example.com/flipper-api/features/reports/percentage_of_time
+curl -X POST -d "percentage=20" http://example.com/flipper/api/features/reports/percentage_of_time
 ```
 
 **Response**
@@ -753,7 +754,7 @@ Successful enabling of a percentage of time will return a 200 HTTP status and th
 **Request**
 
 ```
-curl -X DELETE http://example.com/flipper-api/features/reports/percentage_of_time
+curl -X DELETE http://example.com/flipper/api/features/reports/percentage_of_time
 ```
 
 **Response**

--- a/docs/api/README.md
+++ b/docs/api/README.md
@@ -57,12 +57,12 @@ For more advanced mounting techniques and for suggestions on how to mount in a n
 
 **URL**
 
-`GET /api/v1/features`
+`GET /features`
 
 **Request**
 
 ```
-curl http://example.com/flipper-api/api/v1/features
+curl http://example.com/flipper-api/features
 ```
 
 **Response**
@@ -142,7 +142,7 @@ Returns an array of feature objects:
 
 **URL**
 
-`POST /api/v1/features`
+`POST /features`
 
 **Parameters**
 
@@ -151,7 +151,7 @@ Returns an array of feature objects:
 **Request**
 
 ```
-curl -X POST -d "name=reports" http://example.com/flipper-api/api/v1/features
+curl -X POST -d "name=reports" http://example.com/flipper-api/features
 ```
 
 **Response**
@@ -162,7 +162,7 @@ On successful creation, the API will respond with an empty JSON response.
 
 **URL**
 
-`GET /api/v1/features/{feature_name}`
+`GET /features/{feature_name}`
 
 **Parameters**
 
@@ -171,7 +171,7 @@ On successful creation, the API will respond with an empty JSON response.
 **Request**
 
 ```
-curl http://example.com/flipper-api/api/v1/features/reports
+curl http://example.com/flipper-api/features/reports
 ```
 
 **Response**
@@ -216,7 +216,7 @@ Returns an individual feature object:
 
 **URL**
 
-`DELETE /api/v1/features/{feature_name}`
+`DELETE /features/{feature_name}`
 
 **Parameters**
 
@@ -225,7 +225,7 @@ Returns an individual feature object:
 **Request**
 
 ```
-curl -X DELETE http://example.com/flipper-api/api/v1/features/reports
+curl -X DELETE http://example.com/flipper-api/features/reports
 ```
 
 **Response**
@@ -238,11 +238,11 @@ The API supports enabling / disabling any of the Flipper [gates](https://github.
 
 **enable**
 
-`POST /api/v1/{feature_name}/{gate_name}`
+`POST /{feature_name}/{gate_name}`
 
 **disable**
 
-`DELETE /api/v1/{feature_name}/{gate_name}`
+`DELETE /{feature_name}/{gate_name}`
 
 and on a succesful request return a 200 HTTP status and the feature object as the response body.
 
@@ -250,7 +250,7 @@ and on a succesful request return a 200 HTTP status and the feature object as th
 
 **URL**
 
-`POST /api/v1/features/{feature_name}/boolean`
+`POST /features/{feature_name}/boolean`
 
 **Parameters**
 
@@ -259,7 +259,7 @@ and on a succesful request return a 200 HTTP status and the feature object as th
 **Request**
 
 ```
-curl -X POST http://example.com/flipper-api/api/v1/features/reports/boolean
+curl -X POST http://example.com/flipper-api/features/reports/boolean
 ```
 
 **Response**
@@ -305,7 +305,7 @@ Successful enabling of the boolean gate will return a 200 HTTP status and the fe
 
 **URL**
 
-`DELETE /api/v1/features/{feature_name}/boolean`
+`DELETE /features/{feature_name}/boolean`
 
 **Parameters**
 
@@ -314,7 +314,7 @@ Successful enabling of the boolean gate will return a 200 HTTP status and the fe
 **Request**
 
 ```
-curl -X DELETE http://example.com/flipper-api/api/v1/features/reports/boolean
+curl -X DELETE http://example.com/flipper-api/features/reports/boolean
 ```
 
 **Response**
@@ -359,7 +359,7 @@ Successful disabling of the boolean gate will return a 200 HTTP status and the f
 
 **URL**
 
-`POST /api/v1/features/{feature_name}/groups`
+`POST /features/{feature_name}/groups`
 
 **Parameters**
 
@@ -370,7 +370,7 @@ Successful disabling of the boolean gate will return a 200 HTTP status and the f
 **Request**
 
 ```
-curl -X POST -d "name=admins" http://example.com/flipper-api/api/v1/features/reports/groups
+curl -X POST -d "name=admins" http://example.com/flipper-api/features/reports/groups
 ```
 
 **Response**
@@ -415,7 +415,7 @@ Successful enabling of the group will return a 200 HTTP status and the feature o
 
 **URL**
 
-`DELETE /api/v1/features/{feature_name}/groups`
+`DELETE /features/{feature_name}/groups`
 
 **Parameters**
 
@@ -426,7 +426,7 @@ Successful enabling of the group will return a 200 HTTP status and the feature o
 **Request**
 
 ```
-curl -X DELETE -d "name=admins" http://example.com/flipper-api/api/v1/features/reports/groups
+curl -X DELETE -d "name=admins" http://example.com/flipper-api/features/reports/groups
 ```
 
 **Response**
@@ -470,7 +470,7 @@ Successful disabling of the group will return a 200 HTTP status and the feature 
 
 **URL**
 
-`POST /api/v1/features/{feature_name}/actors`
+`POST /features/{feature_name}/actors`
 
 **Parameters**
 
@@ -481,7 +481,7 @@ Successful disabling of the group will return a 200 HTTP status and the feature 
 **Request**
 
 ```
-curl -X POST -d "flipper_id=User:1" http://example.com/flipper-api/api/v1/features/reports/actors
+curl -X POST -d "flipper_id=User:1" http://example.com/flipper-api/features/reports/actors
 ```
 
 **Response**
@@ -525,7 +525,7 @@ Successful enabling of the actor will return a 200 HTTP status and the feature o
 
 **URL**
 
-`DELETE /api/v1/features/{feature_name}/actors`
+`DELETE /features/{feature_name}/actors`
 
 **Parameters**
 
@@ -536,7 +536,7 @@ Successful enabling of the actor will return a 200 HTTP status and the feature o
 **Request**
 
 ```
-curl -X DELETE -d "flipper_id=User:1" http://example.com/flipper-api/api/v1/features/reports/actors
+curl -X DELETE -d "flipper_id=User:1" http://example.com/flipper-api/features/reports/actors
 ```
 
 **Response**
@@ -581,7 +581,7 @@ Successful disabling of the actor will return a 200 HTTP status and the feature 
 
 **URL**
 
-`POST /api/v1/features/{feature_name}/percentage_of_actors`
+`POST /features/{feature_name}/percentage_of_actors`
 
 **Parameters**
 
@@ -592,7 +592,7 @@ Successful disabling of the actor will return a 200 HTTP status and the feature 
 **Request**
 
 ```
-curl -X POST -d "percentage=20" http://example.com/flipper-api/api/v1/features/reports/percentage_of_actors
+curl -X POST -d "percentage=20" http://example.com/flipper-api/features/reports/percentage_of_actors
 ```
 
 **Response**
@@ -636,7 +636,7 @@ Successful enabling of a percentage of actors will return a 200 HTTP status and 
 
 **URL**
 
-`DELETE /api/v1/features/{feature_name}/percentage_of_actors`
+`DELETE /features/{feature_name}/percentage_of_actors`
 
 **Parameters**
 
@@ -645,7 +645,7 @@ Successful enabling of a percentage of actors will return a 200 HTTP status and 
 **Request**
 
 ```
-curl -X DELETE http://example.com/flipper-api/api/v1/features/reports/percentage_of_actors
+curl -X DELETE http://example.com/flipper-api/features/reports/percentage_of_actors
 ```
 
 **Response**
@@ -689,7 +689,7 @@ Successful disabling of a percentage of actors will set the percentage to 0 and 
 
 **URL**
 
-`POST /api/v1/features/{feature_name}/percentage_of_time`
+`POST /features/{feature_name}/percentage_of_time`
 
 **Parameters**
 
@@ -700,7 +700,7 @@ Successful disabling of a percentage of actors will set the percentage to 0 and 
 **Request**
 
 ```
-curl -X POST -d "percentage=20" http://example.com/flipper-api/api/v1/features/reports/percentage_of_time
+curl -X POST -d "percentage=20" http://example.com/flipper-api/features/reports/percentage_of_time
 ```
 
 **Response**
@@ -744,7 +744,7 @@ Successful enabling of a percentage of time will return a 200 HTTP status and th
 
 **URL**
 
-`DELETE /api/v1/features/{feature_name}/percentage_of_time`
+`DELETE /features/{feature_name}/percentage_of_time`
 
 **Parameters**
 
@@ -753,7 +753,7 @@ Successful enabling of a percentage of time will return a 200 HTTP status and th
 **Request**
 
 ```
-curl -X DELETE http://example.com/flipper-api/api/v1/features/reports/percentage_of_time
+curl -X DELETE http://example.com/flipper-api/features/reports/percentage_of_time
 ```
 
 **Response**

--- a/lib/flipper/adapters/http.rb
+++ b/lib/flipper/adapters/http.rb
@@ -102,7 +102,7 @@ module Flipper
       end
 
       def get(feature)
-        response = @request.get(@uri + "/api/v1/features/#{feature.key}")
+        response = @request.get(@uri + "/features/#{feature.key}")
         raise Error, response unless response.is_a?(Net::HTTPOK)
 
         parsed_response = JSON.parse(response.body)
@@ -110,13 +110,13 @@ module Flipper
       end
 
       def add(feature)
-        response = @request.post(@uri + '/api/v1/features', name: feature.key)
+        response = @request.post(@uri + '/features', name: feature.key)
         response.is_a?(Net::HTTPOK)
       end
 
       def get_multi(features)
         csv_keys = features.map(&:key).join(',')
-        response = @request.get(@uri + "/api/v1/features?keys=#{csv_keys}")
+        response = @request.get(@uri + "/features?keys=#{csv_keys}")
         raise Error, response unless response.is_a?(Net::HTTPOK)
 
         parsed_response = JSON.parse(response.body)
@@ -134,7 +134,7 @@ module Flipper
       end
 
       def features
-        response = @request.get(@uri + '/api/v1/features')
+        response = @request.get(@uri + '/features')
         raise Error, response unless response.is_a?(Net::HTTPOK)
 
         parsed_response = JSON.parse(response.body)
@@ -142,24 +142,24 @@ module Flipper
       end
 
       def remove(feature)
-        response = @request.delete(@uri + "/api/v1/features/#{feature.key}")
+        response = @request.delete(@uri + "/features/#{feature.key}")
         response.is_a?(Net::HTTPNoContent)
       end
 
       def enable(feature, gate, thing)
         body = gate_request_body(gate.key, thing.value.to_s)
-        response = @request.post(@uri + "/api/v1/features/#{feature.key}/#{gate.key}", body)
+        response = @request.post(@uri + "/features/#{feature.key}/#{gate.key}", body)
         response.is_a?(Net::HTTPOK)
       end
 
       def disable(feature, gate, thing)
         body = gate_request_body(gate.key, thing.value)
-        response = @request.delete(@uri + "/api/v1/features/#{feature.key}/#{gate.key}", body)
+        response = @request.delete(@uri + "/features/#{feature.key}/#{gate.key}", body)
         response.is_a?(Net::HTTPOK)
       end
 
       def clear(feature)
-        response = @request.delete(@uri + "/api/v1/features/#{feature.key}/boolean")
+        response = @request.delete(@uri + "/features/#{feature.key}/boolean")
         response.is_a?(Net::HTTPOK)
       end
 

--- a/lib/flipper/api.rb
+++ b/lib/flipper/api.rb
@@ -10,7 +10,7 @@ module Flipper
     CONTENT_TYPE = 'application/json'.freeze
 
     def self.app(flipper = nil)
-      app = App.new(200, { 'Content-Type' => CONTENT_TYPE }, [''])
+      app = ->(_) { [404, { 'Content-Type'.freeze => CONTENT_TYPE }, ['{}'.freeze]] }
       builder = Rack::Builder.new
       yield builder if block_given?
       builder.use Flipper::Api::SetupEnv, flipper
@@ -20,30 +20,6 @@ module Flipper
       klass = self
       builder.define_singleton_method(:inspect) { klass.inspect } # pretty rake routes output
       builder
-    end
-
-    class App
-      # Public: HTTP response code
-      # Use this method to update status code before responding
-      attr_writer :status
-
-      def initialize(status, headers, body)
-        @status = status
-        @headers = headers
-        @body = body
-      end
-
-      # Public : Rack expects object that responds to call
-      # env - environment hash
-      def call(_env)
-        response
-      end
-
-      private
-
-      def response
-        [@status, @headers, @body]
-      end
     end
   end
 end

--- a/lib/flipper/api/action.rb
+++ b/lib/flipper/api/action.rb
@@ -137,7 +137,7 @@ module Flipper
       end
 
       # Private: split request path by "/"
-      # Example: "api/v1/features/feature_name" => ['api', 'v1', 'features', 'feature_name']
+      # Example: "features/feature_name" => ['features', 'feature_name']
       def path_parts
         @request.path.split('/')
       end

--- a/lib/flipper/api/middleware.rb
+++ b/lib/flipper/api/middleware.rb
@@ -30,7 +30,6 @@ module Flipper
         request = Rack::Request.new(env)
         action_class = @action_collection.action_for_request(request)
         if action_class.nil?
-          @app.status = 404
           @app.call(env)
         else
           flipper = env.fetch('flipper')

--- a/lib/flipper/api/v1/actions/actors_gate.rb
+++ b/lib/flipper/api/v1/actions/actors_gate.rb
@@ -6,7 +6,7 @@ module Flipper
     module V1
       module Actions
         class ActorsGate < Api::Action
-          route %r{api/v1/features/[^/]*/actors/?\Z}
+          route %r{features/[^/]*/actors/?\Z}
 
           def post
             ensure_valid_params

--- a/lib/flipper/api/v1/actions/boolean_gate.rb
+++ b/lib/flipper/api/v1/actions/boolean_gate.rb
@@ -6,7 +6,7 @@ module Flipper
     module V1
       module Actions
         class BooleanGate < Api::Action
-          route %r{api/v1/features/[^/]*/boolean/?\Z}
+          route %r{features/[^/]*/boolean/?\Z}
 
           def post
             feature_name = Rack::Utils.unescape(path_parts[-2])

--- a/lib/flipper/api/v1/actions/feature.rb
+++ b/lib/flipper/api/v1/actions/feature.rb
@@ -6,7 +6,7 @@ module Flipper
     module V1
       module Actions
         class Feature < Api::Action
-          route %r{api/v1/features/[^/]*/?\Z}
+          route %r{features/[^/]*/?\Z}
 
           def get
             if feature_names.include?(feature_name)

--- a/lib/flipper/api/v1/actions/features.rb
+++ b/lib/flipper/api/v1/actions/features.rb
@@ -6,7 +6,7 @@ module Flipper
     module V1
       module Actions
         class Features < Api::Action
-          route %r{features\Z}
+          route /features\Z/
 
           def get
             features = flipper.features.map do |feature|

--- a/lib/flipper/api/v1/actions/features.rb
+++ b/lib/flipper/api/v1/actions/features.rb
@@ -1,6 +1,5 @@
 require 'flipper/api/action'
 require 'flipper/api/v1/decorators/feature'
-require 'json'
 
 module Flipper
   module Api

--- a/lib/flipper/api/v1/actions/features.rb
+++ b/lib/flipper/api/v1/actions/features.rb
@@ -6,7 +6,7 @@ module Flipper
     module V1
       module Actions
         class Features < Api::Action
-          route %r{api/v1/features\Z}
+          route %r{features\Z}
 
           def get
             features = flipper.features.map do |feature|

--- a/lib/flipper/api/v1/actions/features.rb
+++ b/lib/flipper/api/v1/actions/features.rb
@@ -6,7 +6,7 @@ module Flipper
     module V1
       module Actions
         class Features < Api::Action
-          route /features\Z/
+          route(/features\Z/)
 
           def get
             features = flipper.features.map do |feature|

--- a/lib/flipper/api/v1/actions/groups_gate.rb
+++ b/lib/flipper/api/v1/actions/groups_gate.rb
@@ -6,7 +6,7 @@ module Flipper
     module V1
       module Actions
         class GroupsGate < Api::Action
-          route %r{api/v1/features/[^/]*/groups/?\Z}
+          route %r{features/[^/]*/groups/?\Z}
 
           def post
             ensure_valid_params

--- a/lib/flipper/api/v1/actions/percentage_of_actors_gate.rb
+++ b/lib/flipper/api/v1/actions/percentage_of_actors_gate.rb
@@ -6,7 +6,7 @@ module Flipper
     module V1
       module Actions
         class PercentageOfActorsGate < Api::Action
-          route %r{api/v1/features/[^/]*/percentage_of_actors/?\Z}
+          route %r{features/[^/]*/percentage_of_actors/?\Z}
 
           def post
             ensure_valid_enable_params

--- a/lib/flipper/api/v1/actions/percentage_of_time_gate.rb
+++ b/lib/flipper/api/v1/actions/percentage_of_time_gate.rb
@@ -6,7 +6,7 @@ module Flipper
     module V1
       module Actions
         class PercentageOfTimeGate < Api::Action
-          route %r{api/v1/features/[^/]*/percentage_of_time/?\Z}
+          route %r{features/[^/]*/percentage_of_time/?\Z}
 
           def post
             ensure_valid_enable_params

--- a/spec/flipper/adapters/http_spec.rb
+++ b/spec/flipper/adapters/http_spec.rb
@@ -47,7 +47,7 @@ RSpec.describe Flipper::Adapters::Http do
 
   describe "#get" do
     it "raises error when not successful response" do
-      stub_request(:get, "http://app.com/flipper/api/v1/features/feature_panel")
+      stub_request(:get, "http://app.com/flipper/features/feature_panel")
         .to_return(status: 503, body: "", headers: {})
 
       adapter = described_class.new('http://app.com/flipper')
@@ -59,7 +59,7 @@ RSpec.describe Flipper::Adapters::Http do
 
   describe "#get_multi" do
     it "raises error when not successful response" do
-      stub_request(:get, "http://app.com/flipper/api/v1/features?keys=feature_panel")
+      stub_request(:get, "http://app.com/flipper/features?keys=feature_panel")
         .to_return(status: 503, body: "", headers: {})
 
       adapter = described_class.new('http://app.com/flipper')
@@ -71,7 +71,7 @@ RSpec.describe Flipper::Adapters::Http do
 
   describe "#features" do
     it "raises error when not successful response" do
-      stub_request(:get, "http://app.com/flipper/api/v1/features")
+      stub_request(:get, "http://app.com/flipper/features")
         .to_return(status: 503, body: "", headers: {})
 
       adapter = described_class.new('http://app.com/flipper')
@@ -99,7 +99,7 @@ RSpec.describe Flipper::Adapters::Http do
     it 'allows client to set request headers' do
       subject.get(feature)
       expect(
-        a_request(:get, 'http://app.com/mount-point/api/v1/features/feature_panel')
+        a_request(:get, 'http://app.com/mount-point/features/feature_panel')
         .with(headers: { 'X-Custom-Header' => 'foo' })
       ).to have_been_made.once
     end
@@ -107,7 +107,7 @@ RSpec.describe Flipper::Adapters::Http do
     it 'allows client to set basic auth' do
       subject.get(feature)
       expect(
-        a_request(:get, 'http://app.com/mount-point/api/v1/features/feature_panel')
+        a_request(:get, 'http://app.com/mount-point/features/feature_panel')
         .with(basic_auth: %w(username password))
       ).to have_been_made.once
     end

--- a/spec/flipper/api/v1/actions/actors_gate_spec.rb
+++ b/spec/flipper/api/v1/actions/actors_gate_spec.rb
@@ -8,7 +8,7 @@ RSpec.describe Flipper::Api::V1::Actions::ActorsGate do
 
     before do
       flipper[:my_feature].disable_actor(actor)
-      post '/api/v1/features/my_feature/actors', flipper_id: actor.flipper_id
+      post '/features/my_feature/actors', flipper_id: actor.flipper_id
     end
 
     it 'enables feature for actor' do
@@ -28,7 +28,7 @@ RSpec.describe Flipper::Api::V1::Actions::ActorsGate do
 
     before do
       flipper[:my_feature].enable_actor(actor)
-      delete '/api/v1/features/my_feature/actors', flipper_id: actor.flipper_id
+      delete '/features/my_feature/actors', flipper_id: actor.flipper_id
     end
 
     it 'disables feature' do
@@ -46,7 +46,7 @@ RSpec.describe Flipper::Api::V1::Actions::ActorsGate do
   describe 'enable missing flipper_id parameter' do
     before do
       flipper[:my_feature].enable
-      post '/api/v1/features/my_feature/actors'
+      post '/features/my_feature/actors'
     end
 
     it 'returns correct error response' do
@@ -58,7 +58,7 @@ RSpec.describe Flipper::Api::V1::Actions::ActorsGate do
   describe 'disable missing flipper_id parameter' do
     before do
       flipper[:my_feature].enable
-      delete '/api/v1/features/my_feature/actors'
+      delete '/features/my_feature/actors'
     end
 
     it 'returns correct error response' do
@@ -70,7 +70,7 @@ RSpec.describe Flipper::Api::V1::Actions::ActorsGate do
   describe 'enable nil flipper_id parameter' do
     before do
       flipper[:my_feature].enable
-      post '/api/v1/features/my_feature/actors', flipper_id: nil
+      post '/features/my_feature/actors', flipper_id: nil
     end
 
     it 'returns correct error response' do
@@ -82,7 +82,7 @@ RSpec.describe Flipper::Api::V1::Actions::ActorsGate do
   describe 'disable nil flipper_id parameter' do
     before do
       flipper[:my_feature].enable
-      delete '/api/v1/features/my_feature/actors', flipper_id: nil
+      delete '/features/my_feature/actors', flipper_id: nil
     end
 
     it 'returns correct error response' do
@@ -93,7 +93,7 @@ RSpec.describe Flipper::Api::V1::Actions::ActorsGate do
 
   describe 'enable missing feature' do
     before do
-      post '/api/v1/features/my_feature/actors'
+      post '/features/my_feature/actors'
     end
 
     it 'returns correct error response' do
@@ -104,7 +104,7 @@ RSpec.describe Flipper::Api::V1::Actions::ActorsGate do
 
   describe 'disable missing feature' do
     before do
-      delete '/api/v1/features/my_feature/actors'
+      delete '/features/my_feature/actors'
     end
 
     it 'returns correct error response' do

--- a/spec/flipper/api/v1/actions/boolean_gate_spec.rb
+++ b/spec/flipper/api/v1/actions/boolean_gate_spec.rb
@@ -6,7 +6,7 @@ RSpec.describe Flipper::Api::V1::Actions::BooleanGate do
   describe 'enable' do
     before do
       flipper[:my_feature].disable
-      post '/api/v1/features/my_feature/boolean'
+      post '/features/my_feature/boolean'
     end
 
     it 'enables feature' do
@@ -23,7 +23,7 @@ RSpec.describe Flipper::Api::V1::Actions::BooleanGate do
   describe 'disable' do
     before do
       flipper[:my_feature].enable
-      delete '/api/v1/features/my_feature/boolean'
+      delete '/features/my_feature/boolean'
     end
 
     it 'disables feature' do

--- a/spec/flipper/api/v1/actions/feature_spec.rb
+++ b/spec/flipper/api/v1/actions/feature_spec.rb
@@ -9,7 +9,7 @@ RSpec.describe Flipper::Api::V1::Actions::Feature do
     context 'enabled feature' do
       before do
         flipper[:my_feature].enable
-        get 'api/v1/features/my_feature'
+        get '/features/my_feature'
       end
 
       it 'responds with correct attributes' do
@@ -53,7 +53,7 @@ RSpec.describe Flipper::Api::V1::Actions::Feature do
     context 'disabled feature' do
       before do
         flipper[:my_feature].disable
-        get 'api/v1/features/my_feature'
+        get '/features/my_feature'
       end
 
       it 'responds with correct attributes' do
@@ -96,7 +96,7 @@ RSpec.describe Flipper::Api::V1::Actions::Feature do
 
     context 'feature does not exist' do
       before do
-        get 'api/v1/features/not_a_feature'
+        get '/features/not_a_feature'
       end
 
       it 'returns 404' do
@@ -114,7 +114,7 @@ RSpec.describe Flipper::Api::V1::Actions::Feature do
       it 'deletes feature' do
         flipper[:my_feature].enable
         expect(flipper.features.map(&:key)).to include('my_feature')
-        delete 'api/v1/features/my_feature'
+        delete '/features/my_feature'
         expect(last_response.status).to eq(204)
         expect(flipper.features.map(&:key)).not_to include('my_feature')
       end
@@ -122,7 +122,7 @@ RSpec.describe Flipper::Api::V1::Actions::Feature do
 
     context 'feature not found' do
       before do
-        delete 'api/v1/features/my_feature'
+        delete '/features/my_feature'
       end
 
       it 'returns 404' do

--- a/spec/flipper/api/v1/actions/features_spec.rb
+++ b/spec/flipper/api/v1/actions/features_spec.rb
@@ -10,7 +10,7 @@ RSpec.describe Flipper::Api::V1::Actions::Features do
       before do
         flipper[:my_feature].enable
         flipper[:my_feature].enable(admin)
-        get 'api/v1/features'
+        get '/features'
       end
 
       it 'responds with correct attributes' do
@@ -56,7 +56,7 @@ RSpec.describe Flipper::Api::V1::Actions::Features do
 
     context 'with no flipper features' do
       before do
-        get 'api/v1/features'
+        get '/features'
       end
 
       it 'returns empty array for features key' do
@@ -72,7 +72,7 @@ RSpec.describe Flipper::Api::V1::Actions::Features do
   describe 'post' do
     context 'succesful request' do
       before do
-        post 'api/v1/features', name: 'my_feature'
+        post '/features', name: 'my_feature'
       end
 
       it 'responds 200 ' do
@@ -126,7 +126,7 @@ RSpec.describe Flipper::Api::V1::Actions::Features do
 
     context 'bad request' do
       before do
-        post 'api/v1/features'
+        post '/features'
       end
 
       it 'returns correct status code' do

--- a/spec/flipper/api/v1/actions/features_spec.rb
+++ b/spec/flipper/api/v1/actions/features_spec.rb
@@ -60,7 +60,7 @@ RSpec.describe Flipper::Api::V1::Actions::Features do
         flipper[:issues].enable
         flipper[:search].enable
         flipper[:stats].disable
-        get 'api/v1/features', 'keys' => 'search,stats'
+        get '/features', 'keys' => 'search,stats'
       end
 
       it 'responds with correct attributes' do

--- a/spec/flipper/api/v1/actions/groups_gate_spec.rb
+++ b/spec/flipper/api/v1/actions/groups_gate_spec.rb
@@ -9,7 +9,7 @@ RSpec.describe Flipper::Api::V1::Actions::GroupsGate do
       Flipper.register(:admins) do |actor|
         actor.respond_to?(:admin?) && actor.admin?
       end
-      post '/api/v1/features/my_feature/groups', name: 'admins'
+      post '/features/my_feature/groups', name: 'admins'
     end
 
     it 'enables feature for group' do
@@ -33,7 +33,7 @@ RSpec.describe Flipper::Api::V1::Actions::GroupsGate do
         actor.respond_to?(:admin?) && actor.admin?
       end
       flipper[:my_feature].enable_group(:admins)
-      delete '/api/v1/features/my_feature/groups', name: 'admins'
+      delete '/features/my_feature/groups', name: 'admins'
     end
 
     it 'disables feature for group' do
@@ -52,7 +52,7 @@ RSpec.describe Flipper::Api::V1::Actions::GroupsGate do
 
   describe 'non-existent feature' do
     before do
-      delete '/api/v1/features/my_feature/groups', name: 'admins'
+      delete '/features/my_feature/groups', name: 'admins'
     end
 
     it '404s with correct error response when feature does not exist' do
@@ -64,7 +64,7 @@ RSpec.describe Flipper::Api::V1::Actions::GroupsGate do
   describe 'group not registered' do
     before do
       flipper[:my_feature].disable
-      delete '/api/v1/features/my_feature/groups', name: 'admins'
+      delete '/features/my_feature/groups', name: 'admins'
     end
 
     it '404s with correct error response when group not registered' do

--- a/spec/flipper/api/v1/actions/percentage_of_actors_gate_spec.rb
+++ b/spec/flipper/api/v1/actions/percentage_of_actors_gate_spec.rb
@@ -7,7 +7,7 @@ RSpec.describe Flipper::Api::V1::Actions::PercentageOfActorsGate do
     context 'url-encoded request' do
       before do
         flipper[:my_feature].disable
-        post '/api/v1/features/my_feature/percentage_of_actors', percentage: '10'
+        post '/features/my_feature/percentage_of_actors', percentage: '10'
       end
 
       it 'enables gate for feature' do
@@ -23,7 +23,7 @@ RSpec.describe Flipper::Api::V1::Actions::PercentageOfActorsGate do
     context 'json request' do
       before do
         flipper[:my_feature].disable
-        post '/api/v1/features/my_feature/percentage_of_actors',
+        post '/features/my_feature/percentage_of_actors',
              { percentage: '10' }.to_json,
              'CONTENT_TYPE' => 'application/json'
       end
@@ -42,7 +42,7 @@ RSpec.describe Flipper::Api::V1::Actions::PercentageOfActorsGate do
   describe 'disable' do
     before do
       flipper[:my_feature].enable_percentage_of_actors(10)
-      delete '/api/v1/features/my_feature/percentage_of_actors'
+      delete '/features/my_feature/percentage_of_actors'
     end
 
     it 'disables gate for feature' do
@@ -57,7 +57,7 @@ RSpec.describe Flipper::Api::V1::Actions::PercentageOfActorsGate do
 
   describe 'non-existent feature' do
     before do
-      delete '/api/v1/features/my_feature/percentage_of_actors'
+      delete '/features/my_feature/percentage_of_actors'
     end
 
     it '404s with correct error response when feature does not exist' do
@@ -69,7 +69,7 @@ RSpec.describe Flipper::Api::V1::Actions::PercentageOfActorsGate do
   describe 'out of range parameter percentage parameter' do
     before do
       flipper[:my_feature].disable
-      post '/api/v1/features/my_feature/percentage_of_actors', percentage: '300'
+      post '/features/my_feature/percentage_of_actors', percentage: '300'
     end
 
     it '422s with correct error response when percentage parameter is invalid' do
@@ -81,7 +81,7 @@ RSpec.describe Flipper::Api::V1::Actions::PercentageOfActorsGate do
   describe 'percentage parameter not an integer' do
     before do
       flipper[:my_feature].disable
-      post '/api/v1/features/my_feature/percentage_of_actors', percentage: 'foo'
+      post '/features/my_feature/percentage_of_actors', percentage: 'foo'
     end
 
     it '422s with correct error response when percentage parameter is invalid' do
@@ -93,7 +93,7 @@ RSpec.describe Flipper::Api::V1::Actions::PercentageOfActorsGate do
   describe 'missing percentage parameter' do
     before do
       flipper[:my_feature].disable
-      post '/api/v1/features/my_feature/percentage_of_actors'
+      post '/features/my_feature/percentage_of_actors'
     end
 
     it '422s with correct error response when percentage parameter is missing' do

--- a/spec/flipper/api/v1/actions/percentage_of_actors_gate_spec.rb
+++ b/spec/flipper/api/v1/actions/percentage_of_actors_gate_spec.rb
@@ -58,7 +58,7 @@ RSpec.describe Flipper::Api::V1::Actions::PercentageOfActorsGate do
   describe 'disable with percentage' do
     before do
       flipper[:my_feature].enable_percentage_of_actors(10)
-      delete '/api/v1/features/my_feature/percentage_of_actors',
+      delete '/features/my_feature/percentage_of_actors',
              { percentage: '5' }.to_json,
              'CONTENT_TYPE' => 'application/json'
     end

--- a/spec/flipper/api/v1/actions/percentage_of_time_gate_spec.rb
+++ b/spec/flipper/api/v1/actions/percentage_of_time_gate_spec.rb
@@ -38,7 +38,7 @@ RSpec.describe Flipper::Api::V1::Actions::PercentageOfTimeGate do
   describe 'disable with percentage' do
     before do
       flipper[:my_feature].enable_percentage_of_time(10)
-      delete '/api/v1/features/my_feature/percentage_of_time',
+      delete '/features/my_feature/percentage_of_time',
              { percentage: '5' }.to_json,
              'CONTENT_TYPE' => 'application/json'
     end

--- a/spec/flipper/api/v1/actions/percentage_of_time_gate_spec.rb
+++ b/spec/flipper/api/v1/actions/percentage_of_time_gate_spec.rb
@@ -6,7 +6,7 @@ RSpec.describe Flipper::Api::V1::Actions::PercentageOfTimeGate do
   describe 'enable' do
     before do
       flipper[:my_feature].disable
-      post '/api/v1/features/my_feature/percentage_of_time', percentage: '10'
+      post '/features/my_feature/percentage_of_time', percentage: '10'
     end
 
     it 'enables gate for feature' do
@@ -22,7 +22,7 @@ RSpec.describe Flipper::Api::V1::Actions::PercentageOfTimeGate do
   describe 'disable' do
     before do
       flipper[:my_feature].enable_percentage_of_time(10)
-      delete '/api/v1/features/my_feature/percentage_of_time'
+      delete '/features/my_feature/percentage_of_time'
     end
 
     it 'disables gate for feature' do
@@ -37,7 +37,7 @@ RSpec.describe Flipper::Api::V1::Actions::PercentageOfTimeGate do
 
   describe 'non-existent feature' do
     before do
-      delete '/api/v1/features/my_feature/percentage_of_time'
+      delete '/features/my_feature/percentage_of_time'
     end
 
     it '404s with correct error response when feature does not exist' do
@@ -49,7 +49,7 @@ RSpec.describe Flipper::Api::V1::Actions::PercentageOfTimeGate do
   describe 'out of range parameter percentage parameter' do
     before do
       flipper[:my_feature].disable
-      post '/api/v1/features/my_feature/percentage_of_time', percentage: '300'
+      post '/features/my_feature/percentage_of_time', percentage: '300'
     end
 
     it '422s with correct error response when percentage parameter is invalid' do
@@ -61,7 +61,7 @@ RSpec.describe Flipper::Api::V1::Actions::PercentageOfTimeGate do
   describe 'percentage parameter not an integer' do
     before do
       flipper[:my_feature].disable
-      post '/api/v1/features/my_feature/percentage_of_time', percentage: 'foo'
+      post '/features/my_feature/percentage_of_time', percentage: 'foo'
     end
 
     it '422s with correct error response when percentage parameter is invalid' do
@@ -73,7 +73,7 @@ RSpec.describe Flipper::Api::V1::Actions::PercentageOfTimeGate do
   describe 'missing percentage parameter' do
     before do
       flipper[:my_feature].disable
-      post '/api/v1/features/my_feature/percentage_of_time'
+      post '/features/my_feature/percentage_of_time'
     end
 
     it '422s with correct error response when percentage parameter is missing' do

--- a/spec/flipper/api_spec.rb
+++ b/spec/flipper/api_spec.rb
@@ -42,4 +42,14 @@ RSpec.describe Flipper::Api do
       expect(feature_names).to eq(%w(a b))
     end
   end
+
+  context "when request does not match any api routes" do
+    let(:app) { build_api(flipper) }
+
+    it "returns 404" do
+      get '/gibberish'
+      expect(last_response.status).to eq(404)
+      expect(json_response).to eq({})
+    end
+  end
 end

--- a/spec/flipper/api_spec.rb
+++ b/spec/flipper/api_spec.rb
@@ -16,7 +16,7 @@ RSpec.describe Flipper::Api do
       env = {
         'flipper' => env_flipper,
       }
-      get 'api/v1/features', params, env
+      get '/features', params, env
 
       expect(last_response.status).to eq(200)
       feature_names = json_response.fetch('features').map { |feature| feature.fetch('key') }
@@ -35,7 +35,7 @@ RSpec.describe Flipper::Api do
       env = {
         'flipper' => flipper,
       }
-      get 'api/v1/features', params, env
+      get '/features', params, env
 
       expect(last_response.status).to eq(200)
       feature_names = json_response.fetch('features').map { |feature| feature.fetch('key') }


### PR DESCRIPTION
This shortens the api routes to exactly what is necessary for flipper. This allows for flexibility as people can mount this however/wherever they want (e.g. `/flipper`, `/flipper/api`, `/flipper/api/v1`).

Any downside of doing this that I'm overlooking?