### PR TITLE
UI Flipper from Env

### DIFF
--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -61,6 +61,7 @@ Lint/UselessAssignment:
     - 'spec/flipper/instrumentation/metriks_subscriber_spec.rb'
     - 'spec/flipper/instrumentation/statsd_subscriber_spec.rb'
     - 'spec/flipper_spec.rb'
+    - 'spec/flipper/middleware/memoizer_spec.rb'
     - 'test/helper.rb'
 
 # Offense count: 27

--- a/docs/Optimization.md
+++ b/docs/Optimization.md
@@ -12,8 +12,10 @@ You can use the middleware from a Rails initializer like so:
 # create flipper dsl instance, see above Usage for more details
 flipper = Flipper.new(...)
 
+require 'flipper/middleware/setup_env'
 require 'flipper/middleware/memoizer'
-config.middleware.use Flipper::Middleware::Memoizer, flipper
+config.middleware.use Flipper::Middleware::SetupEnv, flipper
+config.middleware.use Flipper::Middleware::Memoizer
 ```
 
 If you set your flipper instance up in an initializer, you can pass a block to the middleware and it will lazily load the instance the first time the middleware is invoked.
@@ -27,9 +29,12 @@ module MyRailsApp
 end
 
 # config/application.rb
-config.middleware.use Flipper::Middleware::Memoizer, lambda {
+require 'flipper/middleware/setup_env'
+require 'flipper/middleware/memoizer'
+config.middleware.use Flipper::Middleware::SetupEnv, lambda {
   MyRailsApp.flipper
 }
+config.middleware.use Flipper::Middleware::Memoizer
 ```
 
 **Note**: Be sure that the middleware is high enough up in your stack that all feature checks are wrapped.
@@ -40,12 +45,12 @@ The Memoizer middleware also supports a few options. Use either `preload` or `pr
 
 * **`:preload`** - An `Array` of feature names (`Symbol`) to preload for every request. Useful if you have features that are used on every endpoint. `preload` uses `Adapter#get_multi` to attempt to load the features in one network call instead of N+1 network calls.
     ```ruby
-    config.middleware.use Flipper::Middleware::Memoizer, flipper,
+    config.middleware.use Flipper::Middleware::Memoizer,
       preload: [:stats, :search, :some_feature]
     ```
 * **`:preload_all`** - A Boolean value (default: false) of whether or not all features should be preloaded. Using this results in a `preload` call with the result of `Adapter#features`. Any subsequent feature checks will be memoized and perform no network calls. I wouldn't recommend using this unless you have few features (< 30?) and nearly all of them are used on every request.  
     ```ruby
-    config.middleware.use Flipper::Middleware::Memoizer, flipper,
+    config.middleware.use Flipper::Middleware::Memoizer,
       preload_all: true
     ```
 

--- a/lib/flipper/api.rb
+++ b/lib/flipper/api.rb
@@ -1,8 +1,8 @@
 require 'rack'
 require 'flipper'
+require 'flipper/middleware/setup_env'
 require 'flipper/api/middleware'
 require 'flipper/api/json_params'
-require 'flipper/api/setup_env'
 require 'flipper/api/actor'
 
 module Flipper
@@ -13,7 +13,7 @@ module Flipper
       app = ->(_) { [404, { 'Content-Type'.freeze => CONTENT_TYPE }, ['{}'.freeze]] }
       builder = Rack::Builder.new
       yield builder if block_given?
-      builder.use Flipper::Api::SetupEnv, flipper
+      builder.use Flipper::Middleware::SetupEnv, flipper
       builder.use Flipper::Api::JsonParams
       builder.use Flipper::Api::Middleware
       builder.run app

--- a/lib/flipper/api.rb
+++ b/lib/flipper/api.rb
@@ -14,6 +14,7 @@ module Flipper
       builder = Rack::Builder.new
       yield builder if block_given?
       builder.use Flipper::Middleware::SetupEnv, flipper
+      builder.use Flipper::Middleware::Memoizer
       builder.use Flipper::Api::JsonParams
       builder.use Flipper::Api::Middleware
       builder.run app

--- a/lib/flipper/middleware/memoizer.rb
+++ b/lib/flipper/middleware/memoizer.rb
@@ -3,43 +3,29 @@ require 'rack/body_proxy'
 module Flipper
   module Middleware
     class Memoizer
-      # Public: Initializes an instance of the Memoizer middleware.
+      # Public: Initializes an instance of the Memoizer middleware. The flipper
+      # instance must be setup in the env of the request. You can do this by
+      # using the Flipper::Middleware::SetupEnv middleware.
       #
       # app - The app this middleware is included in.
-      # flipper_or_block - The Flipper::DSL instance or a block that yields a
-      #                    Flipper::DSL instance to use for all operations.
       #
       # Examples
       #
-      #   # using with a normal flipper instance
-      #   flipper = Flipper.new(...)
-      #   use Flipper::Middleware::Memoizer, flipper
-      #
-      #   # using with a block that yields a flipper instance
-      #   use Flipper::Middleware::Memoizer, lambda { Flipper.new(...) }
+      #   use Flipper::Middleware::Memoizer
       #
       #   # using with preload_all features
-      #   use Flipper::Middleware::Memoizer, flipper, preload_all: true
+      #   use Flipper::Middleware::Memoizer, preload_all: true
       #
       #   # using with preload specific features
-      #   use Flipper::Middleware::Memoizer, flipper, preload: [:stats, :search, :some_feature]
+      #   use Flipper::Middleware::Memoizer, preload: [:stats, :search, :some_feature]
       #
-      def initialize(app, flipper_or_block, opts = {})
+      def initialize(app, opts = {})
         @app = app
         @opts = opts
-
-        if flipper_or_block.respond_to?(:call)
-          @flipper_block = flipper_or_block
-        else
-          @flipper = flipper_or_block
-        end
-      end
-
-      def flipper
-        @flipper ||= @flipper_block.call
       end
 
       def call(env)
+        flipper = env.fetch('flipper')
         original = flipper.adapter.memoizing?
         flipper.adapter.memoize = true
 

--- a/lib/flipper/middleware/setup_env.rb
+++ b/lib/flipper/middleware/setup_env.rb
@@ -1,5 +1,5 @@
 module Flipper
-  module Api
+  module Middleware
     class SetupEnv
       # Public: Initializes an instance of the SetEnv middleware. Allows for
       # lazy initialization of the flipper instance being set in the env by
@@ -14,10 +14,10 @@ module Flipper
       #   flipper = Flipper.new(...)
       #
       #   # using with a normal flipper instance
-      #   use Flipper::Api::SetEnv, flipper
+      #   use Flipper::Middleware::SetEnv, flipper
       #
       #   # using with a block that yields a flipper instance
-      #   use Flipper::Api::SetEnv, lambda { Flipper.new(...) }
+      #   use Flipper::Middleware::SetEnv, lambda { Flipper.new(...) }
       #
       def initialize(app, flipper_or_block)
         @app = app

--- a/lib/flipper/ui.rb
+++ b/lib/flipper/ui.rb
@@ -9,6 +9,7 @@ end
 require 'rack/protection'
 
 require 'flipper'
+require 'flipper/middleware/setup_env'
 require 'flipper/middleware/memoizer'
 
 require 'flipper/ui/actor'

--- a/lib/flipper/ui.rb
+++ b/lib/flipper/ui.rb
@@ -34,15 +34,16 @@ module Flipper
       @root ||= Pathname(__FILE__).dirname.expand_path.join('ui')
     end
 
-    def self.app(flipper, _options = {})
-      app = ->(_env) { [200, { 'Content-Type' => 'text/html' }, ['']] }
+    def self.app(flipper = nil)
+      app = ->() { [200, { 'Content-Type' => 'text/html' }, ['']] }
       builder = Rack::Builder.new
       yield builder if block_given?
       builder.use Rack::Protection
       builder.use Rack::Protection::AuthenticityToken
       builder.use Rack::MethodOverride
-      builder.use Flipper::Middleware::Memoizer, flipper
-      builder.use Middleware, flipper
+      builder.use Flipper::Middleware::SetupEnv, flipper
+      builder.use Flipper::Middleware::Memoizer
+      builder.use Middleware
       builder.run app
       klass = self
       builder.define_singleton_method(:inspect) { klass.inspect } # pretty rake routes output

--- a/lib/flipper/ui/middleware.rb
+++ b/lib/flipper/ui/middleware.rb
@@ -9,30 +9,8 @@ end
 module Flipper
   module UI
     class Middleware
-      # Public: Initializes an instance of the UI middleware.
-      #
-      # app - The app this middleware is included in.
-      # flipper_or_block - The Flipper::DSL instance or a block that yields a
-      #                    Flipper::DSL instance to use for all operations.
-      #
-      # Examples
-      #
-      #   flipper = Flipper.new(...)
-      #
-      #   # using with a normal flipper instance
-      #   use Flipper::UI::Middleware, flipper
-      #
-      #   # using with a block that yields a flipper instance
-      #   use Flipper::UI::Middleware, lambda { Flipper.new(...) }
-      #
-      def initialize(app, flipper_or_block)
+      def initialize(app)
         @app = app
-
-        if flipper_or_block.respond_to?(:call)
-          @flipper_block = flipper_or_block
-        else
-          @flipper = flipper_or_block
-        end
 
         @action_collection = ActionCollection.new
 
@@ -54,10 +32,6 @@ module Flipper
         @action_collection.add UI::Actions::Home
       end
 
-      def flipper
-        @flipper ||= @flipper_block.call
-      end
-
       def call(env)
         dup.call!(env)
       end
@@ -69,6 +43,7 @@ module Flipper
         if action_class.nil?
           @app.call(env)
         else
+          flipper = env.fetch('flipper')
           action_class.run(flipper, request)
         end
       end

--- a/spec/flipper/middleware/memoizer_spec.rb
+++ b/spec/flipper/middleware/memoizer_spec.rb
@@ -12,7 +12,7 @@ RSpec.describe Flipper::Middleware::Memoizer do
     Flipper::Adapters::OperationLogger.new(memory_adapter)
   end
   let(:flipper) { Flipper.new(adapter) }
-  let(:env) { {'flipper' => flipper} }
+  let(:env) { { 'flipper' => flipper } }
 
   after do
     flipper.adapter.memoize = nil
@@ -52,14 +52,14 @@ RSpec.describe Flipper::Middleware::Memoizer do
 
     it 'clears the local cache with a successful request' do
       flipper.adapter.cache['hello'] = 'world'
-      get '/', {}, {'flipper' => flipper}
+      get '/', {}, 'flipper' => flipper
       expect(flipper.adapter.cache).to be_empty
     end
 
     it 'clears the local cache even when the request raises an error' do
       flipper.adapter.cache['hello'] = 'world'
       begin
-        get '/fail', {}, {'flipper' => flipper}
+        get '/fail', {}, 'flipper' => flipper
       rescue
         nil
       end

--- a/spec/flipper/middleware/memoizer_spec.rb
+++ b/spec/flipper/middleware/memoizer_spec.rb
@@ -221,7 +221,7 @@ RSpec.describe Flipper::Middleware::Memoizer do
     end
   end
 
-  context 'with flipper instance' do
+  context 'with flipper setup in env' do
     let(:app) do
       # ensure scoped for builder block, annoying...
       instance = flipper

--- a/spec/flipper/middleware/memoizer_spec.rb
+++ b/spec/flipper/middleware/memoizer_spec.rb
@@ -12,6 +12,7 @@ RSpec.describe Flipper::Middleware::Memoizer do
     Flipper::Adapters::OperationLogger.new(memory_adapter)
   end
   let(:flipper) { Flipper.new(adapter) }
+  let(:env) { {'flipper' => flipper} }
 
   after do
     flipper.adapter.memoize = nil
@@ -24,15 +25,15 @@ RSpec.describe Flipper::Middleware::Memoizer do
         called = true
         [200, {}, nil]
       end
-      middleware = described_class.new app, flipper
-      middleware.call({})
+      middleware = described_class.new(app)
+      middleware.call(env)
       expect(called).to eq(true)
     end
 
     it 'disables local cache after body close' do
       app = ->(_env) { [200, {}, []] }
-      middleware = described_class.new app, flipper
-      body = middleware.call({}).last
+      middleware = described_class.new(app)
+      body = middleware.call(env).last
 
       expect(flipper.adapter.memoizing?).to eq(true)
       body.close
@@ -41,8 +42,8 @@ RSpec.describe Flipper::Middleware::Memoizer do
 
     it 'clears local cache after body close' do
       app = ->(_env) { [200, {}, []] }
-      middleware = described_class.new app, flipper
-      body = middleware.call({}).last
+      middleware = described_class.new(app)
+      body = middleware.call(env).last
 
       flipper.adapter.cache['hello'] = 'world'
       body.close
@@ -51,14 +52,14 @@ RSpec.describe Flipper::Middleware::Memoizer do
 
     it 'clears the local cache with a successful request' do
       flipper.adapter.cache['hello'] = 'world'
-      get '/'
+      get '/', {}, {'flipper' => flipper}
       expect(flipper.adapter.cache).to be_empty
     end
 
     it 'clears the local cache even when the request raises an error' do
       flipper.adapter.cache['hello'] = 'world'
       begin
-        get '/fail'
+        get '/fail', {}, {'flipper' => flipper}
       rescue
         nil
       end
@@ -81,33 +82,11 @@ RSpec.describe Flipper::Middleware::Memoizer do
         [200, {}, []]
       end
 
-      middleware = described_class.new app, flipper
-      middleware.call({})
+      middleware = described_class.new(app)
+      middleware.call(env)
 
       expect(adapter.count(:get)).to be(1)
     end
-  end
-
-  context 'with flipper instance' do
-    let(:app) do
-      # ensure scoped for builder block, annoying...
-      instance = flipper
-      middleware = described_class
-
-      Rack::Builder.new do
-        use middleware, instance
-
-        map '/' do
-          run ->(_env) { [200, {}, []] }
-        end
-
-        map '/fail' do
-          run ->(_env) { raise 'FAIL!' }
-        end
-      end.to_app
-    end
-
-    include_examples 'flipper middleware'
   end
 
   context 'with preload_all' do
@@ -117,7 +96,7 @@ RSpec.describe Flipper::Middleware::Memoizer do
       middleware = described_class
 
       Rack::Builder.new do
-        use middleware, instance, preload_all: true
+        use middleware, preload_all: true
 
         map '/' do
           run ->(_env) { [200, {}, []] }
@@ -146,8 +125,8 @@ RSpec.describe Flipper::Middleware::Memoizer do
         [200, {}, []]
       end
 
-      middleware = described_class.new app, flipper, preload_all: true
-      middleware.call({})
+      middleware = described_class.new(app, preload_all: true)
+      middleware.call(env)
 
       expect(adapter.count(:features)).to be(1)
       expect(adapter.count(:get_multi)).to be(1)
@@ -164,8 +143,8 @@ RSpec.describe Flipper::Middleware::Memoizer do
         [200, {}, []]
       end
 
-      middleware = described_class.new app, flipper, preload_all: true
-      middleware.call({})
+      middleware = described_class.new(app, preload_all: true)
+      middleware.call(env)
 
       expect(adapter.count(:get)).to be(1)
       expect(adapter.last(:get).args).to eq([flipper[:other]])
@@ -179,7 +158,7 @@ RSpec.describe Flipper::Middleware::Memoizer do
       middleware = described_class
 
       Rack::Builder.new do
-        use middleware, instance, preload: %i(stats)
+        use middleware, preload: %i(stats)
 
         map '/' do
           run ->(_env) { [200, {}, []] }
@@ -205,8 +184,8 @@ RSpec.describe Flipper::Middleware::Memoizer do
         [200, {}, []]
       end
 
-      middleware = described_class.new app, flipper, preload: %i(stats)
-      middleware.call({})
+      middleware = described_class.new app, preload: %i(stats)
+      middleware.call(env)
 
       expect(adapter.count(:get_multi)).to be(1)
       expect(adapter.last(:get_multi).args).to eq([[flipper[:stats]]])
@@ -222,8 +201,8 @@ RSpec.describe Flipper::Middleware::Memoizer do
         [200, {}, []]
       end
 
-      middleware = described_class.new app, flipper, preload: %i(stats)
-      middleware.call({})
+      middleware = described_class.new app, preload: %i(stats)
+      middleware.call(env)
 
       expect(adapter.count(:get)).to be(1)
       expect(adapter.last(:get).args).to eq([flipper[:other]])
@@ -234,22 +213,22 @@ RSpec.describe Flipper::Middleware::Memoizer do
     it 'resets memoize' do
       begin
         app = ->(_env) { raise }
-        middleware = described_class.new app, flipper
-        middleware.call({})
+        middleware = described_class.new(app)
+        middleware.call(env)
       rescue RuntimeError
         expect(flipper.adapter.memoizing?).to be(false)
       end
     end
   end
 
-  context 'with block that yields flipper instance' do
+  context 'with flipper instance' do
     let(:app) do
       # ensure scoped for builder block, annoying...
       instance = flipper
       middleware = described_class
 
       Rack::Builder.new do
-        use middleware, -> { instance }
+        use middleware
 
         map '/' do
           run ->(_env) { [200, {}, []] }

--- a/spec/flipper/middleware/setup_env_spec.rb
+++ b/spec/flipper/middleware/setup_env_spec.rb
@@ -1,6 +1,6 @@
 require 'helper'
 
-RSpec.describe Flipper::Api::SetupEnv do
+RSpec.describe Flipper::Middleware::SetupEnv do
   context 'with flipper instance' do
     let(:app) do
       app = lambda do |env|


### PR DESCRIPTION
This makes the UI load from the env. It also makes the memoizer middleware use the flipper from env for consistency sake. The downside is that it requires a parameter change to the memoizer middleware, but it is a minor change we can note it in the changelog for those upgrading.