### PR TITLE
Rename shadowing variable

### DIFF
--- a/lib/flipper/gates/percentage_of_actors.rb
+++ b/lib/flipper/gates/percentage_of_actors.rb
@@ -29,8 +29,8 @@ module Flipper
 
         if Types::Actor.wrappable?(context.thing)
           actor = Types::Actor.wrap(context.thing)
-          key = "#{context.feature_name}#{actor.value}"
-          Zlib.crc32(key) % 100 < percentage
+          id = "#{context.feature_name}#{actor.value}"
+          Zlib.crc32(id) % 100 < percentage
         else
           false
         end


### PR DESCRIPTION
`Percentage#open?` has 2 things named key, a method and a local variable that shadows it. This works fine but is confusing to read.

This patch renames the local variable, since `#key` is part of the `Gate` interface.