### PR TITLE
Allow set_debug_output for http adapter via configuration hash

### DIFF
--- a/lib/flipper/adapters/http.rb
+++ b/lib/flipper/adapters/http.rb
@@ -18,7 +18,8 @@ module Flipper
                              basic_auth_username: options[:basic_auth_username],
                              basic_auth_password: options[:basic_auth_password],
                              read_timeout: options[:read_timeout],
-                             open_timeout: options[:open_timeout])
+                             open_timeout: options[:open_timeout],
+                             debug_output: options[:debug_output])
         @name = :http
       end
 

--- a/lib/flipper/adapters/http/client.rb
+++ b/lib/flipper/adapters/http/client.rb
@@ -21,6 +21,7 @@ module Flipper
           @basic_auth_password = options[:basic_auth_password]
           @read_timeout = options[:read_timeout]
           @open_timeout = options[:open_timeout]
+          @debug_output = options[:debug_output]
         end
 
         def get(path)
@@ -56,6 +57,7 @@ module Flipper
           http = Net::HTTP.new(uri.host, uri.port)
           http.read_timeout = @read_timeout if @read_timeout
           http.open_timeout = @open_timeout if @open_timeout
+          http.set_debug_output(@debug_output) if @debug_output
 
           if uri.scheme == HTTPS_SCHEME
             http.use_ssl = true

--- a/spec/flipper/adapters/http_spec.rb
+++ b/spec/flipper/adapters/http_spec.rb
@@ -119,6 +119,7 @@ RSpec.describe Flipper::Adapters::Http do
   end
 
   describe 'configuration' do
+    let(:debug_output) { object_double($stderr) }
     let(:options) do
       {
         uri: URI('http://app.com/mount-point'),
@@ -127,6 +128,7 @@ RSpec.describe Flipper::Adapters::Http do
         basic_auth_password: 'password',
         read_timeout: 100,
         open_timeout: 40,
+        debug_output: debug_output,
       }
     end
     subject { described_class.new(options) }
@@ -150,6 +152,14 @@ RSpec.describe Flipper::Adapters::Http do
         a_request(:get, 'http://app.com/mount-point/features/feature_panel')
         .with(basic_auth: %w(username password))
       ).to have_been_made.once
+    end
+
+    it 'allows client to set debug output' do
+      user_agent = Net::HTTP.new("app.com")
+      allow(Net::HTTP).to receive(:new).and_return(user_agent)
+
+      expect(user_agent).to receive(:set_debug_output).with(debug_output)
+      subject.get(feature)
     end
   end
 


### PR DESCRIPTION
addresses #254 

* allow an http adapter user to set where to write debug output by
specifying sink in the configuration hash passed to the adapter

* this will most likely be $stderr/$stdout

* will need to add documentation in next PR