### PR TITLE
Api DELETE features/:feature/:gate can only fully disable a gate

### DIFF
--- a/lib/flipper/adapters/http.rb
+++ b/lib/flipper/adapters/http.rb
@@ -76,7 +76,13 @@ module Flipper
 
       def disable(feature, gate, thing)
         body = request_body_for_gate(gate, thing.value.to_s)
-        response = @client.delete("/features/#{feature.key}/#{gate.key}", body)
+        response =
+          case gate.key
+          when :percentage_of_actors, :percentage_of_time
+            @client.post("/features/#{feature.key}/#{gate.key}", body)
+          else
+            @client.delete("/features/#{feature.key}/#{gate.key}", body)
+          end
         response.is_a?(Net::HTTPOK)
       end
 

--- a/lib/flipper/api/v1/actions/percentage_of_actors_gate.rb
+++ b/lib/flipper/api/v1/actions/percentage_of_actors_gate.rb
@@ -21,12 +21,7 @@ module Flipper
 
           def delete
             feature = flipper[feature_name]
-
-            if percentage >= 0
-              feature.enable_percentage_of_actors(percentage)
-            else
-              feature.disable_percentage_of_actors
-            end
+            feature.disable_percentage_of_actors
             decorated_feature = Decorators::Feature.new(feature)
             json_response(decorated_feature.as_json, 200)
           end

--- a/lib/flipper/api/v1/actions/percentage_of_time_gate.rb
+++ b/lib/flipper/api/v1/actions/percentage_of_time_gate.rb
@@ -21,12 +21,7 @@ module Flipper
 
           def delete
             feature = flipper[feature_name]
-
-            if percentage >= 0
-              feature.enable_percentage_of_time(percentage)
-            else
-              feature.disable_percentage_of_time
-            end
+            feature.disable_percentage_of_time
 
             decorated_feature = Decorators::Feature.new(feature)
             json_response(decorated_feature.as_json, 200)

--- a/spec/flipper/api/v1/actions/percentage_of_actors_gate_spec.rb
+++ b/spec/flipper/api/v1/actions/percentage_of_actors_gate_spec.rb
@@ -63,9 +63,9 @@ RSpec.describe Flipper::Api::V1::Actions::PercentageOfActorsGate do
              'CONTENT_TYPE' => 'application/json'
     end
 
-    it 'returns decorated feature with gate disabled' do
+    it 'returns decorated feature with gate value set to 0 regardless of percentage requested' do
       gate = json_response['gates'].find { |gate| gate['name'] == 'percentage_of_actors' }
-      expect(gate['value']).to eq('5')
+      expect(gate['value']).to eq('0')
     end
   end
 

--- a/spec/flipper/api/v1/actions/percentage_of_time_gate_spec.rb
+++ b/spec/flipper/api/v1/actions/percentage_of_time_gate_spec.rb
@@ -43,10 +43,10 @@ RSpec.describe Flipper::Api::V1::Actions::PercentageOfTimeGate do
              'CONTENT_TYPE' => 'application/json'
     end
 
-    it 'returns decorated feature with gate disabled' do
+    it 'returns decorated feature with gate value set to 0 regardless of percentage requested' do
       expect(last_response.status).to eq(200)
       gate = json_response['gates'].find { |gate| gate['name'] == 'percentage_of_time' }
-      expect(gate['value']).to eq('5')
+      expect(gate['value']).to eq('0')
     end
   end
 


### PR DESCRIPTION
decouple the api from the adapter when disabling percentage_of_gate, percentage_of_actor gates

* The disable gate route should only be used to fully disable a gate by always setting the gate value to 0.  This way the enable/disable endpoints don't behave the same.  The enable endpoint is for setting the value to anything other than 0.  The disable endpoint will be used for always setting the value to 0

* The adapter handles which route to request, for percentage_of_time,
percentage_of_actors.  Will request enable with the value when
adapter.disable is passed a value > 0