### PR TITLE
Import

### DIFF
--- a/Guardfile
+++ b/Guardfile
@@ -14,8 +14,8 @@ rspec_options = {
 }
 
 guard 'rspec', rspec_options do
-  watch(%r{^spec/.+_spec\.rb$}) { 'spec' }
-  watch(%r{^lib/(.+)\.rb$}) { 'spec' }
+  watch(%r{^spec/.+_spec\.rb$})
+  watch(%r{^lib/(.+)\.rb$}) { |m| "spec/#{m[1]}_spec.rb" }
   watch(/shared_adapter_specs\.rb$/) { 'spec' }
   watch('spec/helper.rb') { 'spec' }
 end

--- a/examples/importing.rb
+++ b/examples/importing.rb
@@ -1,0 +1,38 @@
+require File.expand_path('../example_setup', __FILE__)
+
+require 'flipper'
+require 'flipper/adapters/redis'
+require 'flipper/adapters/active_record'
+
+# Active Record boiler plate, feel free to ignore.
+ActiveRecord::Base.establish_connection({
+  adapter: 'sqlite3',
+  database: ':memory:',
+})
+require 'generators/flipper/templates/migration'
+CreateFlipperTables.up
+
+
+# Say you are using redis...
+redis_adapter = Flipper::Adapters::Redis.new(Redis.new)
+redis_flipper = Flipper.new(redis_adapter)
+
+# And redis has some stuff enabled...
+redis_flipper.enable(:search)
+redis_flipper.enable_percentage_of_time(:verbose_logging, 5)
+redis_flipper.enable_percentage_of_actors(:new_feature, 5)
+redis_flipper.enable_actor(:issues, Flipper::Actor.new('1'))
+redis_flipper.enable_actor(:issues, Flipper::Actor.new('2'))
+redis_flipper.enable_group(:request_tracing, :staff)
+
+# And would like to switch to active record...
+ar_adapter = Flipper::Adapters::ActiveRecord.new
+ar_flipper = Flipper.new(ar_adapter)
+
+# Note: This wipes active record clean and copies features/gates from redis.
+ar_flipper.import(redis_flipper)
+
+# AR is now identical to Redis.
+ar_flipper.features.each do |feature|
+  pp feature: feature.key, values: feature.gate_values
+end

--- a/examples/importing.rb
+++ b/examples/importing.rb
@@ -12,7 +12,6 @@ ActiveRecord::Base.establish_connection({
 require 'generators/flipper/templates/migration'
 CreateFlipperTables.up
 
-
 # Say you are using redis...
 redis_adapter = Flipper::Adapters::Redis.new(Redis.new)
 redis_flipper = Flipper.new(redis_adapter)
@@ -25,14 +24,14 @@ redis_flipper.enable_actor(:issues, Flipper::Actor.new('1'))
 redis_flipper.enable_actor(:issues, Flipper::Actor.new('2'))
 redis_flipper.enable_group(:request_tracing, :staff)
 
-# And would like to switch to active record...
+# And you would like to switch to active record...
 ar_adapter = Flipper::Adapters::ActiveRecord.new
 ar_flipper = Flipper.new(ar_adapter)
 
-# Note: This wipes active record clean and copies features/gates from redis.
+# NOTE: This wipes active record clean and copies features/gates from redis into active record.
 ar_flipper.import(redis_flipper)
 
-# AR is now identical to Redis.
+# active record is now identical to redis.
 ar_flipper.features.each do |feature|
   pp feature: feature.key, values: feature.gate_values
 end

--- a/lib/flipper.rb
+++ b/lib/flipper.rb
@@ -80,6 +80,7 @@ module Flipper
   end
 end
 
+require 'flipper/actor'
 require 'flipper/adapter'
 require 'flipper/dsl'
 require 'flipper/errors'

--- a/lib/flipper/actor.rb
+++ b/lib/flipper/actor.rb
@@ -1,0 +1,16 @@
+# Simple class for turning a flipper_id into an actor that can be based
+# to Flipper::Feature#enabled?.
+module Flipper
+  class Actor
+    attr_reader :flipper_id
+
+    def initialize(flipper_id)
+      @flipper_id = flipper_id
+    end
+
+    def eql?(other)
+      self.class.eql?(other.class) && @flipper_id == other.flipper_id
+    end
+    alias_method :==, :eql?
+  end
+end

--- a/lib/flipper/adapter.rb
+++ b/lib/flipper/adapter.rb
@@ -18,6 +18,7 @@ module Flipper
       adapter.features.each do |key|
         feature = Flipper::Feature.new(key, adapter)
         destination_feature = Flipper::Feature.new(key, self)
+        clear(destination_feature)
 
         case feature.state
         when :on

--- a/lib/flipper/adapter.rb
+++ b/lib/flipper/adapter.rb
@@ -12,11 +12,11 @@ module Flipper
       result
     end
 
-    # Public: Migrate current adapter features and gate values to be identical
-    # to provided adapter.
+    # Public: Wipe features and gate values and then import features and gate
+    # values from provided adapter.
     #
     # Returns nothing.
-    def migrate(adapter)
+    def import(adapter)
       actor_class = Struct.new(:flipper_id)
 
       adapter.features.each do |key|

--- a/lib/flipper/adapter.rb
+++ b/lib/flipper/adapter.rb
@@ -12,6 +12,30 @@ module Flipper
       result
     end
 
+    def migrate(adapter)
+      actor_class = Struct.new(:flipper_id)
+      adapter.features.each do |feature|
+        to_feature = Flipper::Feature.new(feature.key, self)
+        case feature.state
+        when :on
+          to_feature.enable
+        when :conditional
+          feature.groups_value.each do |value|
+            to_feature.enable_group(value)
+          end
+
+          feature.actors_value.each do |value|
+            to_feature.enable_actor(actor_class.new(value))
+          end
+
+          to_feature.enable_percentage_of_actors(feature.percentage_of_actors_value)
+          to_feature.enable_percentage_of_time(feature.percentage_of_time_value)
+        when :off
+          add(feature)
+        end
+      end
+    end
+
     def default_config
       {
         boolean: nil,

--- a/lib/flipper/adapter.rb
+++ b/lib/flipper/adapter.rb
@@ -17,8 +17,6 @@ module Flipper
     #
     # Returns nothing.
     def import(adapter)
-      actor_class = Struct.new(:flipper_id)
-
       adapter.features.each do |key|
         feature = Flipper::Feature.new(key, adapter)
         destination_feature = Flipper::Feature.new(key, self)
@@ -33,7 +31,7 @@ module Flipper
           end
 
           feature.actors_value.each do |value|
-            destination_feature.enable_actor(actor_class.new(value))
+            destination_feature.enable_actor(Flipper::Actor.new(value))
           end
 
           destination_feature.enable_percentage_of_actors(feature.percentage_of_actors_value)

--- a/lib/flipper/adapter.rb
+++ b/lib/flipper/adapter.rb
@@ -16,12 +16,26 @@ module Flipper
     # values from provided adapter.
     #
     # Returns nothing.
-    def import(source_adapter) # rubocop:disable Metrics/MethodLength
-      features.each do |key|
-        feature = Flipper::Feature.new(key, self)
-        remove(feature)
-      end
+    def import(source_adapter)
+      wipe
+      copy_features_and_gates(source_adapter)
+      nil
+    end
 
+    def default_config
+      {
+        boolean: nil,
+        groups: Set.new,
+        actors: Set.new,
+        percentage_of_actors: nil,
+        percentage_of_time: nil,
+      }
+    end
+
+    private
+
+    # Private: Copy source adapter features and gate values into self.
+    def copy_features_and_gates(source_adapter)
       source_adapter.features.each do |key|
         source_feature = Flipper::Feature.new(key, source_adapter)
         destination_feature = Flipper::Feature.new(key, self)
@@ -44,18 +58,14 @@ module Flipper
           destination_feature.add
         end
       end
-
-      nil
     end
 
-    def default_config
-      {
-        boolean: nil,
-        groups: Set.new,
-        actors: Set.new,
-        percentage_of_actors: nil,
-        percentage_of_time: nil,
-      }
+    # Private: Completely wipe adapter features and gate values.
+    def wipe
+      features.each do |key|
+        feature = Flipper::Feature.new(key, self)
+        remove(feature)
+      end
     end
   end
 end

--- a/lib/flipper/adapter.rb
+++ b/lib/flipper/adapter.rb
@@ -17,6 +17,11 @@ module Flipper
     #
     # Returns nothing.
     def import(adapter)
+      features.each do |key|
+        feature = Flipper::Feature.new(key, self)
+        remove(feature)
+      end
+
       adapter.features.each do |key|
         feature = Flipper::Feature.new(key, adapter)
         destination_feature = Flipper::Feature.new(key, self)

--- a/lib/flipper/adapter.rb
+++ b/lib/flipper/adapter.rb
@@ -42,6 +42,8 @@ module Flipper
           add(feature)
         end
       end
+
+      nil
     end
 
     def default_config

--- a/lib/flipper/adapter.rb
+++ b/lib/flipper/adapter.rb
@@ -14,22 +14,25 @@ module Flipper
 
     def migrate(adapter)
       actor_class = Struct.new(:flipper_id)
-      adapter.features.each do |feature|
-        to_feature = Flipper::Feature.new(feature.key, self)
+
+      adapter.features.each do |key|
+        feature = Flipper::Feature.new(key, adapter)
+        destination_feature = Flipper::Feature.new(key, self)
+
         case feature.state
         when :on
-          to_feature.enable
+          destination_feature.enable
         when :conditional
           feature.groups_value.each do |value|
-            to_feature.enable_group(value)
+            destination_feature.enable_group(value)
           end
 
           feature.actors_value.each do |value|
-            to_feature.enable_actor(actor_class.new(value))
+            destination_feature.enable_actor(actor_class.new(value))
           end
 
-          to_feature.enable_percentage_of_actors(feature.percentage_of_actors_value)
-          to_feature.enable_percentage_of_time(feature.percentage_of_time_value)
+          destination_feature.enable_percentage_of_actors(feature.percentage_of_actors_value)
+          destination_feature.enable_percentage_of_time(feature.percentage_of_time_value)
         when :off
           add(feature)
         end

--- a/lib/flipper/adapter.rb
+++ b/lib/flipper/adapter.rb
@@ -16,7 +16,7 @@ module Flipper
     # values from provided adapter.
     #
     # Returns nothing.
-    def import(source_adapter)
+    def import(source_adapter) # rubocop:disable Metrics/MethodLength
       features.each do |key|
         feature = Flipper::Feature.new(key, self)
         remove(feature)

--- a/lib/flipper/adapter.rb
+++ b/lib/flipper/adapter.rb
@@ -12,6 +12,10 @@ module Flipper
       result
     end
 
+    # Public: Migrate current adapter features and gate values to be identical
+    # to provided adapter.
+    #
+    # Returns nothing.
     def migrate(adapter)
       actor_class = Struct.new(:flipper_id)
 

--- a/lib/flipper/adapter.rb
+++ b/lib/flipper/adapter.rb
@@ -25,7 +25,6 @@ module Flipper
       adapter.features.each do |key|
         feature = Flipper::Feature.new(key, adapter)
         destination_feature = Flipper::Feature.new(key, self)
-        clear(destination_feature)
 
         case feature.state
         when :on

--- a/lib/flipper/adapter.rb
+++ b/lib/flipper/adapter.rb
@@ -16,32 +16,32 @@ module Flipper
     # values from provided adapter.
     #
     # Returns nothing.
-    def import(adapter)
+    def import(source_adapter)
       features.each do |key|
         feature = Flipper::Feature.new(key, self)
         remove(feature)
       end
 
-      adapter.features.each do |key|
-        feature = Flipper::Feature.new(key, adapter)
+      source_adapter.features.each do |key|
+        source_feature = Flipper::Feature.new(key, source_adapter)
         destination_feature = Flipper::Feature.new(key, self)
 
-        case feature.state
+        case source_feature.state
         when :on
           destination_feature.enable
         when :conditional
-          feature.groups_value.each do |value|
+          source_feature.groups_value.each do |value|
             destination_feature.enable_group(value)
           end
 
-          feature.actors_value.each do |value|
+          source_feature.actors_value.each do |value|
             destination_feature.enable_actor(Flipper::Actor.new(value))
           end
 
-          destination_feature.enable_percentage_of_actors(feature.percentage_of_actors_value)
-          destination_feature.enable_percentage_of_time(feature.percentage_of_time_value)
+          destination_feature.enable_percentage_of_actors(source_feature.percentage_of_actors_value)
+          destination_feature.enable_percentage_of_time(source_feature.percentage_of_time_value)
         when :off
-          add(feature)
+          destination_feature.add
         end
       end
 

--- a/lib/flipper/dsl.rb
+++ b/lib/flipper/dsl.rb
@@ -241,5 +241,9 @@ module Flipper
     def features
       adapter.features.map { |name| feature(name) }.to_set
     end
+
+    def migrate(flipper)
+      adapter.migrate(flipper.adapter)
+    end
   end
 end

--- a/lib/flipper/dsl.rb
+++ b/lib/flipper/dsl.rb
@@ -251,8 +251,8 @@ module Flipper
       adapter.features.map { |name| feature(name) }.to_set
     end
 
-    def migrate(flipper)
-      adapter.migrate(flipper.adapter)
+    def import(flipper)
+      adapter.import(flipper.adapter)
     end
   end
 end

--- a/lib/flipper/dsl.rb
+++ b/lib/flipper/dsl.rb
@@ -139,6 +139,15 @@ module Flipper
       feature(name).disable_percentage_of_actors
     end
 
+    # Public: Add a feature.
+    #
+    # name - The String or Symbol name of the feature.
+    #
+    # Returns result of add.
+    def add(name)
+      feature(name).add
+    end
+
     # Public: Remove a feature.
     #
     # name - The String or Symbol name of the feature.

--- a/lib/flipper/feature.rb
+++ b/lib/flipper/feature.rb
@@ -69,6 +69,13 @@ module Flipper
       end
     end
 
+    # Public: Adds this feature.
+    #
+    # Returns the result of Adapter#add.
+    def add
+      instrument(:add) { adapter.add(self) }
+    end
+
     # Public: Removes this feature.
     #
     # Returns the result of Adapter#remove.

--- a/lib/flipper/spec/shared_adapter_specs.rb
+++ b/lib/flipper/spec/shared_adapter_specs.rb
@@ -1,8 +1,6 @@
 # Requires the following methods:
 # * subject - The instance of the adapter
 RSpec.shared_examples_for 'a flipper adapter' do
-  let(:actor_class) { Struct.new(:flipper_id) }
-
   let(:flipper) { Flipper.new(subject) }
   let(:feature) { flipper[:stats] }
 
@@ -52,7 +50,7 @@ RSpec.shared_examples_for 'a flipper adapter' do
   end
 
   it 'fully disables all enabled things when boolean gate disabled' do
-    actor22 = actor_class.new('22')
+    actor22 = Flipper::Actor.new('22')
     expect(subject.enable(feature, boolean_gate, flipper.boolean)).to eq(true)
     expect(subject.enable(feature, group_gate, flipper.group(:admins))).to eq(true)
     expect(subject.enable(feature, actor_gate, flipper.actor(actor22))).to eq(true)
@@ -81,8 +79,8 @@ RSpec.shared_examples_for 'a flipper adapter' do
   end
 
   it 'can enable, disable and get value for actor gate' do
-    actor22 = actor_class.new('22')
-    actor_asdf = actor_class.new('asdf')
+    actor22 = Flipper::Actor.new('22')
+    actor_asdf = Flipper::Actor.new('asdf')
 
     expect(subject.enable(feature, actor_gate, flipper.actor(actor22))).to eq(true)
     expect(subject.enable(feature, actor_gate, flipper.actor(actor_asdf))).to eq(true)
@@ -158,7 +156,7 @@ RSpec.shared_examples_for 'a flipper adapter' do
   end
 
   it 'converts the actor value to a string' do
-    expect(subject.enable(feature, actor_gate, flipper.actor(actor_class.new(22)))).to eq(true)
+    expect(subject.enable(feature, actor_gate, flipper.actor(Flipper::Actor.new(22)))).to eq(true)
     result = subject.get(feature)
     expect(result[:actors]).to eq(Set['22'])
   end
@@ -198,7 +196,7 @@ RSpec.shared_examples_for 'a flipper adapter' do
   end
 
   it 'clears all the gate values for the feature on remove' do
-    actor22 = actor_class.new('22')
+    actor22 = Flipper::Actor.new('22')
     expect(subject.enable(feature, boolean_gate, flipper.boolean)).to eq(true)
     expect(subject.enable(feature, group_gate, flipper.group(:admins))).to eq(true)
     expect(subject.enable(feature, actor_gate, flipper.actor(actor22))).to eq(true)
@@ -211,7 +209,7 @@ RSpec.shared_examples_for 'a flipper adapter' do
   end
 
   it 'can clear all the gate values for a feature' do
-    actor22 = actor_class.new('22')
+    actor22 = Flipper::Actor.new('22')
     subject.add(feature)
     expect(subject.features).to include(feature.key)
 

--- a/lib/flipper/test/shared_adapter_test.rb
+++ b/lib/flipper/test/shared_adapter_test.rb
@@ -5,7 +5,6 @@ module Flipper
       def setup
         super
         @flipper = Flipper.new(@adapter)
-        @actor_class = Struct.new(:flipper_id)
         @feature = @flipper[:stats]
         @boolean_gate = @feature.gate(:boolean)
         @group_gate = @feature.gate(:group)
@@ -48,7 +47,7 @@ module Flipper
       end
 
       def test_fully_disables_all_enabled_things_when_boolean_gate_disabled
-        actor22 = @actor_class.new('22')
+        actor22 = Flipper::Actor.new('22')
         assert_equal true, @adapter.enable(@feature, @boolean_gate, @flipper.boolean)
         assert_equal true, @adapter.enable(@feature, @group_gate, @flipper.group(:admins))
         assert_equal true, @adapter.enable(@feature, @actor_gate, @flipper.actor(actor22))
@@ -75,8 +74,8 @@ module Flipper
       end
 
       def test_can_enable_disable_and_get_value_for_an_actor_gate
-        actor22 = @actor_class.new('22')
-        actor_asdf = @actor_class.new('asdf')
+        actor22 = Flipper::Actor.new('22')
+        actor_asdf = Flipper::Actor.new('asdf')
 
         assert_equal true, @adapter.enable(@feature, @actor_gate, @flipper.actor(actor22))
         assert_equal true, @adapter.enable(@feature, @actor_gate, @flipper.actor(actor_asdf))
@@ -153,7 +152,7 @@ module Flipper
 
       def test_converts_the_actor_value_to_a_string
         assert_equal true,
-                     @adapter.enable(@feature, @actor_gate, @flipper.actor(@actor_class.new(22)))
+                     @adapter.enable(@feature, @actor_gate, @flipper.actor(Flipper::Actor.new(22)))
         result = @adapter.get(@feature)
         assert_equal Set['22'], result[:actors]
       end
@@ -193,7 +192,7 @@ module Flipper
       end
 
       def test_clears_all_the_gate_values_for_the_feature_on_remove
-        actor22 = @actor_class.new('22')
+        actor22 = Flipper::Actor.new('22')
         assert_equal true, @adapter.enable(@feature, @boolean_gate, @flipper.boolean)
         assert_equal true, @adapter.enable(@feature, @group_gate, @flipper.group(:admins))
         assert_equal true, @adapter.enable(@feature, @actor_gate, @flipper.actor(actor22))
@@ -206,7 +205,7 @@ module Flipper
       end
 
       def test_can_clear_all_the_gate_values_for_a_feature
-        actor22 = @actor_class.new('22')
+        actor22 = Flipper::Actor.new('22')
         @adapter.add(@feature)
         assert_includes @adapter.features, @feature.key
 

--- a/script/bootstrap
+++ b/script/bootstrap
@@ -18,4 +18,4 @@ cd $(dirname "$0")/..
 }
 
 rm -rf .bundle/{binstubs,config}
-bundle install --binstubs --path .bundle --quiet "$@"
+bundle install --binstubs --quiet "$@"

--- a/spec/flipper/actor_spec.rb
+++ b/spec/flipper/actor_spec.rb
@@ -1,0 +1,28 @@
+require 'helper'
+
+RSpec.describe Flipper::Actor do
+  it 'initializes with and knows flipper_id' do
+    actor = described_class.new("User;235")
+    expect(actor.flipper_id).to eq("User;235")
+  end
+
+  describe '#eql?' do
+    it 'returns true if same class and flipper_id' do
+      actor1 = described_class.new("User;235")
+      actor2 = described_class.new("User;235")
+      expect(actor1.eql?(actor2)).to be(true)
+    end
+
+    it 'returns false if same class but different flipper_id' do
+      actor1 = described_class.new("User;235")
+      actor2 = described_class.new("User;1")
+      expect(actor1.eql?(actor2)).to be(false)
+    end
+
+    it 'returns false for different class' do
+      actor1 = described_class.new("User;235")
+      actor2 = Struct.new(:flipper_id).new("User;235")
+      expect(actor1.eql?(actor2)).to be(false)
+    end
+  end
+end

--- a/spec/flipper/actor_spec.rb
+++ b/spec/flipper/actor_spec.rb
@@ -25,4 +25,24 @@ RSpec.describe Flipper::Actor do
       expect(actor1.eql?(actor2)).to be(false)
     end
   end
+
+  describe '#==' do
+    it 'returns true if same class and flipper_id' do
+      actor1 = described_class.new("User;235")
+      actor2 = described_class.new("User;235")
+      expect(actor1.==(actor2)).to be(true)
+    end
+
+    it 'returns false if same class but different flipper_id' do
+      actor1 = described_class.new("User;235")
+      actor2 = described_class.new("User;1")
+      expect(actor1.==(actor2)).to be(false)
+    end
+
+    it 'returns false for different class' do
+      actor1 = described_class.new("User;235")
+      actor2 = Struct.new(:flipper_id).new("User;235")
+      expect(actor1.==(actor2)).to be(false)
+    end
+  end
 end

--- a/spec/flipper/adapter_spec.rb
+++ b/spec/flipper/adapter_spec.rb
@@ -1,0 +1,31 @@
+require 'helper'
+require 'flipper/adapters/memory'
+
+RSpec.describe Flipper::Adapter do
+  it 'can migrate from one adapter to another' do
+    actor = Struct.new(:flipper_id).new('22')
+    from_adapter = Flipper::Adapters::Memory.new
+    to_adapter = Flipper::Adapters::Memory.new
+    from_flipper = Flipper.new(from_adapter)
+    to_flipper = Flipper.new(to_adapter)
+
+    from_flipper.enable(:search)
+    from_flipper.enable_group(:admins, :admins)
+    from_flipper.enable_actor(:debug, actor)
+    from_flipper.enable_percentage_of_actors(:issues, 25)
+    from_flipper.enable_percentage_of_time(:logging, 50)
+    from_flipper.enable(:nope)
+    from_flipper.disable(:nope)
+
+    to_flipper.migrate(from_flipper)
+
+    expect(to_flipper[:search].gate_values).to eq(from_flipper[:search].gate_values)
+    expect(to_flipper[:admin].gate_values).to eq(from_flipper[:admin].gate_values)
+    expect(to_flipper[:debug].gate_values).to eq(from_flipper[:debug].gate_values)
+    expect(to_flipper[:issues].gate_values).to eq(from_flipper[:issues].gate_values)
+    expect(to_flipper[:logging].gate_values).to eq(from_flipper[:logging].gate_values)
+    expect(to_flipper[:nope].gate_values).to eq(from_flipper[:nope].gate_values)
+    expected_feature_keys = %w[search admins debug issues logging nope].sort
+    expect(to_flipper.features.map(&:key).sort).to eq(expected_feature_keys)
+  end
+end

--- a/spec/flipper/adapter_spec.rb
+++ b/spec/flipper/adapter_spec.rb
@@ -8,6 +8,11 @@ RSpec.describe Flipper::Adapter do
   let(:destination_flipper) { build_flipper }
 
   describe '#migrate' do
+    it 'returns nothing' do
+      result = destination_flipper.migrate(source_flipper)
+      expect(result).to be(nil)
+    end
+
     it 'can migrate from one adapter to another' do
       source_flipper.enable(:search)
       destination_flipper.migrate(source_flipper)

--- a/spec/flipper/adapter_spec.rb
+++ b/spec/flipper/adapter_spec.rb
@@ -77,5 +77,11 @@ RSpec.describe Flipper::Adapter do
       expect(feature.percentage_of_time_value).to be(0)
       expect(feature.percentage_of_actors_value).to be(25)
     end
+
+    it 'wipes existing features for adapter' do
+      destination_flipper.add(:stats)
+      destination_flipper.import(source_flipper)
+      expect(destination_flipper.features.map(&:key)).to eq([])
+    end
   end
 end

--- a/spec/flipper/adapter_spec.rb
+++ b/spec/flipper/adapter_spec.rb
@@ -27,4 +27,13 @@ RSpec.describe Flipper::Adapter do
     expected_feature_keys = %w[search admins debug issues logging nope].sort
     expect(destination_flipper.features.map(&:key).sort).to eq(expected_feature_keys)
   end
+
+  it 'can migrate features that exist but are off' do
+    feature = source_flipper[:search]
+    source_flipper.add(:search)
+
+    destination_flipper.migrate(source_flipper)
+
+    expect(destination_flipper.features.map(&:key)).to eq(["search"])
+  end
 end

--- a/spec/flipper/adapter_spec.rb
+++ b/spec/flipper/adapter_spec.rb
@@ -2,38 +2,59 @@ require 'helper'
 require 'flipper/adapters/memory'
 
 RSpec.describe Flipper::Adapter do
-  let(:actor) { Struct.new(:flipper_id).new('22') }
+  let(:actor_class) { Struct.new(:flipper_id) }
 
   let(:source_flipper) { build_flipper }
   let(:destination_flipper) { build_flipper }
 
   it 'can migrate from one adapter to another' do
     source_flipper.enable(:search)
-    source_flipper.enable_group(:admins, :admins)
-    source_flipper.enable_actor(:debug, actor)
-    source_flipper.enable_percentage_of_actors(:issues, 25)
-    source_flipper.enable_percentage_of_time(:logging, 50)
-    source_flipper.enable(:nope)
-    source_flipper.disable(:nope)
-
     destination_flipper.migrate(source_flipper)
-
-    expect(destination_flipper[:search].gate_values).to eq(source_flipper[:search].gate_values)
-    expect(destination_flipper[:admin].gate_values).to eq(source_flipper[:admin].gate_values)
-    expect(destination_flipper[:debug].gate_values).to eq(source_flipper[:debug].gate_values)
-    expect(destination_flipper[:issues].gate_values).to eq(source_flipper[:issues].gate_values)
-    expect(destination_flipper[:logging].gate_values).to eq(source_flipper[:logging].gate_values)
-    expect(destination_flipper[:nope].gate_values).to eq(source_flipper[:nope].gate_values)
-    expected_feature_keys = %w[search admins debug issues logging nope].sort
-    expect(destination_flipper.features.map(&:key).sort).to eq(expected_feature_keys)
+    expect(destination_flipper[:search].boolean_value).to eq(true)
+    expect(destination_flipper.features.map(&:key).sort).to eq(%w[search])
   end
 
   it 'can migrate features that exist but are off' do
     feature = source_flipper[:search]
     source_flipper.add(:search)
+    destination_flipper.migrate(source_flipper)
+    expect(destination_flipper.features.map(&:key)).to eq(["search"])
+  end
+
+  it 'can migrate multiple features' do
+    source_flipper.enable(:yep)
+    source_flipper.enable_group(:preview_features, :developers)
+    source_flipper.enable_group(:preview_features, :marketers)
+    source_flipper.enable_group(:preview_features, :company)
+    source_flipper.enable_group(:preview_features, :early_access)
+    source_flipper.enable_actor(:preview_features, actor_class.new('1'))
+    source_flipper.enable_actor(:preview_features, actor_class.new('2'))
+    source_flipper.enable_actor(:preview_features, actor_class.new('3'))
+    source_flipper.enable_percentage_of_actors(:issues_next, 25)
+    source_flipper.enable_percentage_of_time(:verbose_logging, 5)
 
     destination_flipper.migrate(source_flipper)
 
-    expect(destination_flipper.features.map(&:key)).to eq(["search"])
+    feature = destination_flipper[:preview_features]
+    expect(feature.boolean_value).to eq(false)
+    expect(feature.actors_value).to eq(Set['1', '2', '3'])
+    expected_groups = Set['developers', 'marketers', 'company', 'early_access']
+    expect(feature.groups_value).to eq(expected_groups)
+    expect(feature.percentage_of_actors_value).to eq(0)
+    expect(feature.percentage_of_time_value).to eq(0)
+
+    feature = destination_flipper[:issues_next]
+    expect(feature.boolean_value).to eq(false)
+    expect(feature.actors_value).to eq(Set.new)
+    expect(feature.groups_value).to eq(Set.new)
+    expect(feature.percentage_of_actors_value).to eq(25)
+    expect(feature.percentage_of_time_value).to eq(0)
+
+    feature = destination_flipper[:verbose_logging]
+    expect(feature.boolean_value).to eq(false)
+    expect(feature.actors_value).to eq(Set.new)
+    expect(feature.groups_value).to eq(Set.new)
+    expect(feature.percentage_of_actors_value).to eq(0)
+    expect(feature.percentage_of_time_value).to eq(5)
   end
 end

--- a/spec/flipper/adapter_spec.rb
+++ b/spec/flipper/adapter_spec.rb
@@ -7,71 +7,73 @@ RSpec.describe Flipper::Adapter do
   let(:source_flipper) { build_flipper }
   let(:destination_flipper) { build_flipper }
 
-  it 'can migrate from one adapter to another' do
-    source_flipper.enable(:search)
-    destination_flipper.migrate(source_flipper)
-    expect(destination_flipper[:search].boolean_value).to eq(true)
-    expect(destination_flipper.features.map(&:key).sort).to eq(%w[search])
-  end
+  describe '#migrate' do
+    it 'can migrate from one adapter to another' do
+      source_flipper.enable(:search)
+      destination_flipper.migrate(source_flipper)
+      expect(destination_flipper[:search].boolean_value).to eq(true)
+      expect(destination_flipper.features.map(&:key).sort).to eq(%w[search])
+    end
 
-  it 'can migrate features that exist but are off' do
-    feature = source_flipper[:search]
-    source_flipper.add(:search)
-    destination_flipper.migrate(source_flipper)
-    expect(destination_flipper.features.map(&:key)).to eq(["search"])
-  end
+    it 'can migrate features that have been added but their state is off' do
+      feature = source_flipper[:search]
+      source_flipper.add(:search)
+      destination_flipper.migrate(source_flipper)
+      expect(destination_flipper.features.map(&:key)).to eq(["search"])
+    end
 
-  it 'can migrate multiple features' do
-    source_flipper.enable(:yep)
-    source_flipper.enable_group(:preview_features, :developers)
-    source_flipper.enable_group(:preview_features, :marketers)
-    source_flipper.enable_group(:preview_features, :company)
-    source_flipper.enable_group(:preview_features, :early_access)
-    source_flipper.enable_actor(:preview_features, actor_class.new('1'))
-    source_flipper.enable_actor(:preview_features, actor_class.new('2'))
-    source_flipper.enable_actor(:preview_features, actor_class.new('3'))
-    source_flipper.enable_percentage_of_actors(:issues_next, 25)
-    source_flipper.enable_percentage_of_time(:verbose_logging, 5)
+    it 'can migrate multiple features' do
+      source_flipper.enable(:yep)
+      source_flipper.enable_group(:preview_features, :developers)
+      source_flipper.enable_group(:preview_features, :marketers)
+      source_flipper.enable_group(:preview_features, :company)
+      source_flipper.enable_group(:preview_features, :early_access)
+      source_flipper.enable_actor(:preview_features, actor_class.new('1'))
+      source_flipper.enable_actor(:preview_features, actor_class.new('2'))
+      source_flipper.enable_actor(:preview_features, actor_class.new('3'))
+      source_flipper.enable_percentage_of_actors(:issues_next, 25)
+      source_flipper.enable_percentage_of_time(:verbose_logging, 5)
 
-    destination_flipper.migrate(source_flipper)
+      destination_flipper.migrate(source_flipper)
 
-    feature = destination_flipper[:preview_features]
-    expect(feature.boolean_value).to be(false)
-    expect(feature.actors_value).to eq(Set['1', '2', '3'])
-    expected_groups = Set['developers', 'marketers', 'company', 'early_access']
-    expect(feature.groups_value).to eq(expected_groups)
-    expect(feature.percentage_of_actors_value).to be(0)
-    expect(feature.percentage_of_time_value).to be(0)
+      feature = destination_flipper[:preview_features]
+      expect(feature.boolean_value).to be(false)
+      expect(feature.actors_value).to eq(Set['1', '2', '3'])
+      expected_groups = Set['developers', 'marketers', 'company', 'early_access']
+      expect(feature.groups_value).to eq(expected_groups)
+      expect(feature.percentage_of_actors_value).to be(0)
+      expect(feature.percentage_of_time_value).to be(0)
 
-    feature = destination_flipper[:issues_next]
-    expect(feature.boolean_value).to eq(false)
-    expect(feature.actors_value).to eq(Set.new)
-    expect(feature.groups_value).to eq(Set.new)
-    expect(feature.percentage_of_actors_value).to be(25)
-    expect(feature.percentage_of_time_value).to be(0)
+      feature = destination_flipper[:issues_next]
+      expect(feature.boolean_value).to eq(false)
+      expect(feature.actors_value).to eq(Set.new)
+      expect(feature.groups_value).to eq(Set.new)
+      expect(feature.percentage_of_actors_value).to be(25)
+      expect(feature.percentage_of_time_value).to be(0)
 
-    feature = destination_flipper[:verbose_logging]
-    expect(feature.boolean_value).to eq(false)
-    expect(feature.actors_value).to eq(Set.new)
-    expect(feature.groups_value).to eq(Set.new)
-    expect(feature.percentage_of_actors_value).to be(0)
-    expect(feature.percentage_of_time_value).to be(5)
-  end
+      feature = destination_flipper[:verbose_logging]
+      expect(feature.boolean_value).to eq(false)
+      expect(feature.actors_value).to eq(Set.new)
+      expect(feature.groups_value).to eq(Set.new)
+      expect(feature.percentage_of_actors_value).to be(0)
+      expect(feature.percentage_of_time_value).to be(5)
+    end
 
-  it 'wipes existing enablements when migrating' do
-    destination_flipper.enable(:stats)
-    destination_flipper.enable_percentage_of_time(:verbose_logging, 5)
-    source_flipper.enable_percentage_of_time(:stats, 5)
-    source_flipper.enable_percentage_of_actors(:verbose_logging, 25)
+    it 'wipes existing enablements for adapter' do
+      destination_flipper.enable(:stats)
+      destination_flipper.enable_percentage_of_time(:verbose_logging, 5)
+      source_flipper.enable_percentage_of_time(:stats, 5)
+      source_flipper.enable_percentage_of_actors(:verbose_logging, 25)
 
-    destination_flipper.migrate(source_flipper)
+      destination_flipper.migrate(source_flipper)
 
-    feature = destination_flipper[:stats]
-    expect(feature.boolean_value).to be(false)
-    expect(feature.percentage_of_time_value).to be(5)
+      feature = destination_flipper[:stats]
+      expect(feature.boolean_value).to be(false)
+      expect(feature.percentage_of_time_value).to be(5)
 
-    feature = destination_flipper[:verbose_logging]
-    expect(feature.percentage_of_time_value).to be(0)
-    expect(feature.percentage_of_actors_value).to be(25)
+      feature = destination_flipper[:verbose_logging]
+      expect(feature.percentage_of_time_value).to be(0)
+      expect(feature.percentage_of_actors_value).to be(25)
+    end
   end
 end

--- a/spec/flipper/adapter_spec.rb
+++ b/spec/flipper/adapter_spec.rb
@@ -17,7 +17,7 @@ RSpec.describe Flipper::Adapter do
       source_flipper.enable(:search)
       destination_flipper.import(source_flipper)
       expect(destination_flipper[:search].boolean_value).to eq(true)
-      expect(destination_flipper.features.map(&:key).sort).to eq(%w[search])
+      expect(destination_flipper.features.map(&:key).sort).to eq(%w(search))
     end
 
     it 'can import features that have been added but their state is off' do

--- a/spec/flipper/adapter_spec.rb
+++ b/spec/flipper/adapter_spec.rb
@@ -21,7 +21,6 @@ RSpec.describe Flipper::Adapter do
     end
 
     it 'can import features that have been added but their state is off' do
-      feature = source_flipper[:search]
       source_flipper.add(:search)
       destination_flipper.import(source_flipper)
       expect(destination_flipper.features.map(&:key)).to eq(["search"])

--- a/spec/flipper/adapter_spec.rb
+++ b/spec/flipper/adapter_spec.rb
@@ -36,25 +36,42 @@ RSpec.describe Flipper::Adapter do
     destination_flipper.migrate(source_flipper)
 
     feature = destination_flipper[:preview_features]
-    expect(feature.boolean_value).to eq(false)
+    expect(feature.boolean_value).to be(false)
     expect(feature.actors_value).to eq(Set['1', '2', '3'])
     expected_groups = Set['developers', 'marketers', 'company', 'early_access']
     expect(feature.groups_value).to eq(expected_groups)
-    expect(feature.percentage_of_actors_value).to eq(0)
-    expect(feature.percentage_of_time_value).to eq(0)
+    expect(feature.percentage_of_actors_value).to be(0)
+    expect(feature.percentage_of_time_value).to be(0)
 
     feature = destination_flipper[:issues_next]
     expect(feature.boolean_value).to eq(false)
     expect(feature.actors_value).to eq(Set.new)
     expect(feature.groups_value).to eq(Set.new)
-    expect(feature.percentage_of_actors_value).to eq(25)
-    expect(feature.percentage_of_time_value).to eq(0)
+    expect(feature.percentage_of_actors_value).to be(25)
+    expect(feature.percentage_of_time_value).to be(0)
 
     feature = destination_flipper[:verbose_logging]
     expect(feature.boolean_value).to eq(false)
     expect(feature.actors_value).to eq(Set.new)
     expect(feature.groups_value).to eq(Set.new)
-    expect(feature.percentage_of_actors_value).to eq(0)
-    expect(feature.percentage_of_time_value).to eq(5)
+    expect(feature.percentage_of_actors_value).to be(0)
+    expect(feature.percentage_of_time_value).to be(5)
+  end
+
+  it 'wipes existing enablements when migrating' do
+    destination_flipper.enable(:stats)
+    destination_flipper.enable_percentage_of_time(:verbose_logging, 5)
+    source_flipper.enable_percentage_of_time(:stats, 5)
+    source_flipper.enable_percentage_of_actors(:verbose_logging, 25)
+
+    destination_flipper.migrate(source_flipper)
+
+    feature = destination_flipper[:stats]
+    expect(feature.boolean_value).to be(false)
+    expect(feature.percentage_of_time_value).to be(5)
+
+    feature = destination_flipper[:verbose_logging]
+    expect(feature.percentage_of_time_value).to be(0)
+    expect(feature.percentage_of_actors_value).to be(25)
   end
 end

--- a/spec/flipper/adapter_spec.rb
+++ b/spec/flipper/adapter_spec.rb
@@ -2,13 +2,12 @@ require 'helper'
 require 'flipper/adapters/memory'
 
 RSpec.describe Flipper::Adapter do
-  it 'can migrate from one adapter to another' do
-    actor = Struct.new(:flipper_id).new('22')
-    source_adapter = Flipper::Adapters::Memory.new
-    destination_adapter = Flipper::Adapters::Memory.new
-    source_flipper = Flipper.new(source_adapter)
-    destination_flipper = Flipper.new(destination_adapter)
+  let(:actor) { Struct.new(:flipper_id).new('22') }
 
+  let(:source_flipper) { build_flipper }
+  let(:destination_flipper) { build_flipper }
+
+  it 'can migrate from one adapter to another' do
     source_flipper.enable(:search)
     source_flipper.enable_group(:admins, :admins)
     source_flipper.enable_actor(:debug, actor)

--- a/spec/flipper/adapter_spec.rb
+++ b/spec/flipper/adapter_spec.rb
@@ -2,8 +2,6 @@ require 'helper'
 require 'flipper/adapters/memory'
 
 RSpec.describe Flipper::Adapter do
-  let(:actor_class) { Struct.new(:flipper_id) }
-
   let(:source_flipper) { build_flipper }
   let(:destination_flipper) { build_flipper }
 
@@ -32,9 +30,9 @@ RSpec.describe Flipper::Adapter do
       source_flipper.enable_group(:preview_features, :marketers)
       source_flipper.enable_group(:preview_features, :company)
       source_flipper.enable_group(:preview_features, :early_access)
-      source_flipper.enable_actor(:preview_features, actor_class.new('1'))
-      source_flipper.enable_actor(:preview_features, actor_class.new('2'))
-      source_flipper.enable_actor(:preview_features, actor_class.new('3'))
+      source_flipper.enable_actor(:preview_features, Flipper::Actor.new('1'))
+      source_flipper.enable_actor(:preview_features, Flipper::Actor.new('2'))
+      source_flipper.enable_actor(:preview_features, Flipper::Actor.new('3'))
       source_flipper.enable_percentage_of_actors(:issues_next, 25)
       source_flipper.enable_percentage_of_time(:verbose_logging, 5)
 

--- a/spec/flipper/adapter_spec.rb
+++ b/spec/flipper/adapter_spec.rb
@@ -4,28 +4,28 @@ require 'flipper/adapters/memory'
 RSpec.describe Flipper::Adapter do
   it 'can migrate from one adapter to another' do
     actor = Struct.new(:flipper_id).new('22')
-    from_adapter = Flipper::Adapters::Memory.new
-    to_adapter = Flipper::Adapters::Memory.new
-    from_flipper = Flipper.new(from_adapter)
-    to_flipper = Flipper.new(to_adapter)
+    source_adapter = Flipper::Adapters::Memory.new
+    destination_adapter = Flipper::Adapters::Memory.new
+    source_flipper = Flipper.new(source_adapter)
+    destination_flipper = Flipper.new(destination_adapter)
 
-    from_flipper.enable(:search)
-    from_flipper.enable_group(:admins, :admins)
-    from_flipper.enable_actor(:debug, actor)
-    from_flipper.enable_percentage_of_actors(:issues, 25)
-    from_flipper.enable_percentage_of_time(:logging, 50)
-    from_flipper.enable(:nope)
-    from_flipper.disable(:nope)
+    source_flipper.enable(:search)
+    source_flipper.enable_group(:admins, :admins)
+    source_flipper.enable_actor(:debug, actor)
+    source_flipper.enable_percentage_of_actors(:issues, 25)
+    source_flipper.enable_percentage_of_time(:logging, 50)
+    source_flipper.enable(:nope)
+    source_flipper.disable(:nope)
 
-    to_flipper.migrate(from_flipper)
+    destination_flipper.migrate(source_flipper)
 
-    expect(to_flipper[:search].gate_values).to eq(from_flipper[:search].gate_values)
-    expect(to_flipper[:admin].gate_values).to eq(from_flipper[:admin].gate_values)
-    expect(to_flipper[:debug].gate_values).to eq(from_flipper[:debug].gate_values)
-    expect(to_flipper[:issues].gate_values).to eq(from_flipper[:issues].gate_values)
-    expect(to_flipper[:logging].gate_values).to eq(from_flipper[:logging].gate_values)
-    expect(to_flipper[:nope].gate_values).to eq(from_flipper[:nope].gate_values)
+    expect(destination_flipper[:search].gate_values).to eq(source_flipper[:search].gate_values)
+    expect(destination_flipper[:admin].gate_values).to eq(source_flipper[:admin].gate_values)
+    expect(destination_flipper[:debug].gate_values).to eq(source_flipper[:debug].gate_values)
+    expect(destination_flipper[:issues].gate_values).to eq(source_flipper[:issues].gate_values)
+    expect(destination_flipper[:logging].gate_values).to eq(source_flipper[:logging].gate_values)
+    expect(destination_flipper[:nope].gate_values).to eq(source_flipper[:nope].gate_values)
     expected_feature_keys = %w[search admins debug issues logging nope].sort
-    expect(to_flipper.features.map(&:key).sort).to eq(expected_feature_keys)
+    expect(destination_flipper.features.map(&:key).sort).to eq(expected_feature_keys)
   end
 end

--- a/spec/flipper/adapter_spec.rb
+++ b/spec/flipper/adapter_spec.rb
@@ -7,27 +7,27 @@ RSpec.describe Flipper::Adapter do
   let(:source_flipper) { build_flipper }
   let(:destination_flipper) { build_flipper }
 
-  describe '#migrate' do
+  describe '#import' do
     it 'returns nothing' do
-      result = destination_flipper.migrate(source_flipper)
+      result = destination_flipper.import(source_flipper)
       expect(result).to be(nil)
     end
 
-    it 'can migrate from one adapter to another' do
+    it 'can import from one adapter to another' do
       source_flipper.enable(:search)
-      destination_flipper.migrate(source_flipper)
+      destination_flipper.import(source_flipper)
       expect(destination_flipper[:search].boolean_value).to eq(true)
       expect(destination_flipper.features.map(&:key).sort).to eq(%w[search])
     end
 
-    it 'can migrate features that have been added but their state is off' do
+    it 'can import features that have been added but their state is off' do
       feature = source_flipper[:search]
       source_flipper.add(:search)
-      destination_flipper.migrate(source_flipper)
+      destination_flipper.import(source_flipper)
       expect(destination_flipper.features.map(&:key)).to eq(["search"])
     end
 
-    it 'can migrate multiple features' do
+    it 'can import multiple features' do
       source_flipper.enable(:yep)
       source_flipper.enable_group(:preview_features, :developers)
       source_flipper.enable_group(:preview_features, :marketers)
@@ -39,7 +39,7 @@ RSpec.describe Flipper::Adapter do
       source_flipper.enable_percentage_of_actors(:issues_next, 25)
       source_flipper.enable_percentage_of_time(:verbose_logging, 5)
 
-      destination_flipper.migrate(source_flipper)
+      destination_flipper.import(source_flipper)
 
       feature = destination_flipper[:preview_features]
       expect(feature.boolean_value).to be(false)
@@ -70,7 +70,7 @@ RSpec.describe Flipper::Adapter do
       source_flipper.enable_percentage_of_time(:stats, 5)
       source_flipper.enable_percentage_of_actors(:verbose_logging, 25)
 
-      destination_flipper.migrate(source_flipper)
+      destination_flipper.import(source_flipper)
 
       feature = destination_flipper[:stats]
       expect(feature.boolean_value).to be(false)

--- a/spec/flipper/adapters/read_only_spec.rb
+++ b/spec/flipper/adapters/read_only_spec.rb
@@ -2,8 +2,6 @@ require 'helper'
 require 'flipper/adapters/read_only'
 
 RSpec.describe Flipper::Adapters::ReadOnly do
-  let(:actor_class) { Struct.new(:flipper_id) }
-
   let(:adapter) { Flipper::Adapters::Memory.new }
   let(:flipper) { Flipper.new(subject) }
   let(:feature) { flipper[:stats] }
@@ -44,7 +42,7 @@ RSpec.describe Flipper::Adapters::ReadOnly do
   end
 
   it 'can get feature' do
-    actor22 = actor_class.new('22')
+    actor22 = Flipper::Actor.new('22')
     adapter.enable(feature, boolean_gate, flipper.boolean)
     adapter.enable(feature, group_gate, flipper.group(:admins))
     adapter.enable(feature, actor_gate, flipper.actor(actor22))

--- a/spec/flipper/api/v1/actions/clear_feature_spec.rb
+++ b/spec/flipper/api/v1/actions/clear_feature_spec.rb
@@ -6,8 +6,7 @@ RSpec.describe Flipper::Api::V1::Actions::ClearFeature do
   describe 'clear' do
     before do
       Flipper.register(:admins) {}
-      actor_class = Flipper::Actor
-      actor22 = actor_class.new('22')
+      actor22 = Flipper::Actor.new('22')
 
       feature = flipper[:my_feature]
       feature.enable flipper.boolean

--- a/spec/flipper/api/v1/actions/clear_feature_spec.rb
+++ b/spec/flipper/api/v1/actions/clear_feature_spec.rb
@@ -6,7 +6,7 @@ RSpec.describe Flipper::Api::V1::Actions::ClearFeature do
   describe 'clear' do
     before do
       Flipper.register(:admins) {}
-      actor_class = Struct.new(:flipper_id)
+      actor_class = Flipper::Actor
       actor22 = actor_class.new('22')
 
       feature = flipper[:my_feature]

--- a/spec/flipper/dsl_spec.rb
+++ b/spec/flipper/dsl_spec.rb
@@ -260,4 +260,12 @@ RSpec.describe Flipper::DSL do
       expect(subject.features).to be_empty
     end
   end
+
+  describe '#migrate' do
+    it 'delegates to adapter' do
+      destination_flipper = build_flipper
+      expect(subject.adapter).to receive(:migrate).with(destination_flipper.adapter)
+      subject.migrate(destination_flipper)
+    end
+  end
 end

--- a/spec/flipper/dsl_spec.rb
+++ b/spec/flipper/dsl_spec.rb
@@ -268,11 +268,11 @@ RSpec.describe Flipper::DSL do
     end
   end
 
-  describe '#migrate' do
+  describe '#import' do
     it 'delegates to adapter' do
       destination_flipper = build_flipper
-      expect(subject.adapter).to receive(:migrate).with(destination_flipper.adapter)
-      subject.migrate(destination_flipper)
+      expect(subject.adapter).to receive(:import).with(destination_flipper.adapter)
+      subject.import(destination_flipper)
     end
   end
 end

--- a/spec/flipper/dsl_spec.rb
+++ b/spec/flipper/dsl_spec.rb
@@ -107,7 +107,7 @@ RSpec.describe Flipper::DSL do
   describe '#actor' do
     context 'for a thing' do
       it 'returns actor instance' do
-        thing = Struct.new(:flipper_id).new(33)
+        thing = Flipper::Actor.new(33)
         actor = subject.actor(thing)
         expect(actor).to be_instance_of(Flipper::Types::Actor)
         expect(actor.value).to eq('33')
@@ -204,7 +204,7 @@ RSpec.describe Flipper::DSL do
 
   describe '#enable_actor/disable_actor' do
     it 'enables and disables the feature for actor' do
-      actor = Struct.new(:flipper_id).new(5)
+      actor = Flipper::Actor.new(5)
 
       expect(subject[:stats].actors_value).to be_empty
       subject.enable_actor(:stats, actor)
@@ -217,7 +217,7 @@ RSpec.describe Flipper::DSL do
 
   describe '#enable_group/disable_group' do
     it 'enables and disables the feature for group' do
-      actor = Struct.new(:flipper_id).new(5)
+      actor = Flipper::Actor.new(5)
       group = Flipper.register(:fives) { |actor| actor.flipper_id == 5 }
 
       expect(subject[:stats].groups_value).to be_empty

--- a/spec/flipper/dsl_spec.rb
+++ b/spec/flipper/dsl_spec.rb
@@ -251,13 +251,20 @@ RSpec.describe Flipper::DSL do
     end
   end
 
+  describe '#add' do
+    it 'adds the feature' do
+      expect(subject.features).to eq(Set.new)
+      subject.add(:stats)
+      expect(subject.features).to eq(Set[subject[:stats]])
+    end
+  end
+
   describe '#remove' do
     it 'removes the feature' do
-      subject.enable(:stats)
-
-      expect { subject.remove(:stats) }.to change { subject.enabled?(:stats) }.to(false)
-
-      expect(subject.features).to be_empty
+      subject.adapter.add(subject[:stats])
+      expect(subject.features).to eq(Set[subject[:stats]])
+      subject.remove(:stats)
+      expect(subject.features).to eq(Set.new)
     end
   end
 

--- a/spec/flipper/feature_check_context_spec.rb
+++ b/spec/flipper/feature_check_context_spec.rb
@@ -3,7 +3,7 @@ require 'helper'
 RSpec.describe Flipper::FeatureCheckContext do
   let(:feature_name) { :new_profiles }
   let(:values) { Flipper::GateValues.new({}) }
-  let(:thing) { Struct.new(:flipper_id).new('5') }
+  let(:thing) { Flipper::Actor.new('5') }
   let(:options) do
     {
       feature_name: feature_name,

--- a/spec/flipper/feature_spec.rb
+++ b/spec/flipper/feature_spec.rb
@@ -89,6 +89,23 @@ RSpec.describe Flipper::Feature do
     end
   end
 
+  describe '#add' do
+    it 'adds feature to adapter' do
+      expect(adapter.features).to eq(Set.new)
+      subject.add
+      expect(adapter.features).to eq(Set[subject.key])
+    end
+  end
+
+  describe '#remove' do
+    it 'removes feature from adapter' do
+      adapter.add(subject)
+      expect(adapter.features).to eq(Set[subject.key])
+      subject.remove
+      expect(adapter.features).to eq(Set.new)
+    end
+  end
+
   describe '#inspect' do
     it 'returns easy to read string representation' do
       string = subject.inspect
@@ -193,6 +210,17 @@ RSpec.describe Flipper::Feature do
       expect(event).not_to be_nil
       expect(event.payload[:operation]).to eq(:disable)
       expect(event.payload[:thing]).to eq(Flipper::Types::Actor.new(thing))
+    end
+
+    it 'is recorded for add' do
+      subject.add
+
+      event = instrumenter.events.last
+      expect(event).not_to be_nil
+      expect(event.name).to eq('feature_operation.flipper')
+      expect(event.payload[:feature_name]).to eq(:search)
+      expect(event.payload[:operation]).to eq(:add)
+      expect(event.payload[:result]).not_to be_nil
     end
 
     it 'is recorded for remove' do

--- a/spec/flipper/feature_spec.rb
+++ b/spec/flipper/feature_spec.rb
@@ -130,7 +130,7 @@ RSpec.describe Flipper::Feature do
     end
 
     it 'is recorded for enable' do
-      thing = Flipper::Types::Actor.new(Struct.new(:flipper_id).new('1'))
+      thing = Flipper::Types::Actor.new(Flipper::Actor.new('1'))
       gate = subject.gate_for(thing)
 
       subject.enable(thing)
@@ -145,7 +145,7 @@ RSpec.describe Flipper::Feature do
     end
 
     it 'always instruments flipper type instance for enable' do
-      thing = Struct.new(:flipper_id).new('1')
+      thing = Flipper::Actor.new('1')
       gate = subject.gate_for(thing)
 
       subject.enable(thing)
@@ -170,7 +170,7 @@ RSpec.describe Flipper::Feature do
       expect(event.payload[:result]).not_to be_nil
     end
 
-    user = Struct.new(:flipper_id).new('1')
+    user = Flipper::Actor.new('1')
     actor = Flipper::Types::Actor.new(user)
     boolean_true = Flipper::Types::Boolean.new(true)
     boolean_false = Flipper::Types::Boolean.new(false)
@@ -201,7 +201,7 @@ RSpec.describe Flipper::Feature do
     end
 
     it 'always instruments flipper type instance for disable' do
-      thing = Struct.new(:flipper_id).new('1')
+      thing = Flipper::Actor.new('1')
       gate = subject.gate_for(thing)
 
       subject.disable(thing)
@@ -235,7 +235,7 @@ RSpec.describe Flipper::Feature do
     end
 
     it 'is recorded for enabled?' do
-      thing = Flipper::Types::Actor.new(Struct.new(:flipper_id).new('1'))
+      thing = Flipper::Types::Actor.new(Flipper::Actor.new('1'))
       gate = subject.gate_for(thing)
 
       subject.enabled?(thing)
@@ -249,7 +249,7 @@ RSpec.describe Flipper::Feature do
       expect(event.payload[:result]).to eq(false)
     end
 
-    user = Struct.new(:flipper_id).new('1')
+    user = Flipper::Actor.new('1')
     actor = Flipper::Types::Actor.new(user)
     {
       nil => nil,
@@ -489,8 +489,8 @@ RSpec.describe Flipper::Feature do
 
     context 'when one or more actors are enabled' do
       before do
-        subject.enable Flipper::Types::Actor.new(Struct.new(:flipper_id).new('User:5'))
-        subject.enable Flipper::Types::Actor.new(Struct.new(:flipper_id).new('User:22'))
+        subject.enable Flipper::Types::Actor.new(Flipper::Actor.new('User:5'))
+        subject.enable Flipper::Types::Actor.new(Flipper::Actor.new('User:22'))
       end
 
       it 'returns set of actor ids' do
@@ -593,7 +593,7 @@ RSpec.describe Flipper::Feature do
     context 'with gate values set in adapter' do
       before do
         subject.enable Flipper::Types::Boolean.new(true)
-        subject.enable Flipper::Types::Actor.new(Struct.new(:flipper_id).new(5))
+        subject.enable Flipper::Types::Actor.new(Flipper::Actor.new(5))
         subject.enable Flipper::Types::Group.new(:admins)
         subject.enable Flipper::Types::PercentageOfTime.new(50)
         subject.enable Flipper::Types::PercentageOfActors.new(25)
@@ -612,7 +612,7 @@ RSpec.describe Flipper::Feature do
   describe '#enable_actor/disable_actor' do
     context 'with object that responds to flipper_id' do
       it 'updates the gate values to include the actor' do
-        actor = Struct.new(:flipper_id).new(5)
+        actor = Flipper::Actor.new(5)
         expect(subject.gate_values.actors).to be_empty
         subject.enable_actor(actor)
         expect(subject.gate_values.actors).to eq(Set['5'])
@@ -623,7 +623,7 @@ RSpec.describe Flipper::Feature do
 
     context 'with actor instance' do
       it 'updates the gate values to include the actor' do
-        actor = Struct.new(:flipper_id).new(5)
+        actor = Flipper::Actor.new(5)
         instance = Flipper::Types::Actor.new(actor)
         expect(subject.gate_values.actors).to be_empty
         subject.enable_actor(instance)
@@ -637,7 +637,7 @@ RSpec.describe Flipper::Feature do
   describe '#enable_group/disable_group' do
     context 'with symbol group name' do
       it 'updates the gate values to include the group' do
-        actor = Struct.new(:flipper_id).new(5)
+        actor = Flipper::Actor.new(5)
         group = Flipper.register(:five_only) { |actor| actor.flipper_id == 5 }
         expect(subject.gate_values.groups).to be_empty
         subject.enable_group(:five_only)
@@ -649,7 +649,7 @@ RSpec.describe Flipper::Feature do
 
     context 'with string group name' do
       it 'updates the gate values to include the group' do
-        actor = Struct.new(:flipper_id).new(5)
+        actor = Flipper::Actor.new(5)
         group = Flipper.register(:five_only) { |actor| actor.flipper_id == 5 }
         expect(subject.gate_values.groups).to be_empty
         subject.enable_group('five_only')
@@ -661,7 +661,7 @@ RSpec.describe Flipper::Feature do
 
     context 'with group instance' do
       it 'updates the gate values for the group' do
-        actor = Struct.new(:flipper_id).new(5)
+        actor = Flipper::Actor.new(5)
         group = Flipper.register(:five_only) { |actor| actor.flipper_id == 5 }
         expect(subject.gate_values.groups).to be_empty
         subject.enable_group(group)

--- a/spec/flipper/gates/boolean_spec.rb
+++ b/spec/flipper/gates/boolean_spec.rb
@@ -11,7 +11,7 @@ RSpec.describe Flipper::Gates::Boolean do
     Flipper::FeatureCheckContext.new(
       feature_name: feature_name,
       values: Flipper::GateValues.new(boolean: bool),
-      thing: Flipper::Types::Actor.new(Struct.new(:flipper_id).new(1))
+      thing: Flipper::Types::Actor.new(Flipper::Actor.new(1))
     )
   end
 

--- a/spec/flipper/gates/group_spec.rb
+++ b/spec/flipper/gates/group_spec.rb
@@ -11,7 +11,7 @@ RSpec.describe Flipper::Gates::Group do
     Flipper::FeatureCheckContext.new(
       feature_name: feature_name,
       values: Flipper::GateValues.new(groups: set),
-      thing: Flipper::Types::Actor.new(Struct.new(:flipper_id).new('5'))
+      thing: Flipper::Types::Actor.new(Flipper::Actor.new('5'))
     )
   end
 
@@ -22,7 +22,7 @@ RSpec.describe Flipper::Gates::Group do
       end
 
       it 'ignores group' do
-        thing = Struct.new(:flipper_id).new('5')
+        thing = Flipper::Actor.new('5')
         expect(subject.open?(context(Set[:newbs, :staff]))).to be(true)
       end
     end

--- a/spec/flipper/gates/percentage_of_actors_spec.rb
+++ b/spec/flipper/gates/percentage_of_actors_spec.rb
@@ -11,7 +11,7 @@ RSpec.describe Flipper::Gates::PercentageOfActors do
     Flipper::FeatureCheckContext.new(
       feature_name: feature,
       values: Flipper::GateValues.new(percentage_of_actors: integer),
-      thing: thing || Flipper::Types::Actor.new(Struct.new(:flipper_id).new(1))
+      thing: thing || Flipper::Types::Actor.new(Flipper::Actor.new(1))
     )
   end
 
@@ -22,7 +22,7 @@ RSpec.describe Flipper::Gates::PercentageOfActors do
       let(:number_of_actors) { 100 }
 
       let(:actors) do
-        (1..number_of_actors).map { |n| Struct.new(:flipper_id).new(n) }
+        (1..number_of_actors).map { |n| Flipper::Actor.new(n) }
       end
 
       let(:feature_one_enabled_actors) do

--- a/spec/flipper/instrumentation/log_subscriber_spec.rb
+++ b/spec/flipper/instrumentation/log_subscriber_spec.rb
@@ -49,7 +49,7 @@ RSpec.describe Flipper::Instrumentation::LogSubscriber do
   end
 
   context 'feature enabled checks with a thing' do
-    let(:user) { Flipper::Types::Actor.new(Struct.new(:flipper_id).new('1')) }
+    let(:user) { Flipper::Types::Actor.new(Flipper::Actor.new('1')) }
 
     before do
       clear_logs
@@ -63,7 +63,7 @@ RSpec.describe Flipper::Instrumentation::LogSubscriber do
   end
 
   context 'changing feature enabled state' do
-    let(:user) { Flipper::Types::Actor.new(Struct.new(:flipper_id).new('1')) }
+    let(:user) { Flipper::Types::Actor.new(Flipper::Actor.new('1')) }
 
     before do
       clear_logs

--- a/spec/flipper/instrumentation/metriks_subscriber_spec.rb
+++ b/spec/flipper/instrumentation/metriks_subscriber_spec.rb
@@ -11,7 +11,7 @@ RSpec.describe Flipper::Instrumentation::MetriksSubscriber do
     Flipper.new(adapter, instrumenter: ActiveSupport::Notifications)
   end
 
-  let(:user) { user = Struct.new(:flipper_id).new('1') }
+  let(:user) { user = Flipper::Actor.new('1') }
 
   before do
     Metriks::Registry.default.clear

--- a/spec/flipper/instrumentation/statsd_subscriber_spec.rb
+++ b/spec/flipper/instrumentation/statsd_subscriber_spec.rb
@@ -15,7 +15,7 @@ RSpec.describe Flipper::Instrumentation::StatsdSubscriber do
     Flipper.new(adapter, instrumenter: ActiveSupport::Notifications)
   end
 
-  let(:user) { user = Struct.new(:flipper_id).new('1') }
+  let(:user) { user = Flipper::Actor.new('1') }
 
   before do
     described_class.client = statsd_client

--- a/spec/flipper/types/group_spec.rb
+++ b/spec/flipper/types/group_spec.rb
@@ -69,7 +69,7 @@ RSpec.describe Flipper::Types::Group do
       context = Flipper::FeatureCheckContext.new(
         feature_name: :my_feature,
         values: Flipper::GateValues.new({}),
-        thing: Flipper::Types::Actor.new(Struct.new(:flipper_id).new(1))
+        thing: Flipper::Types::Actor.new(Flipper::Actor.new(1))
       )
       group = Flipper.register(:group_with_context) { |actor| actor }
       yielded_actor = group.match?(admin_actor, context)
@@ -80,7 +80,7 @@ RSpec.describe Flipper::Types::Group do
       context = Flipper::FeatureCheckContext.new(
         feature_name: :my_feature,
         values: Flipper::GateValues.new({}),
-        thing: Flipper::Types::Actor.new(Struct.new(:flipper_id).new(1))
+        thing: Flipper::Types::Actor.new(Flipper::Actor.new(1))
       )
       group = Flipper.register(:group_with_context) { |actor, context| [actor, context] }
       yielded_actor, yielded_context = group.match?(admin_actor, context)

--- a/spec/integration_spec.rb
+++ b/spec/integration_spec.rb
@@ -6,9 +6,6 @@ RSpec.describe Flipper do
   let(:adapter)     { Flipper::Adapters::Memory.new }
   let(:flipper)     { described_class.new(adapter) }
   let(:feature)     { flipper[:search] }
-
-  let(:actor_class) { Flipper::Actor }
-
   let(:admin_group) { flipper.group(:admins) }
   let(:dev_group)   { flipper.group(:devs) }
 
@@ -26,8 +23,8 @@ RSpec.describe Flipper do
     double 'Non Flipper Thing', flipper_id: 1,  admin?: nil, dev?: false
   end
 
-  let(:pitt)        { actor_class.new(1) }
-  let(:clooney)     { actor_class.new(10) }
+  let(:pitt)        { Flipper::Actor.new(1) }
+  let(:clooney)     { Flipper::Actor.new(10) }
 
   let(:five_percent_of_actors) { flipper.actors(5) }
   let(:five_percent_of_time) { flipper.time(5) }
@@ -123,7 +120,7 @@ RSpec.describe Flipper do
 
       it 'enables feature for actor within percentage' do
         enabled = (1..100).select do |i|
-          thing = actor_class.new(i)
+          thing = Flipper::Actor.new(i)
           feature.enabled?(thing)
         end.size
 
@@ -202,7 +199,7 @@ RSpec.describe Flipper do
 
       it 'disables actor in percentage of actors' do
         enabled = (1..100).select do |i|
-          thing = actor_class.new(i)
+          thing = Flipper::Actor.new(i)
           feature.enabled?(thing)
         end.size
 
@@ -285,7 +282,7 @@ RSpec.describe Flipper do
 
       it 'disables feature' do
         enabled = (1..100).select do |i|
-          thing = actor_class.new(i)
+          thing = Flipper::Actor.new(i)
           feature.enabled?(thing)
         end.size
 

--- a/spec/integration_spec.rb
+++ b/spec/integration_spec.rb
@@ -7,7 +7,7 @@ RSpec.describe Flipper do
   let(:flipper)     { described_class.new(adapter) }
   let(:feature)     { flipper[:search] }
 
-  let(:actor_class) { Struct.new(:flipper_id) }
+  let(:actor_class) { Flipper::Actor }
 
   let(:admin_group) { flipper.group(:admins) }
   let(:dev_group)   { flipper.group(:devs) }


### PR DESCRIPTION
I've been thinking for a while it would be nice to have a way to swap from one adapter to another. This PR makes that easy. It is not super efficient about network calls, but that can be improved later. I wanted to start with easy and correct. Plus, this is something that should happen very rarely, so if it does a few extra network calls, it probably isn't a big deal.

## Example

```ruby
redis_adapter = Flipper::Adapters::Redis.new
active_record_adapter = Flipper::Adapters::ActiveRecord.new

source = Flipper.new(redis_adapter)
destination = Flipper.new(active_record_adapter)

# wipes destination clean and copies features/gate values from source to it
destination.import(source)
# at this point destination == source
```