### PR TITLE
Instrumented Cloud

### DIFF
--- a/lib/flipper/cloud.rb
+++ b/lib/flipper/cloud.rb
@@ -6,7 +6,7 @@ module Flipper
     # The default adapter wrapper which doesn't wrap at all.
     DEFAULT_ADAPTER_WRAPPER_BLOCK = ->(adapter) { adapter }
 
-    # The default url should be the one, the only, the website™.
+    # The default url should be the one, the only, the website.
     DEFAULT_URL = "https://www.featureflipper.com/adapter".freeze
 
     # Public: Returns a new Flipper instance with an http adapter correctly

--- a/lib/flipper/cloud.rb
+++ b/lib/flipper/cloud.rb
@@ -4,7 +4,7 @@ require "flipper/instrumenters/noop"
 module Flipper
   module Cloud
     def self.new(token, options = {})
-      url = options.fetch(:url) { "https://www.featureflipper.com/adapter" }
+      url = options.fetch(:url, "https://www.featureflipper.com/adapter")
       instrumenter = options.fetch(:instrumenter, Flipper::Instrumenters::Noop)
       adapter = Flipper::Adapters::Http.new(uri: URI(url),
                                             headers: {

--- a/lib/flipper/cloud.rb
+++ b/lib/flipper/cloud.rb
@@ -7,7 +7,7 @@ module Flipper
     DEFAULT_ADAPTER_WRAPPER_BLOCK = ->(adapter) { adapter }
 
     # The default url should be the one, the only, the website™.
-    DEFAULT_URL = "https://www.featureflipper.com/adapter"
+    DEFAULT_URL = "https://www.featureflipper.com/adapter".freeze
 
     # Public: Returns a new Flipper instance with an http adapter correctly
     # configured for flipper cloud.

--- a/lib/flipper/cloud.rb
+++ b/lib/flipper/cloud.rb
@@ -1,14 +1,16 @@
 require "flipper/adapters/http"
+require "flipper/instrumenters/noop"
 
 module Flipper
   module Cloud
     def self.new(token, options = {})
       url = options.fetch(:url) { "https://www.featureflipper.com/adapter" }
+      instrumenter = options.fetch(:instrumenter, Flipper::Instrumenters::Noop)
       adapter = Flipper::Adapters::Http.new(uri: URI(url),
                                             headers: {
                                               "Feature-Flipper-Token" => token,
                                             })
-      Flipper.new(adapter)
+      Flipper.new(adapter, instrumenter: instrumenter)
     end
   end
 end

--- a/lib/flipper/cloud.rb
+++ b/lib/flipper/cloud.rb
@@ -6,10 +6,14 @@ module Flipper
     def self.new(token, options = {})
       url = options.fetch(:url, "https://www.featureflipper.com/adapter")
       instrumenter = options.fetch(:instrumenter, Flipper::Instrumenters::Noop)
-      adapter = Flipper::Adapters::Http.new(uri: URI(url),
-                                            headers: {
-                                              "Feature-Flipper-Token" => token,
-                                            })
+
+      http_options = {
+        uri: URI(url),
+        headers: {
+          "Feature-Flipper-Token" => token,
+        },
+      }
+      adapter = Flipper::Adapters::Http.new(http_options)
       Flipper.new(adapter, instrumenter: instrumenter)
     end
   end

--- a/lib/flipper/cloud.rb
+++ b/lib/flipper/cloud.rb
@@ -3,10 +3,27 @@ require "flipper/instrumenters/noop"
 
 module Flipper
   module Cloud
-    def self.new(token, options = {})
-      url = options.fetch(:url, "https://www.featureflipper.com/adapter")
-      instrumenter = options.fetch(:instrumenter, Flipper::Instrumenters::Noop)
+    # The default adapter wrapper which doesn't wrap at all.
+    DEFAULT_ADAPTER_WRAPPER_BLOCK = ->(adapter) { adapter }
 
+    # The default url should be the one, the only, the website™.
+    DEFAULT_URL = "https://www.featureflipper.com/adapter"
+
+    # Public: Returns a new Flipper instance with an http adapter correctly
+    # configured for flipper cloud.
+    #
+    # token - The String token for the environment from the website.
+    # options - The Hash of options.
+    #           # :url - The url to point at (defaults to DEFAULT_URL).
+    #           # :adapter_wrapper - The adapter wrapper block. Block should
+    #                                receive an adapter and return an adapter.
+    #                                Allows you to wrap the http adapter with
+    #                                other adapters to make instrumentation and
+    #                                caching easy.
+    #           # :instrumenter - The optional instrumenter to use for the
+    #                             Flipper::DSL instance (defaults to Noop).
+    def self.new(token, options = {})
+      url = options.fetch(:url, DEFAULT_URL)
       http_options = {
         uri: URI(url),
         headers: {
@@ -14,6 +31,11 @@ module Flipper
         },
       }
       adapter = Flipper::Adapters::Http.new(http_options)
+
+      adapter_wrapper = options.fetch(:adapter_wrapper, DEFAULT_ADAPTER_WRAPPER_BLOCK)
+      adapter = adapter_wrapper.call(adapter)
+
+      instrumenter = options.fetch(:instrumenter, Flipper::Instrumenters::Noop)
       Flipper.new(adapter, instrumenter: instrumenter)
     end
   end

--- a/spec/flipper/cloud_spec.rb
+++ b/spec/flipper/cloud_spec.rb
@@ -1,5 +1,6 @@
 require 'helper'
 require 'flipper/cloud'
+require 'flipper/adapters/instrumented'
 
 RSpec.describe Flipper::Cloud do
   context "initialize with token" do
@@ -51,5 +52,20 @@ RSpec.describe Flipper::Cloud do
       expect(uri.host).to eq('www.fakeflipper.com')
       expect(uri.path).to eq('/sadpanda')
     end
+  end
+
+  it 'can set instrumenter' do
+    instrumenter = Object.new
+    instance = described_class.new('asdf', instrumenter: instrumenter)
+    expect(instance.instrumenter).to be(instrumenter)
+  end
+
+  it 'allows wrapping adapter with another adapter like the instrumenter' do
+    adapter_wrapper = ->(adapter) {
+      Flipper::Adapters::Instrumented.new(adapter)
+    }
+    instance = described_class.new('asdf', adapter_wrapper: adapter_wrapper)
+    # instance.adapter is memoizable adapter instance
+    expect(instance.adapter.adapter).to be_instance_of(Flipper::Adapters::Instrumented)
   end
 end

--- a/spec/flipper/cloud_spec.rb
+++ b/spec/flipper/cloud_spec.rb
@@ -61,9 +61,9 @@ RSpec.describe Flipper::Cloud do
   end
 
   it 'allows wrapping adapter with another adapter like the instrumenter' do
-    adapter_wrapper = ->(adapter) {
+    adapter_wrapper = lambda do |adapter|
       Flipper::Adapters::Instrumented.new(adapter)
-    }
+    end
     instance = described_class.new('asdf', adapter_wrapper: adapter_wrapper)
     # instance.adapter is memoizable adapter instance
     expect(instance.adapter.adapter).to be_instance_of(Flipper::Adapters::Instrumented)

--- a/spec/flipper/cloud_spec.rb
+++ b/spec/flipper/cloud_spec.rb
@@ -31,6 +31,10 @@ RSpec.describe Flipper::Cloud do
       headers = @http_client.instance_variable_get('@headers')
       expect(headers['Feature-Flipper-Token']).to eq(token)
     end
+
+    it 'uses noop instrumenter' do
+      expect(@instance.instrumenter).to be(Flipper::Instrumenters::Noop)
+    end
   end
 
   context 'initialize with token and options' do

--- a/spec/flipper/ui/actions/actors_gate_spec.rb
+++ b/spec/flipper/ui/actions/actors_gate_spec.rb
@@ -9,11 +9,7 @@ RSpec.describe Flipper::UI::Actions::ActorsGate do
     end
   end
   let(:session) do
-    if Rack::Protection::AuthenticityToken.respond_to?(:random_token)
-      { csrf: token }
-    else
-      { '_csrf_token' => token }
-    end
+    { :csrf => token, 'csrf' => token, '_csrf_token' => token }
   end
 
   describe 'GET /features/:feature/actors' do

--- a/spec/flipper/ui/actions/boolean_gate_spec.rb
+++ b/spec/flipper/ui/actions/boolean_gate_spec.rb
@@ -9,11 +9,7 @@ RSpec.describe Flipper::UI::Actions::BooleanGate do
     end
   end
   let(:session) do
-    if Rack::Protection::AuthenticityToken.respond_to?(:random_token)
-      { csrf: token }
-    else
-      { '_csrf_token' => token }
-    end
+    { :csrf => token, 'csrf' => token, '_csrf_token' => token }
   end
 
   describe 'POST /features/:feature/boolean' do

--- a/spec/flipper/ui/actions/feature_spec.rb
+++ b/spec/flipper/ui/actions/feature_spec.rb
@@ -9,11 +9,7 @@ RSpec.describe Flipper::UI::Actions::Feature do
     end
   end
   let(:session) do
-    if Rack::Protection::AuthenticityToken.respond_to?(:random_token)
-      { csrf: token }
-    else
-      { '_csrf_token' => token }
-    end
+    { :csrf => token, 'csrf' => token, '_csrf_token' => token }
   end
 
   describe 'DELETE /features/:feature' do

--- a/spec/flipper/ui/actions/features_spec.rb
+++ b/spec/flipper/ui/actions/features_spec.rb
@@ -9,11 +9,7 @@ RSpec.describe Flipper::UI::Actions::Features do
     end
   end
   let(:session) do
-    if Rack::Protection::AuthenticityToken.respond_to?(:random_token)
-      { csrf: token }
-    else
-      { '_csrf_token' => token }
-    end
+    { :csrf => token, 'csrf' => token, '_csrf_token' => token }
   end
 
   describe 'GET /features' do

--- a/spec/flipper/ui/actions/gate_spec.rb
+++ b/spec/flipper/ui/actions/gate_spec.rb
@@ -9,11 +9,7 @@ RSpec.describe Flipper::UI::Actions::Gate do
     end
   end
   let(:session) do
-    if Rack::Protection::AuthenticityToken.respond_to?(:random_token)
-      { csrf: token }
-    else
-      { '_csrf_token' => token }
-    end
+    { :csrf => token, 'csrf' => token, '_csrf_token' => token }
   end
 
   describe 'POST /features/:feature/non-existent-gate' do

--- a/spec/flipper/ui/actions/groups_gate_spec.rb
+++ b/spec/flipper/ui/actions/groups_gate_spec.rb
@@ -10,11 +10,7 @@ RSpec.describe Flipper::UI::Actions::GroupsGate do
   end
 
   let(:session) do
-    if Rack::Protection::AuthenticityToken.respond_to?(:random_token)
-      { csrf: token }
-    else
-      { '_csrf_token' => token }
-    end
+    { :csrf => token, 'csrf' => token, '_csrf_token' => token }
   end
 
   describe 'GET /features/:feature/groups' do

--- a/spec/flipper/ui/actions/percentage_of_actors_gate_spec.rb
+++ b/spec/flipper/ui/actions/percentage_of_actors_gate_spec.rb
@@ -9,11 +9,7 @@ RSpec.describe Flipper::UI::Actions::PercentageOfActorsGate do
     end
   end
   let(:session) do
-    if Rack::Protection::AuthenticityToken.respond_to?(:random_token)
-      { csrf: token }
-    else
-      { '_csrf_token' => token }
-    end
+    { :csrf => token, 'csrf' => token, '_csrf_token' => token }
   end
 
   describe 'POST /features/:feature/percentage_of_actors' do

--- a/spec/flipper/ui/actions/percentage_of_time_gate_spec.rb
+++ b/spec/flipper/ui/actions/percentage_of_time_gate_spec.rb
@@ -9,11 +9,7 @@ RSpec.describe Flipper::UI::Actions::PercentageOfTimeGate do
     end
   end
   let(:session) do
-    if Rack::Protection::AuthenticityToken.respond_to?(:random_token)
-      { csrf: token }
-    else
-      { '_csrf_token' => token }
-    end
+    { :csrf => token, 'csrf' => token, '_csrf_token' => token }
   end
 
   describe 'POST /features/:feature/percentage_of_time' do

--- a/spec/flipper/ui_spec.rb
+++ b/spec/flipper/ui_spec.rb
@@ -9,11 +9,7 @@ RSpec.describe Flipper::UI do
     end
   end
   let(:session) do
-    if Rack::Protection::AuthenticityToken.respond_to?(:random_token)
-      { csrf: token }
-    else
-      { '_csrf_token' => token }
-    end
+    { :csrf => token, 'csrf' => token, '_csrf_token' => token }
   end
 
   describe 'Initializing middleware with flipper instance' do


### PR DESCRIPTION
This makes it possible to pass an instrumenter to the `Flipper.new` call so feature operations can be instrumented. Additionally, it allows passing an adapter wrapper so people can wrap the lower level http adapter with caching, instrumentation, logging or whatever. 