### PR TITLE
Allow Unregistered Groups

### DIFF
--- a/lib/flipper.rb
+++ b/lib/flipper.rb
@@ -66,7 +66,7 @@ module Flipper
   #
   # Returns Flipper::Group.
   def self.group(name)
-    groups_registry.fetch(name) { Types::Group.new(name) }
+    groups_registry.get(name) || Types::Group.new(name)
   end
 
   # Internal: Registry of all groups_registry.

--- a/lib/flipper.rb
+++ b/lib/flipper.rb
@@ -64,7 +64,7 @@ module Flipper
   #
   #   Flipper.group(:admins)
   #
-  # Returns the Flipper::Group or registers new one with default block.
+  # Returns Flipper::Group.
   def self.group(name)
     groups_registry.fetch(name) { Types::Group.new(name) }
   end

--- a/lib/flipper.rb
+++ b/lib/flipper.rb
@@ -64,12 +64,9 @@ module Flipper
   #
   #   Flipper.group(:admins)
   #
-  # Returns the Flipper::Group if group registered.
-  # Raises Flipper::GroupNotRegistered if group is not registered.
+  # Returns the Flipper::Group or registers new one with default block.
   def self.group(name)
-    groups_registry.get(name)
-  rescue Registry::KeyNotFound => e
-    raise GroupNotRegistered, "Group #{e.key.inspect} has not been registered"
+    groups_registry.fetch(name) { Types::Group.new(name) { false } }
   end
 
   # Internal: Registry of all groups_registry.

--- a/lib/flipper.rb
+++ b/lib/flipper.rb
@@ -66,7 +66,7 @@ module Flipper
   #
   # Returns the Flipper::Group or registers new one with default block.
   def self.group(name)
-    groups_registry.fetch(name) { Types::Group.new(name) { false } }
+    groups_registry.fetch(name) { Types::Group.new(name) }
   end
 
   # Internal: Registry of all groups_registry.

--- a/lib/flipper/api/v1/actions/groups_gate.rb
+++ b/lib/flipper/api/v1/actions/groups_gate.rb
@@ -28,7 +28,7 @@ module Flipper
 
           def ensure_valid_params
             return if allow_unregistered_groups?
-            return unless Flipper.group_exists?(group_name)
+            return if Flipper.group_exists?(group_name)
 
             json_error_response(:group_not_registered)
           end

--- a/lib/flipper/api/v1/actions/groups_gate.rb
+++ b/lib/flipper/api/v1/actions/groups_gate.rb
@@ -27,9 +27,10 @@ module Flipper
           private
 
           def ensure_valid_params
-            if disallow_unregistered_groups? && !Flipper.group_exists?(group_name)
-              json_error_response(:group_not_registered)
-            end
+            return if allow_unregistered_groups?
+            return unless Flipper.group_exists?(group_name)
+
+            json_error_response(:group_not_registered)
           end
 
           def allow_unregistered_groups?

--- a/lib/flipper/api/v1/actions/groups_gate.rb
+++ b/lib/flipper/api/v1/actions/groups_gate.rb
@@ -27,6 +27,10 @@ module Flipper
           private
 
           def ensure_valid_params
+            if group_name.nil? || group_name.empty?
+              json_error_response(:name_invalid)
+            end
+
             return if allow_unregistered_groups?
             return if Flipper.group_exists?(group_name)
 

--- a/lib/flipper/api/v1/actions/groups_gate.rb
+++ b/lib/flipper/api/v1/actions/groups_gate.rb
@@ -27,7 +27,18 @@ module Flipper
           private
 
           def ensure_valid_params
-            json_error_response(:group_not_registered) unless Flipper.group_exists?(group_name)
+            if disallow_unregistered_groups? && !Flipper.group_exists?(group_name)
+              json_error_response(:group_not_registered)
+            end
+          end
+
+          def allow_unregistered_groups?
+            allow_unregistered_groups = params['allow_unregistered_groups']
+            allow_unregistered_groups && allow_unregistered_groups == 'true'
+          end
+
+          def disallow_unregistered_groups?
+            !allow_unregistered_groups?
           end
 
           def feature_name

--- a/lib/flipper/registry.rb
+++ b/lib/flipper/registry.rb
@@ -46,17 +46,7 @@ module Flipper
     def get(key)
       key = key.to_sym
       @mutex.synchronize do
-        @source.fetch(key) do
-          raise KeyNotFound, key
-        end
-      end
-    end
-
-    def fetch(key)
-      raise ArgumentError, "block is required" unless block_given?
-      key = key.to_sym
-      @mutex.synchronize do
-        @source[key] ||= yield(key)
+        @source[key]
       end
     end
 

--- a/lib/flipper/registry.rb
+++ b/lib/flipper/registry.rb
@@ -52,6 +52,14 @@ module Flipper
       end
     end
 
+    def fetch(key, &block)
+      raise ArgumentError, "block is required" unless block_given?
+      key = key.to_sym
+      @mutex.synchronize do
+        @source[key] ||= yield(key)
+      end
+    end
+
     def key?(key)
       key = key.to_sym
       @mutex.synchronize do

--- a/lib/flipper/registry.rb
+++ b/lib/flipper/registry.rb
@@ -52,7 +52,7 @@ module Flipper
       end
     end
 
-    def fetch(key, &block)
+    def fetch(key)
       raise ArgumentError, "block is required" unless block_given?
       key = key.to_sym
       @mutex.synchronize do

--- a/lib/flipper/ui/actions/groups_gate.rb
+++ b/lib/flipper/ui/actions/groups_gate.rb
@@ -25,17 +25,19 @@ module Flipper
           feature = flipper[feature_name.to_sym]
           value = params['value'].to_s.strip
 
-          case params['operation']
-          when 'enable'
-            feature.enable_group value
-          when 'disable'
-            feature.disable_group value
-          end
+          if Flipper.group_exists?(value)
+            case params['operation']
+            when 'enable'
+              feature.enable_group value
+            when 'disable'
+              feature.disable_group value
+            end
 
-          redirect_to("/features/#{feature.key}")
-        rescue Flipper::GroupNotRegistered => e
-          error = Rack::Utils.escape("The group named #{value.inspect} has not been registered.")
-          redirect_to("/features/#{feature.key}/groups?error=#{error}")
+            redirect_to("/features/#{feature.key}")
+          else
+            error = Rack::Utils.escape("The group named #{value.inspect} has not been registered.")
+            redirect_to("/features/#{feature.key}/groups?error=#{error}")
+          end
         end
       end
     end

--- a/spec/flipper/adapters/http_spec.rb
+++ b/spec/flipper/adapters/http_spec.rb
@@ -53,9 +53,9 @@ RSpec.describe Flipper::Adapters::Http do
       'Content-Type' => 'application/json',
       'User-Agent' => 'Flipper HTTP Adapter v0.10.2',
     }
-    stub_request(:get, "http://app.com/flipper/features/feature_panel").
-       with(:headers => headers).
-       to_return(:status => 404, :body => "", :headers => {})
+    stub_request(:get, "http://app.com/flipper/features/feature_panel")
+      .with(headers: headers)
+      .to_return(status: 404, body: "", headers: {})
 
     adapter = described_class.new(uri: URI('http://app.com/flipper'))
     adapter.get(flipper[:feature_panel])

--- a/spec/flipper/api/v1/actions/groups_gate_spec.rb
+++ b/spec/flipper/api/v1/actions/groups_gate_spec.rb
@@ -89,7 +89,7 @@ RSpec.describe Flipper::Api::V1::Actions::GroupsGate do
     end
   end
 
-  describe 'enable for group not reigstered when allow_unregistered_groups is true' do
+  describe 'enable for group not registered when allow_unregistered_groups is true' do
     before do
       Flipper.unregister_groups
       flipper[:my_feature].disable

--- a/spec/flipper/api/v1/actions/groups_gate_spec.rb
+++ b/spec/flipper/api/v1/actions/groups_gate_spec.rb
@@ -26,6 +26,29 @@ RSpec.describe Flipper::Api::V1::Actions::GroupsGate do
     end
   end
 
+  describe 'enable without name params' do
+    before do
+      flipper[:my_feature].disable
+      Flipper.register(:admins) do |actor|
+        actor.respond_to?(:admin?) && actor.admin?
+      end
+      post '/features/my_feature/groups'
+    end
+
+    it 'returns correct status code' do
+      expect(last_response.status).to eq(422)
+    end
+
+    it 'returns formatted error' do
+      expected = {
+        'code' => 5,
+        'message' => 'Required parameter name is missing.',
+        'more_info' => api_error_code_reference_url,
+      }
+      expect(json_response).to eq(expected)
+    end
+  end
+
   describe 'disable' do
     before do
       flipper[:my_feature].disable

--- a/spec/flipper/api/v1/actions/groups_gate_spec.rb
+++ b/spec/flipper/api/v1/actions/groups_gate_spec.rb
@@ -50,7 +50,7 @@ RSpec.describe Flipper::Api::V1::Actions::GroupsGate do
     end
   end
 
-  describe 'non-existent feature' do
+  describe 'disable for non-existent feature' do
     before do
       Flipper.register(:admins) do |actor|
         actor.respond_to?(:admin?) && actor.admin?
@@ -72,7 +72,7 @@ RSpec.describe Flipper::Api::V1::Actions::GroupsGate do
     end
   end
 
-  describe 'group not registered' do
+  describe 'disable for group not registered' do
     before do
       flipper[:my_feature].disable
       delete '/features/my_feature/groups', name: 'admins'
@@ -86,6 +86,49 @@ RSpec.describe Flipper::Api::V1::Actions::GroupsGate do
         'more_info' => api_error_code_reference_url,
       }
       expect(json_response).to eq(expected)
+    end
+  end
+
+  describe 'enable for group not reigstered when allow_unregistered_groups is true' do
+    before do
+      Flipper.unregister_groups
+      flipper[:my_feature].disable
+      post '/features/my_feature/groups', name: 'admins', allow_unregistered_groups: 'true'
+    end
+
+    it 'responds successfully' do
+      expect(last_response.status).to eq(200)
+    end
+
+    it 'returns decorated feature with group in groups set' do
+      group_gate = json_response['gates'].find { |m| m['name'] == 'group' }
+      expect(group_gate['value']).to eq(['admins'])
+    end
+
+    it 'enables group' do
+      expect(flipper[:my_feature].groups_value).to eq(Set["admins"])
+    end
+  end
+
+  describe 'disable for group not registered when allow_unregistered_groups is true' do
+    before do
+      Flipper.unregister_groups
+      flipper[:my_feature].disable
+      flipper[:my_feature].enable_group(:admins)
+      delete '/features/my_feature/groups', name: 'admins', allow_unregistered_groups: 'true'
+    end
+
+    it 'responds successfully' do
+      expect(last_response.status).to eq(200)
+    end
+
+    it 'returns decorated feature with group not in groups set' do
+      group_gate = json_response['gates'].find { |m| m['name'] == 'group' }
+      expect(group_gate['value']).to eq([])
+    end
+
+    it 'disables group' do
+      expect(flipper[:my_feature].groups_value).to be_empty
     end
   end
 end

--- a/spec/flipper/dsl_spec.rb
+++ b/spec/flipper/dsl_spec.rb
@@ -97,22 +97,9 @@ RSpec.describe Flipper::DSL do
         @group = Flipper.register(:admins) {}
       end
 
-      it 'returns group' do
-        expect(subject.group(:admins)).to eq(@group)
-      end
-
-      it 'always returns same instance for same name' do
-        expect(subject.group(:admins)).to equal(subject.group(:admins))
-      end
-    end
-
-    context 'for unregistered group' do
-      it 'returns group with default block' do
-        expect(subject.group(:admins)).to be_instance_of(Flipper::Types::Group)
-      end
-
-      it 'always returns same instance for same name' do
-        expect(subject.group(:admins)).to equal(subject.group(:admins))
+      it 'delegates to Flipper' do
+        expect(Flipper).to receive(:group).with(:admins).and_return(@group)
+        expect(subject.group(:admins)).to be(@group)
       end
     end
   end

--- a/spec/flipper/dsl_spec.rb
+++ b/spec/flipper/dsl_spec.rb
@@ -107,10 +107,12 @@ RSpec.describe Flipper::DSL do
     end
 
     context 'for unregistered group' do
-      it 'raises error' do
-        expect do
-          subject.group(:admins)
-        end.to raise_error(Flipper::GroupNotRegistered)
+      it 'returns group with default block' do
+        expect(subject.group(:admins)).to be_instance_of(Flipper::Types::Group)
+      end
+
+      it 'always returns same instance for same name' do
+        expect(subject.group(:admins)).to equal(subject.group(:admins))
       end
     end
   end

--- a/spec/flipper/registry_spec.rb
+++ b/spec/flipper/registry_spec.rb
@@ -44,10 +44,8 @@ RSpec.describe Flipper::Registry do
     end
 
     context 'key not registered' do
-      it 'raises key not found' do
-        expect do
-          subject.get(:admins)
-        end.to raise_error(Flipper::Registry::KeyNotFound)
+      it 'returns nil' do
+        expect(subject.get(:admins)).to be(nil)
       end
     end
   end
@@ -138,37 +136,6 @@ RSpec.describe Flipper::Registry do
     it 'clears the source' do
       subject.clear
       expect(source).to be_empty
-    end
-  end
-
-  describe '#fetch' do
-    context 'key registered' do
-      before do
-        source[:admins] = 'admins'
-      end
-
-      it 'returns value' do
-        expect(subject.fetch(:admins) {}).to eq('admins')
-      end
-
-      it 'returns value with string key' do
-        expect(subject.fetch('admins') {}).to eq('admins')
-      end
-    end
-
-    context 'key not registered' do
-      it 'sets value to result of block' do
-        subject.fetch(:admins) { 'admins' }
-        expect(source[:admins]).to eq('admins')
-      end
-    end
-
-    context 'key not registered and block not provided' do
-      it 'raises error' do
-        expect do
-          subject.fetch(:admins)
-        end.to raise_error(ArgumentError, "block is required")
-      end
     end
   end
 end

--- a/spec/flipper/registry_spec.rb
+++ b/spec/flipper/registry_spec.rb
@@ -140,4 +140,35 @@ RSpec.describe Flipper::Registry do
       expect(source).to be_empty
     end
   end
+
+  describe '#fetch' do
+    context 'key registered' do
+      before do
+        source[:admins] = 'admins'
+      end
+
+      it 'returns value' do
+        expect(subject.fetch(:admins) {}).to eq('admins')
+      end
+
+      it 'returns value with string key' do
+        expect(subject.fetch('admins') {}).to eq('admins')
+      end
+    end
+
+    context 'key not registered' do
+      it 'sets value to result of block' do
+        subject.fetch(:admins) { 'admins' }
+        expect(source[:admins]).to eq('admins')
+      end
+    end
+
+    context 'key not registered and block not provided' do
+      it 'raises error' do
+        expect do
+          subject.fetch(:admins)
+        end.to raise_error(ArgumentError, "block is required")
+      end
+    end
+  end
 end

--- a/spec/flipper/ui/actions/groups_gate_spec.rb
+++ b/spec/flipper/ui/actions/groups_gate_spec.rb
@@ -8,6 +8,7 @@ RSpec.describe Flipper::UI::Actions::GroupsGate do
       'a'
     end
   end
+
   let(:session) do
     if Rack::Protection::AuthenticityToken.respond_to?(:random_token)
       { csrf: token }

--- a/spec/flipper_spec.rb
+++ b/spec/flipper_spec.rb
@@ -80,10 +80,17 @@ RSpec.describe Flipper do
     end
 
     context 'for unregistered group' do
+      before do
+        @group = described_class.group(:cats)
+      end
+
       it 'returns group' do
-        group = described_class.group(:cats)
-        expect(group).to be_instance_of(Flipper::Types::Group)
-        expect(group.name).to eq(:cats)
+        expect(@group).to be_instance_of(Flipper::Types::Group)
+        expect(@group.name).to eq(:cats)
+      end
+
+      it 'does not add group to registry' do
+        expect(Flipper.group_exists?(@group.name)).to be(false)
       end
     end
   end

--- a/spec/flipper_spec.rb
+++ b/spec/flipper_spec.rb
@@ -80,10 +80,10 @@ RSpec.describe Flipper do
     end
 
     context 'for unregistered group' do
-      it 'raises group not registered error' do
-        expect do
-          described_class.group(:cats)
-        end.to raise_error(Flipper::GroupNotRegistered, 'Group :cats has not been registered')
+      it 'returns group' do
+        group = described_class.group(:cats)
+        expect(group).to be_instance_of(Flipper::Types::Group)
+        expect(group.name).to eq(:cats)
       end
     end
   end

--- a/spec/flipper_spec.rb
+++ b/spec/flipper_spec.rb
@@ -90,7 +90,7 @@ RSpec.describe Flipper do
       end
 
       it 'does not add group to registry' do
-        expect(Flipper.group_exists?(@group.name)).to be(false)
+        expect(described_class.group_exists?(@group.name)).to be(false)
       end
     end
   end


### PR DESCRIPTION
This makes it possible to enable/disable groups that are not registered. The use case is API's that are mounted on their own apart from where the groups are registered in the code.