### PR TITLE
Api no longer returns features that do not exist yet - let HTTP adapter handle this

### DIFF
--- a/lib/flipper/adapters/http.rb
+++ b/lib/flipper/adapters/http.rb
@@ -24,10 +24,14 @@ module Flipper
 
       def get(feature)
         response = @client.get("/features/#{feature.key}")
-        raise Error, response unless response.is_a?(Net::HTTPOK)
-
-        parsed_response = JSON.parse(response.body)
-        result_for_feature(feature, parsed_response.fetch('gates'))
+        if response.is_a?(Net::HTTPOK)
+          parsed_response = JSON.parse(response.body)
+          result_for_feature(feature, parsed_response.fetch('gates'))
+        elsif response.is_a?(Net::HTTPNotFound)
+          default_config
+        else
+          raise Error, response
+        end
       end
 
       def add(feature)

--- a/lib/flipper/api/v1/actions/feature.rb
+++ b/lib/flipper/api/v1/actions/feature.rb
@@ -9,6 +9,7 @@ module Flipper
           route %r{features/[^/]*/?\Z}
 
           def get
+            return json_error_response(:feature_not_found) unless feature_exists?(feature_name)
             feature = Decorators::Feature.new(flipper[feature_name])
             json_response(feature.as_json)
           end
@@ -22,6 +23,10 @@ module Flipper
 
           def feature_name
             @feature_name ||= Rack::Utils.unescape(path_parts.last)
+          end
+
+          def feature_exists?(feature_name)
+            flipper.features.map(&:key).include?(feature_name)
           end
         end
       end

--- a/lib/flipper/api/v1/actions/features.rb
+++ b/lib/flipper/api/v1/actions/features.rb
@@ -15,7 +15,11 @@ module Flipper
                          if names.empty?
                            []
                          else
-                           flipper.preload(names)
+                           existing_feature_names = names.keep_if do |feature_name|
+                             feature_exists?(feature_name)
+                           end
+
+                           flipper.preload(existing_feature_names)
                          end
                        else
                          flipper.features
@@ -34,6 +38,12 @@ module Flipper
             flipper.adapter.add(feature)
             decorated_feature = Decorators::Feature.new(feature)
             json_response(decorated_feature.as_json, 200)
+          end
+
+          private
+
+          def feature_exists?(feature_name)
+            flipper.features.map(&:key).include?(feature_name)
           end
         end
       end

--- a/spec/flipper/api/v1/actions/feature_spec.rb
+++ b/spec/flipper/api/v1/actions/feature_spec.rb
@@ -99,41 +99,14 @@ RSpec.describe Flipper::Api::V1::Actions::Feature do
         get '/features/not_a_feature'
       end
 
-      it 'responds with correct attributes' do
-        response_body = {
-          'key' => 'not_a_feature',
-          'state' => 'off',
-          'gates' => [
-            {
-              'key' => 'boolean',
-              'name' => 'boolean',
-              'value' => nil,
-            },
-            {
-              'key' => 'groups',
-              'name' => 'group',
-              'value' => [],
-            },
-            {
-              'key' => 'actors',
-              'name' => 'actor',
-              'value' => [],
-            },
-            {
-              'key' => 'percentage_of_actors',
-              'name' => 'percentage_of_actors',
-              'value' => nil,
-            },
-            {
-              'key' => 'percentage_of_time',
-              'name' => 'percentage_of_time',
-              'value' => nil,
-            },
-          ],
+      it '404s' do
+        expect(last_response.status).to eq(404)
+        expected = {
+          'code' => 1,
+          'message' => 'Feature not found.',
+          'more_info' => api_error_code_reference_url,
         }
-
-        expect(last_response.status).to eq(200)
-        expect(json_response).to eq(response_body)
+        expect(json_response).to eq(expected)
       end
     end
   end

--- a/spec/flipper/api/v1/actions/features_spec.rb
+++ b/spec/flipper/api/v1/actions/features_spec.rb
@@ -70,6 +70,20 @@ RSpec.describe Flipper::Api::V1::Actions::Features do
       end
     end
 
+    context 'with keys that are not existing features' do
+      before do
+        flipper[:search].disable
+        flipper[:stats].disable
+        get '/features', 'keys' => 'search,stats,not_a_feature,another_feature_that_does_not_exist'
+      end
+
+      it 'only returns features that exist' do
+        expect(last_response.status).to eq(200)
+        keys = json_response.fetch('features').map { |feature| feature.fetch('key') }.sort
+        expect(keys).to eq(%w(search stats))
+      end
+    end
+
     context 'with no flipper features' do
       before do
         get '/features'


### PR DESCRIPTION
* The HTTP adapter, as opposed to the api will return any features requested that do not exist.  This will not effect how flipper currently works with the http adapter.  It will only change how the api responds.

Right now for `http_adapter.get(flipper[:feature_that_is_not_in_database])` the json response will return json that makes it seem like the resource exists when it really doesn't.  The same applies for get_multi.

This PR changes this so that `/features/:feature_that_does_not_exist` will 404, and the http adapter will handle the returning of the feature so that it still works the same way from the perspective of a flipper.  It will just initialize a new flipper feature.  In other words `flipper[:some_non_existant_feature]` will still return a feature instance.

It also filters the api response for get_multi to only return features that exist.  Similarly to the get feature endpoint, the adapter handles returning the default_config for the features that don't exist.

* This will nicely decouple the REST api from the http adapter
* A REST client might want to know if a feature does not exist
