### PR TITLE
Adapter#get_all

### DIFF
--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -186,3 +186,13 @@ Style/IfInsideElse:
 Style/MethodMissing:
   Exclude:
     - 'lib/flipper/types/actor.rb'
+
+Style/AccessorMethodName:
+  Exclude:
+    - 'lib/flipper/adapter.rb'
+    - 'lib/flipper/adapters/http.rb'
+    - 'lib/flipper/adapters/instrumented.rb'
+    - 'lib/flipper/adapters/memoizable.rb'
+    - 'lib/flipper/adapters/operation_logger.rb'
+    - 'lib/flipper/adapters/memory.rb'
+    - 'lib/flipper/adapters/pstore.rb'

--- a/docs/Adapters.md
+++ b/docs/Adapters.md
@@ -31,6 +31,7 @@ The basic API for an adapter is this:
 * `enable(feature, gate, thing)` - Enable a gate for a thing.
 * `disable(feature, gate, thing)` - Disable a gate for a thing.
 * `get_multi(features)` - Get all gate values for several features at once. Implementation is optional. If none provided, default implementation performs N+1 `get` calls where N is the number of elements in the features parameter.
+* `get_all` - Get all gate values for all features at once. Implementation is optional. If none provided, default implementation performs two calls, one to `features` to get the names of all features and one to `get_multi` with the feature names from the first call.
 
 If you would like to make your own adapter, there are shared adapter specs (RSpec) and tests (MiniTest) that you can use to verify that you have everything working correctly.
 

--- a/docs/Optimization.md
+++ b/docs/Optimization.md
@@ -53,6 +53,12 @@ The Memoizer middleware also supports a few options. Use either `preload` or `pr
     config.middleware.use Flipper::Middleware::Memoizer,
       preload_all: true
     ```
+* **`:unless`** - A block that prevents preloading and memoization if it evaluates to true.
+    ```ruby
+    # skip preloading and memoizing if path starts with /assets
+    config.middleware.use Flipper::Middleware::Memoizer,
+      unless: ->(request) { request.path =~ /\A\/assets/ }
+    ```
 
 ## Cache Adapters
 

--- a/docs/Optimization.md
+++ b/docs/Optimization.md
@@ -48,7 +48,7 @@ The Memoizer middleware also supports a few options. Use either `preload` or `pr
     config.middleware.use Flipper::Middleware::Memoizer,
       preload: [:stats, :search, :some_feature]
     ```
-* **`:preload_all`** - A Boolean value (default: false) of whether or not all features should be preloaded. Using this results in a `preload` call with the result of `Adapter#features`. Any subsequent feature checks will be memoized and perform no network calls. I wouldn't recommend using this unless you have few features (< 30?) and nearly all of them are used on every request.
+* **`:preload_all`** - A Boolean value (default: false) of whether or not all features should be preloaded. Using this results in a `preload_all` call with the result of `Adapter#get_all`. Any subsequent feature checks will be memoized and perform no network calls. I wouldn't recommend using this unless you have few features (< 100?) and nearly all of them are used on every request.
     ```ruby
     config.middleware.use Flipper::Middleware::Memoizer,
       preload_all: true

--- a/docs/Optimization.md
+++ b/docs/Optimization.md
@@ -57,7 +57,7 @@ The Memoizer middleware also supports a few options. Use either `preload` or `pr
     ```ruby
     # skip preloading and memoizing if path starts with /assets
     config.middleware.use Flipper::Middleware::Memoizer,
-      unless: ->(request) { request.path =~ /\A\/assets/ }
+      unless: ->(request) { request.path.start_with?("/assets") }
     ```
 
 ## Cache Adapters

--- a/lib/flipper/adapter.rb
+++ b/lib/flipper/adapter.rb
@@ -18,6 +18,9 @@ module Flipper
       end
     end
 
+    # Public: Get all features and gate values in one call. Defaults to one call
+    # to features and another to get_multi. Feel free to override per adapter to
+    # make this more efficient.
     def get_all
       instances = features.map { |key| Flipper::Feature.new(key, self) }
       get_multi(instances)

--- a/lib/flipper/adapter.rb
+++ b/lib/flipper/adapter.rb
@@ -18,6 +18,11 @@ module Flipper
       end
     end
 
+    def get_all
+      instances = features.map { |key| Flipper::Feature.new(key, self) }
+      get_multi(instances)
+    end
+
     # Public: Get multiple features in one call. Defaults to one get per
     # feature. Feel free to override per adapter to make this more efficient and
     # reduce network calls.

--- a/lib/flipper/adapters/http.rb
+++ b/lib/flipper/adapters/http.rb
@@ -59,6 +59,25 @@ module Flipper
         result
       end
 
+      def get_all
+        response = @client.get("/features")
+        raise Error, response unless response.is_a?(Net::HTTPOK)
+
+        parsed_response = JSON.parse(response.body)
+        parsed_features = parsed_response.fetch('features')
+        gates_by_key = parsed_features.each_with_object({}) do |parsed_feature, hash|
+          hash[parsed_feature['key']] = parsed_feature['gates']
+          hash
+        end
+
+        result = {}
+        gates_by_key.keys.each do |key|
+          feature = Feature.new(key, self)
+          result[feature.key] = result_for_feature(feature, gates_by_key[feature.key])
+        end
+        result
+      end
+
       def features
         response = @client.get('/features')
         raise Error, response unless response.is_a?(Net::HTTPOK)

--- a/lib/flipper/adapters/instrumented.rb
+++ b/lib/flipper/adapters/instrumented.rb
@@ -107,6 +107,17 @@ module Flipper
         end
       end
 
+      def get_all
+        payload = {
+          operation: :get_all,
+          adapter_name: @adapter.name,
+        }
+
+        @instrumenter.instrument(InstrumentationName, payload) do |payload|
+          payload[:result] = @adapter.get_all
+        end
+      end
+
       # Public
       def enable(feature, gate, thing)
         payload = {

--- a/lib/flipper/adapters/memoizable.rb
+++ b/lib/flipper/adapters/memoizable.rb
@@ -26,6 +26,7 @@ module Flipper
         @name = :memoizable
         @cache = cache || {}
         @memoize = false
+        @all_fetched = false
       end
 
       # Public
@@ -90,6 +91,27 @@ module Flipper
         end
       end
 
+      def get_all
+        if memoizing?
+          unless @all_fetched
+            result = @adapter.get_all
+            result.each do |key, value|
+              cache[key] = value
+            end
+            cache[FeaturesKey] = result.keys.to_set
+            @all_fetched = true
+          end
+
+          result = {}
+          features.each do |key|
+            result[key] = cache[key]
+          end
+          result
+        else
+          @adapter.get_all
+        end
+      end
+
       # Public
       def enable(feature, gate, thing)
         result = @adapter.enable(feature, gate, thing)
@@ -108,6 +130,7 @@ module Flipper
       #
       # value - The Boolean that decides if local caching is on.
       def memoize=(value)
+        @all_fetched = false
         cache.clear
         @memoize = value
       end

--- a/lib/flipper/adapters/operation_logger.rb
+++ b/lib/flipper/adapters/operation_logger.rb
@@ -17,6 +17,7 @@ module Flipper
         :clear,
         :get,
         :get_multi,
+        :get_all,
         :enable,
         :disable,
       ].freeze
@@ -70,6 +71,12 @@ module Flipper
       def get_multi(features)
         @operations << Operation.new(:get_multi, [features])
         @adapter.get_multi(features)
+      end
+
+      # Public
+      def get_all
+        @operations << Operation.new(:get_all, [])
+        @adapter.get_all
       end
 
       # Public

--- a/lib/flipper/dsl.rb
+++ b/lib/flipper/dsl.rb
@@ -181,6 +181,13 @@ module Flipper
       features
     end
 
+    # Public: Preload all the adapters features.
+    #
+    # Returns an Array of Flipper::Feature.
+    def preload_all
+      preload(features.map(&:name))
+    end
+
     # Public: Shortcut access to a feature instance by name.
     #
     # name - The String or Symbol name of the feature.

--- a/lib/flipper/dsl.rb
+++ b/lib/flipper/dsl.rb
@@ -185,7 +185,8 @@ module Flipper
     #
     # Returns an Array of Flipper::Feature.
     def preload_all
-      preload(features.map(&:name))
+      keys = @adapter.get_all.keys
+      keys.map { |key| feature(key) }
     end
 
     # Public: Shortcut access to a feature instance by name.

--- a/lib/flipper/middleware/memoizer.rb
+++ b/lib/flipper/middleware/memoizer.rb
@@ -32,6 +32,22 @@ module Flipper
       end
 
       def call(env)
+        request = Rack::Request.new(env)
+
+        if skip_memoize?(request)
+          @app.call(env)
+        else
+          memoized_call(env)
+        end
+      end
+
+      private
+
+      def skip_memoize?(request)
+        @opts[:unless] && @opts[:unless].call(request)
+      end
+
+      def memoized_call(env)
         flipper = env.fetch('flipper')
         original = flipper.adapter.memoizing?
         flipper.adapter.memoize = true

--- a/lib/flipper/middleware/memoizer.rb
+++ b/lib/flipper/middleware/memoizer.rb
@@ -56,8 +56,8 @@ module Flipper
           flipper.preload_all
         end
 
-        if @opts[:preload]
-          flipper.preload(@opts[:preload])
+        if (preload = @opts[:preload])
+          flipper.preload(preload)
         end
 
         response = @app.call(env)

--- a/lib/flipper/middleware/memoizer.rb
+++ b/lib/flipper/middleware/memoizer.rb
@@ -40,7 +40,9 @@ module Flipper
           flipper.preload_all
         end
 
-        flipper.preload(@opts[:preload]) if @opts[:preload]
+        if @opts[:preload]
+          flipper.preload(@opts[:preload])
+        end
 
         response = @app.call(env)
         response[2] = Rack::BodyProxy.new(response[2]) do

--- a/lib/flipper/middleware/memoizer.rb
+++ b/lib/flipper/middleware/memoizer.rb
@@ -52,9 +52,7 @@ module Flipper
         original = flipper.adapter.memoizing?
         flipper.adapter.memoize = true
 
-        if @opts[:preload_all]
-          flipper.preload_all
-        end
+        flipper.preload_all if @opts[:preload_all]
 
         if (preload = @opts[:preload])
           flipper.preload(preload)

--- a/lib/flipper/middleware/memoizer.rb
+++ b/lib/flipper/middleware/memoizer.rb
@@ -37,8 +37,7 @@ module Flipper
         flipper.adapter.memoize = true
 
         if @opts[:preload_all]
-          names = flipper.features.map(&:name)
-          flipper.preload(names)
+          flipper.preload_all
         end
 
         flipper.preload(@opts[:preload]) if @opts[:preload]

--- a/lib/flipper/spec/shared_adapter_specs.rb
+++ b/lib/flipper/spec/shared_adapter_specs.rb
@@ -1,5 +1,6 @@
 # Requires the following methods:
 # * subject - The instance of the adapter
+# rubocop:disable Metrics/BlockLength
 RSpec.shared_examples_for 'a flipper adapter' do
   let(:flipper) { Flipper.new(subject) }
   let(:feature) { flipper[:stats] }

--- a/lib/flipper/spec/shared_adapter_specs.rb
+++ b/lib/flipper/spec/shared_adapter_specs.rb
@@ -231,15 +231,30 @@ RSpec.shared_examples_for 'a flipper adapter' do
   it 'can get multiple features' do
     expect(subject.add(flipper[:stats])).to eq(true)
     expect(subject.enable(flipper[:stats], boolean_gate, flipper.boolean)).to eq(true)
-
     expect(subject.add(flipper[:search])).to eq(true)
 
     result = subject.get_multi([flipper[:stats], flipper[:search], flipper[:other]])
     expect(result).to be_instance_of(Hash)
 
-    stats, search, other = result.values
+    stats = result["stats"]
+    search = result["search"]
+    other = result["other"]
     expect(stats).to eq(subject.default_config.merge(boolean: 'true'))
     expect(search).to eq(subject.default_config)
     expect(other).to eq(subject.default_config)
+  end
+
+  it 'can get all features' do
+    expect(subject.add(flipper[:stats])).to eq(true)
+    expect(subject.enable(flipper[:stats], boolean_gate, flipper.boolean)).to eq(true)
+    expect(subject.add(flipper[:search])).to eq(true)
+
+    result = subject.get_all
+    expect(result).to be_instance_of(Hash)
+
+    stats = result["stats"]
+    search = result["search"]
+    expect(stats).to eq(subject.default_config.merge(boolean: 'true'))
+    expect(search).to eq(subject.default_config)
   end
 end

--- a/lib/flipper/test/shared_adapter_test.rb
+++ b/lib/flipper/test/shared_adapter_test.rb
@@ -232,10 +232,26 @@ module Flipper
         result = @adapter.get_multi([@flipper[:stats], @flipper[:search], @flipper[:other]])
         assert_instance_of Hash, result
 
-        stats, search, other = result.values
+        stats = result["stats"]
+        search = result["search"]
+        other = result["other"]
         assert_equal @adapter.default_config.merge(boolean: 'true'), stats
         assert_equal @adapter.default_config, search
         assert_equal @adapter.default_config, other
+      end
+
+      def test_can_get_all_features
+        assert @adapter.add(@flipper[:stats])
+        assert @adapter.enable(@flipper[:stats], @boolean_gate, @flipper.boolean)
+        assert @adapter.add(@flipper[:search])
+
+        result = @adapter.get_all
+        assert_instance_of Hash, result
+
+        stats = result["stats"]
+        search = result["search"]
+        assert_equal @adapter.default_config.merge(boolean: 'true'), stats
+        assert_equal @adapter.default_config, search
       end
     end
   end

--- a/spec/flipper/adapters/http_spec.rb
+++ b/spec/flipper/adapters/http_spec.rb
@@ -94,6 +94,18 @@ RSpec.describe Flipper::Adapters::Http do
     end
   end
 
+  describe "#get_all" do
+    it "raises error when not successful response" do
+      stub_request(:get, "http://app.com/flipper/features")
+        .to_return(status: 503, body: "", headers: {})
+
+      adapter = described_class.new(uri: URI('http://app.com/flipper'))
+      expect do
+        adapter.get_all
+      end.to raise_error(Flipper::Adapters::Http::Error)
+    end
+  end
+
   describe "#features" do
     it "raises error when not successful response" do
       stub_request(:get, "http://app.com/flipper/features")

--- a/spec/flipper/adapters/memoizable_spec.rb
+++ b/spec/flipper/adapters/memoizable_spec.rb
@@ -141,7 +141,7 @@ RSpec.describe Flipper::Adapters::Memoizable do
 
       it 'returns result' do
         names = %i(stats shiny)
-        features = names.map { |name| flipper[name].tap(&:enable) }
+        names.map { |name| flipper[name].tap(&:enable) }
         result = subject.get_all
         adapter_result = adapter.get_all
         expect(result).to eq(adapter_result)

--- a/spec/flipper/adapters/memoizable_spec.rb
+++ b/spec/flipper/adapters/memoizable_spec.rb
@@ -90,7 +90,7 @@ RSpec.describe Flipper::Adapters::Memoizable do
         subject.memoize = true
       end
 
-      it 'memoizes feature' do
+      it 'memoizes features' do
         names = %i(stats shiny)
         features = names.map { |name| flipper[name] }
         results = subject.get_multi(features)
@@ -111,6 +111,39 @@ RSpec.describe Flipper::Adapters::Memoizable do
         features = names.map { |name| flipper[name] }
         result = subject.get_multi(features)
         adapter_result = adapter.get_multi(features)
+        expect(result).to eq(adapter_result)
+      end
+    end
+  end
+
+  describe '#get_all' do
+    context "with memoization enabled" do
+      before do
+        subject.memoize = true
+      end
+
+      it 'memoizes features' do
+        names = %i(stats shiny)
+        features = names.map { |name| flipper[name].tap(&:enable) }
+        results = subject.get_all
+        features.each do |feature|
+          expect(cache[feature.key]).not_to be(nil)
+          expect(cache[feature.key]).to be(results[feature.key])
+        end
+        expect(cache[subject.class::FeaturesKey]).to eq(names.map(&:to_s).to_set)
+      end
+    end
+
+    context "with memoization disabled" do
+      before do
+        subject.memoize = false
+      end
+
+      it 'returns result' do
+        names = %i(stats shiny)
+        features = names.map { |name| flipper[name].tap(&:enable) }
+        result = subject.get_all
+        adapter_result = adapter.get_all
         expect(result).to eq(adapter_result)
       end
     end

--- a/spec/flipper/dsl_spec.rb
+++ b/spec/flipper/dsl_spec.rb
@@ -70,6 +70,42 @@ RSpec.describe Flipper::DSL do
     end
   end
 
+  describe '#preload_all' do
+    let(:instrumenter) { double('Instrumentor', instrument: nil) }
+    let(:dsl) do
+      names.each { |name| adapter.add subject[name] }
+      described_class.new(adapter, instrumenter: instrumenter)
+    end
+    let(:names) { %i(stats shiny) }
+    let(:features) { dsl.preload_all }
+
+    it 'returns array of features' do
+      expect(features).to all be_instance_of(Flipper::Feature)
+    end
+
+    it 'sets names' do
+      expect(features.map(&:key)).to eq(names.map(&:to_s))
+    end
+
+    it 'sets adapter' do
+      features.each do |feature|
+        expect(feature.adapter.name).to eq(dsl.adapter.name)
+      end
+    end
+
+    it 'sets instrumenter' do
+      features.each do |feature|
+        expect(feature.instrumenter).to eq(dsl.instrumenter)
+      end
+    end
+
+    it 'memoizes the feature' do
+      features.each do |feature|
+        expect(dsl.feature(feature.name)).to equal(feature)
+      end
+    end
+  end
+
   describe '#[]' do
     it_should_behave_like 'a DSL feature' do
       let(:method_name) { :[] }

--- a/spec/flipper/middleware/memoizer_spec.rb
+++ b/spec/flipper/middleware/memoizer_spec.rb
@@ -260,10 +260,8 @@ RSpec.describe Flipper::Middleware::Memoizer do
       middleware = described_class
 
       Rack::Builder.new do
-        use middleware, {
-          preload_all: true,
-          unless: ->(request) { request.path =~ /\A\/assets\// },
-        }
+        use middleware, preload_all: true,
+                        unless: ->(request) { request.path.start_with?("/assets") }
 
         map '/' do
           run ->(_env) { [200, {}, []] }

--- a/spec/flipper/middleware/memoizer_spec.rb
+++ b/spec/flipper/middleware/memoizer_spec.rb
@@ -141,9 +141,7 @@ RSpec.describe Flipper::Middleware::Memoizer do
       middleware = described_class.new(app, preload_all: true)
       middleware.call(env)
 
-      expect(adapter.count(:features)).to be(1)
-      expect(adapter.count(:get_multi)).to be(1)
-      expect(adapter.last(:get_multi).args).to eq([[flipper[:stats], flipper[:shiny]]])
+      expect(adapter.count(:get_all)).to be(1)
     end
 
     it 'caches unknown features for duration of request' do

--- a/spec/helper.rb
+++ b/spec/helper.rb
@@ -9,6 +9,7 @@ require 'bundler'
 
 Bundler.setup(:default)
 
+require 'pry'
 require 'webmock/rspec'
 WebMock.disable_net_connect!(allow_localhost: true)
 


### PR DESCRIPTION
Previously preload_all made to adapter calls -- features and get_multi with result of features. This makes it so an adapter can get all features and gate values in one call instead of two by adding `Adapter#get_all`. The default implementation is a call to features and then to get_multi like before, but now it is possible for adapters to be more efficient and do it all in one call. I added it to Http adapter as an example. I'll open an issue to add it to other adapters.