### PR TITLE
Add debug_output documentation to http adapter doc.

### DIFF
--- a/docs/http/README.md
+++ b/docs/http/README.md
@@ -32,3 +32,4 @@ flipper = Flipper.new(adapter)
 * basic_auth_password: Basic Auth password.
 * read_timeout: [number in seconds](https://docs.ruby-lang.org/en/2.3.0/Net/HTTP.html#attribute-i-read_timeout).
 * open_timeout: [number in seconds](https://docs.ruby-lang.org/en/2.3.0/Net/HTTP.html#attribute-i-open_timeout).
+* debug_output: Set an output stream for debugging (e.g. `debug_output: $stderr`). The output stream is passed on to [Net::HTTP#set_debug_output](https://ruby-doc.org/stdlib-2.4.1/libdoc/net/http/rdoc/Net/HTTP.html#method-i-set_debug_output).


### PR DESCRIPTION
fixes #257 

adds debug_output option to http adapter documentation section.  

Decided not to add it to the example code since I think its better to not have someone who is just getting started copy/paste this code with debug_output set.
