### PR TITLE
Disable/Clear Tweaks

### DIFF
--- a/docs/api/README.md
+++ b/docs/api/README.md
@@ -233,6 +233,26 @@ curl -X DELETE http://example.com/flipper/api/features/reports
 
 Successful deletion of a feature will return a 204 No Content response.
 
+### Clear a feature
+
+**URL**
+
+`DELETE /features/{feature_name}/clear`
+
+**Parameters**
+
+* `feature_name` - The name of the feature to clear
+
+**Request**
+
+```
+curl -X DELETE http://example.com/flipper/api/features/reports/clear
+```
+
+**Response**
+
+Successful clearing (removing of all gate values) of a feature will return a 204 No Content response.
+
 ## Gates
 
 The API supports enabling / disabling any of the Flipper [gates](https://github.com/jnunemaker/flipper/blob/master/docs/Gates.md). Gate endpoints follow the url convention:

--- a/lib/flipper/adapters/http.rb
+++ b/lib/flipper/adapters/http.rb
@@ -91,7 +91,7 @@ module Flipper
       end
 
       def clear(feature)
-        response = @client.delete("/features/#{feature.key}/boolean")
+        response = @client.delete("/features/#{feature.key}/clear")
         response.is_a?(Net::HTTPOK)
       end
 

--- a/lib/flipper/api/middleware.rb
+++ b/lib/flipper/api/middleware.rb
@@ -18,6 +18,7 @@ module Flipper
         @action_collection.add Api::V1::Actions::ActorsGate
         @action_collection.add Api::V1::Actions::GroupsGate
         @action_collection.add Api::V1::Actions::BooleanGate
+        @action_collection.add Api::V1::Actions::ClearFeature
         @action_collection.add Api::V1::Actions::Feature
         @action_collection.add Api::V1::Actions::Features
       end

--- a/lib/flipper/api/v1/actions/clear_feature.rb
+++ b/lib/flipper/api/v1/actions/clear_feature.rb
@@ -12,8 +12,7 @@ module Flipper
             feature_name = Rack::Utils.unescape(path_parts[-2])
             feature = flipper[feature_name]
             flipper.adapter.clear(feature)
-            decorated_feature = Decorators::Feature.new(feature)
-            json_response(decorated_feature.as_json, 200)
+            json_response({}, 204)
           end
         end
       end

--- a/lib/flipper/api/v1/actions/clear_feature.rb
+++ b/lib/flipper/api/v1/actions/clear_feature.rb
@@ -8,7 +8,7 @@ module Flipper
         class ClearFeature < Api::Action
           route %r{features/[^/]*/clear/?\Z}
 
-          def post
+          def delete
             feature_name = Rack::Utils.unescape(path_parts[-2])
             feature = flipper[feature_name]
             flipper.adapter.clear(feature)

--- a/lib/flipper/api/v1/actions/clear_feature.rb
+++ b/lib/flipper/api/v1/actions/clear_feature.rb
@@ -1,0 +1,22 @@
+require 'flipper/api/action'
+require 'flipper/api/v1/decorators/feature'
+
+module Flipper
+  module Api
+    module V1
+      module Actions
+        class ClearFeature < Api::Action
+          route %r{features/[^/]*/clear/?\Z}
+
+          def post
+            feature_name = Rack::Utils.unescape(path_parts[-2])
+            feature = flipper[feature_name]
+            flipper.adapter.clear(feature)
+            decorated_feature = Decorators::Feature.new(feature)
+            json_response(decorated_feature.as_json, 200)
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/flipper/feature.rb
+++ b/lib/flipper/feature.rb
@@ -65,11 +65,7 @@ module Flipper
         payload[:gate_name] = gate.name
         payload[:thing] = wrapped_thing
 
-        if gate.is_a?(Gates::Boolean)
-          adapter.clear self
-        else
-          adapter.disable self, gate, wrapped_thing
-        end
+        adapter.disable self, gate, wrapped_thing
       end
     end
 

--- a/spec/flipper/api/v1/actions/clear_feature_spec.rb
+++ b/spec/flipper/api/v1/actions/clear_feature_spec.rb
@@ -20,24 +20,8 @@ RSpec.describe Flipper::Api::V1::Actions::ClearFeature do
     end
 
     it 'clears feature' do
-      expect(last_response.status).to eq(200)
+      expect(last_response.status).to eq(204)
       expect(flipper[:my_feature].off?).to be_truthy
-    end
-
-    it 'returns decorated feature with default config' do
-      defaults = flipper.adapter.default_config
-      expect(json_response['key']).to eq('my_feature')
-      expect(json_response['state']).to eq('off')
-
-      by_keys = json_response['gates'].each_with_object({}) { |gate, acc|
-        acc[gate['key']] = gate
-      }
-
-      expect(by_keys['boolean']['value']).to be(nil)
-      expect(by_keys['percentage_of_actors']['value']).to be(nil)
-      expect(by_keys['percentage_of_time']['value']).to be(nil)
-      expect(by_keys['groups']['value']).to eq([])
-      expect(by_keys['actors']['value']).to eq([])
     end
   end
 end

--- a/spec/flipper/api/v1/actions/clear_feature_spec.rb
+++ b/spec/flipper/api/v1/actions/clear_feature_spec.rb
@@ -16,7 +16,7 @@ RSpec.describe Flipper::Api::V1::Actions::ClearFeature do
       feature.enable flipper.actors(25)
       feature.enable flipper.time(45)
 
-      post '/features/my_feature/clear'
+      delete '/features/my_feature/clear'
     end
 
     it 'clears feature' do

--- a/spec/flipper/api/v1/actions/clear_feature_spec.rb
+++ b/spec/flipper/api/v1/actions/clear_feature_spec.rb
@@ -1,0 +1,43 @@
+require 'helper'
+
+RSpec.describe Flipper::Api::V1::Actions::ClearFeature do
+  let(:app) { build_api(flipper) }
+
+  describe 'clear' do
+    before do
+      Flipper.register(:admins) {}
+      actor_class = Struct.new(:flipper_id)
+      actor22 = actor_class.new('22')
+
+      feature = flipper[:my_feature]
+      feature.enable flipper.boolean
+      feature.enable flipper.group(:admins)
+      feature.enable flipper.actor(actor22)
+      feature.enable flipper.actors(25)
+      feature.enable flipper.time(45)
+
+      post '/features/my_feature/clear'
+    end
+
+    it 'clears feature' do
+      expect(last_response.status).to eq(200)
+      expect(flipper[:my_feature].off?).to be_truthy
+    end
+
+    it 'returns decorated feature with default config' do
+      defaults = flipper.adapter.default_config
+      expect(json_response['key']).to eq('my_feature')
+      expect(json_response['state']).to eq('off')
+
+      by_keys = json_response['gates'].each_with_object({}) { |gate, acc|
+        acc[gate['key']] = gate
+      }
+
+      expect(by_keys['boolean']['value']).to be(nil)
+      expect(by_keys['percentage_of_actors']['value']).to be(nil)
+      expect(by_keys['percentage_of_time']['value']).to be(nil)
+      expect(by_keys['groups']['value']).to eq([])
+      expect(by_keys['actors']['value']).to eq([])
+    end
+  end
+end


### PR DESCRIPTION
* adds clear feature endpoint to api
* uses clear feature endpoint for http adapter `clear`
* changes feature#disable to disable for all gates instead of clearing for boolean and disabling for the rest