### PR TITLE
adds link to Sequel library in the Sequel adapter README

### DIFF
--- a/docs/sequel/README.md
+++ b/docs/sequel/README.md
@@ -1,6 +1,6 @@
 # Flipper Sequel
 
-A Sequel adapter for [Flipper](https://github.com/jnunemaker/flipper).
+A [Sequel](https://github.com/jeremyevans/sequel) adapter for [Flipper](https://github.com/jnunemaker/flipper).
 
 ## Installation
 


### PR DESCRIPTION
This adds a link to the Sequel library's home page in the flipper-sequel adapter's README page.

If one does not know about the existence of the Sequel library, then it may be ambiguous whether this adapter supports a particular library or just plain-old SQL (as its commonly pronounced "sequel"). This cost me a considerable amount of time spent getting flipper-sequel to work on my ActiveRecord-decoupled Rails app, until I realized later that it was meant for integration with an app that uses the Sequel library.

I hope this helps.