### PR TITLE
[minor] Fixing Typo and Removing Boxen Remnants

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -24,9 +24,9 @@ app:
     - mongo
     - memcached
   environment:
-    - BOXEN_REDIS_URL=redis://redis:6379
-    - BOXEN_MONGODB_HOST=mongo
-    - BOXEN_MEMCACHED_URL=memcached:11211
+    - REDIS_URL=redis://redis:6379
+    - MONGODB_HOST=mongo
+    - MEMCACHED_URL=memcached:11211
 bundle_cache:
   container_name: flipper_bundle_cache
   image: busybox

--- a/docs/DockerCompose.md
+++ b/docs/DockerCompose.md
@@ -12,7 +12,7 @@ new contributor could start working on code with a minumum efforts.
 1. Run specs `docker-compose run --rm app bundle exec rspec`
 1. Run tests `docker-compose run --rm app bundle exec rake test`
 1. Clear and check files with Rubocop `docker-compose run --rm  app bundle exec rubocop -D`
-1. Optional: log in to container an using a bash for running specs
+1. Optional: log in to container an using a `bash` shell for running specs
 ```sh
 docker-compose run --rm app bash
 bundle exec rspec

--- a/examples/mongo/basic.rb
+++ b/examples/mongo/basic.rb
@@ -7,7 +7,7 @@ $:.unshift(lib_path)
 
 require 'flipper/adapters/mongo'
 Mongo::Logger.logger.level = Logger::INFO
-collection = Mongo::Client.new(["127.0.0.1:#{ENV["BOXEN_MONGODB_PORT"] || 27017}"], :database => 'testing')['flipper']
+collection = Mongo::Client.new(["127.0.0.1:#{ENV["MONGODB_PORT"] || 27017}"], :database => 'testing')['flipper']
 adapter = Flipper::Adapters::Mongo.new(collection)
 flipper = Flipper.new(adapter)
 

--- a/examples/mongo/internals.rb
+++ b/examples/mongo/internals.rb
@@ -8,7 +8,7 @@ $:.unshift(lib_path)
 
 require 'flipper/adapters/mongo'
 Mongo::Logger.logger.level = Logger::INFO
-collection = Mongo::Client.new(["127.0.0.1:#{ENV["BOXEN_MONGODB_PORT"] || 27017}"], :database => 'testing')['flipper']
+collection = Mongo::Client.new(["127.0.0.1:#{ENV["MONGODB_PORT"] || 27017}"], :database => 'testing')['flipper']
 adapter = Flipper::Adapters::Mongo.new(collection)
 flipper = Flipper.new(adapter)
 

--- a/examples/redis/basic.rb
+++ b/examples/redis/basic.rb
@@ -7,8 +7,8 @@ $:.unshift(lib_path)
 
 require 'flipper/adapters/redis'
 options = {}
-if ENV['BOXEN_REDIS_URL']
-  options[:url] = ENV['BOXEN_REDIS_URL']
+if ENV['REDIS_URL']
+  options[:url] = ENV['REDIS_URL']
 end
 client = Redis.new(options)
 adapter = Flipper::Adapters::Redis.new(client)

--- a/examples/redis/internals.rb
+++ b/examples/redis/internals.rb
@@ -9,8 +9,8 @@ $:.unshift(lib_path)
 require 'flipper/adapters/redis'
 
 options = {}
-if ENV['BOXEN_REDIS_URL']
-  options[:url] = ENV['BOXEN_REDIS_URL']
+if ENV['REDIS_URL']
+  options[:url] = ENV['REDIS_URL']
 end
 client = Redis.new(options)
 adapter = Flipper::Adapters::Redis.new(client)

--- a/examples/redis/namespaced.rb
+++ b/examples/redis/namespaced.rb
@@ -14,8 +14,8 @@ $:.unshift(lib_path)
 
 require 'flipper/adapters/redis'
 options = {url: 'redis://127.0.0.1:6379'}
-if ENV['BOXEN_REDIS_URL']
-  options[:url] = ENV['BOXEN_REDIS_URL']
+if ENV['REDIS_URL']
+  options[:url] = ENV['REDIS_URL']
 end
 client = Redis.new(options)
 namespaced_client = Redis::Namespace.new(:flipper_namespace, redis: client)

--- a/spec/flipper/adapters/dalli_spec.rb
+++ b/spec/flipper/adapters/dalli_spec.rb
@@ -5,7 +5,7 @@ require 'flipper/spec/shared_adapter_specs'
 
 RSpec.describe Flipper::Adapters::Dalli do
   let(:memory_adapter) { Flipper::Adapters::Memory.new }
-  let(:cache)   { Dalli::Client.new(ENV['BOXEN_MEMCACHED_URL'] || '127.0.0.1:11211') }
+  let(:cache)   { Dalli::Client.new(ENV['MEMCACHED_URL'] || '127.0.0.1:11211') }
   let(:adapter) { described_class.new(memory_adapter, cache) }
   let(:flipper) { Flipper.new(adapter) }
 

--- a/spec/flipper/adapters/mongo_spec.rb
+++ b/spec/flipper/adapters/mongo_spec.rb
@@ -7,8 +7,8 @@ Mongo::Logger.logger.level = Logger::INFO
 RSpec.describe Flipper::Adapters::Mongo do
   subject { described_class.new(collection) }
 
-  let(:host) { ENV['BOXEN_MONGODB_HOST'] || '127.0.0.1' }
-  let(:port) { ENV['BOXEN_MONGODB_PORT'] || 27017 }
+  let(:host) { ENV['MONGODB_HOST'] || '127.0.0.1' }
+  let(:port) { ENV['MONGODB_PORT'] || 27017 }
 
   let(:client) do
     Mongo::Client.new(["#{host}:#{port}"], server_selection_timeout: 1, database: 'testing')

--- a/spec/flipper/adapters/redis_cache_spec.rb
+++ b/spec/flipper/adapters/redis_cache_spec.rb
@@ -7,13 +7,13 @@ RSpec.describe Flipper::Adapters::RedisCache do
   let(:client) do
     options = {}
 
-    options[:url] = ENV['BOXEN_REDIS_URL'] if ENV['BOXEN_REDIS_URL']
+    options[:url] = ENV['REDIS_URL'] if ENV['REDIS_URL']
 
     Redis.new(options)
   end
 
   let(:memory_adapter) { Flipper::Adapters::Memory.new }
-  let(:cache)   { Redis.new(url: ENV.fetch('BOXEN_REDIS_URL', 'redis://localhost:6379')) }
+  let(:cache)   { Redis.new(url: ENV.fetch('REDIS_URL', 'redis://localhost:6379')) }
   let(:adapter) { described_class.new(memory_adapter, cache) }
   let(:flipper) { Flipper.new(adapter) }
 

--- a/spec/flipper/adapters/redis_spec.rb
+++ b/spec/flipper/adapters/redis_spec.rb
@@ -6,7 +6,7 @@ RSpec.describe Flipper::Adapters::Redis do
   let(:client) do
     options = {}
 
-    options[:url] = ENV['BOXEN_REDIS_URL'] if ENV['BOXEN_REDIS_URL']
+    options[:url] = ENV['REDIS_URL'] if ENV['REDIS_URL']
 
     Redis.new(options)
   end

--- a/test/adapters/dalli_test.rb
+++ b/test/adapters/dalli_test.rb
@@ -6,7 +6,7 @@ class DalliTest < MiniTest::Test
   prepend Flipper::Test::SharedAdapterTests
 
   def setup
-    url = ENV.fetch('BOXEN_MEMCACHED_URL', 'localhost:11211')
+    url = ENV.fetch('MEMCACHED_URL', 'localhost:11211')
     @cache = Dalli::Client.new(url)
     @cache.flush
     memory_adapter = Flipper::Adapters::Memory.new

--- a/test/adapters/mongo_test.rb
+++ b/test/adapters/mongo_test.rb
@@ -5,7 +5,7 @@ class MongoTest < MiniTest::Test
   prepend Flipper::Test::SharedAdapterTests
 
   def setup
-    host = ENV.fetch('BOXEN_MONGODB_HOST', '127.0.0.1')
+    host = ENV.fetch('MONGODB_HOST', '127.0.0.1')
     port = '27017'
     logger = Logger.new('/dev/null')
     client = Mongo::Client.new(["#{host}:#{port}"],

--- a/test/adapters/redis_cache_test.rb
+++ b/test/adapters/redis_cache_test.rb
@@ -6,7 +6,7 @@ class DalliTest < MiniTest::Test
   prepend Flipper::Test::SharedAdapterTests
 
   def setup
-    url = ENV.fetch('BOXEN_REDIS_URL', 'redis://localhost:6379')
+    url = ENV.fetch('REDIS_URL', 'redis://localhost:6379')
     @cache = Redis.new(url: url).tap(&:flushdb)
     memory_adapter = Flipper::Adapters::Memory.new
     @adapter = Flipper::Adapters::RedisCache.new(memory_adapter, @cache)

--- a/test/adapters/redis_test.rb
+++ b/test/adapters/redis_test.rb
@@ -5,7 +5,7 @@ class RedisTest < MiniTest::Test
   prepend Flipper::Test::SharedAdapterTests
 
   def setup
-    url = ENV.fetch('BOXEN_REDIS_URL', 'redis://localhost:6379')
+    url = ENV.fetch('REDIS_URL', 'redis://localhost:6379')
     client = Redis.new(url: url).tap(&:flushdb)
     @adapter = Flipper::Adapters::Redis.new(client)
   end


### PR DESCRIPTION
#### Changes
- fixing typo in docker compose docs
- :fire:-ing boxen remnants

#### Test Steps Used
```bash
docker-compose run --rm app bundle exec rspec
docker-compose run --rm app bundle exec test
docker-compose run --rm app bundle exec rubocop -D
```