### PR TITLE
Default Instance Storage

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,26 +41,34 @@ The goal of the API for flipper was to have everything revolve around features a
 
 ```ruby
 require 'flipper'
-
-# pick an adapter
 require 'flipper/adapters/memory'
-adapter = Flipper::Adapters::Memory.new
 
-# get a handy dsl instance
-flipper = Flipper.new(adapter)
+Flipper.configure do |config|
+  config.default do
+    # pick an adapter, this uses memory, any will do
+    adapter = Flipper::Adapters::Memory.new
 
-# grab a feature
-search = flipper[:search]
+    # pass adapter to handy DSL instance
+    Flipper.new(adapter)
+  end
+end
 
-# check if that feature is enabled
-if search.enabled?
+# check if search is enabled
+if Flipper.enabled?(:search)
   puts 'Search away!'
 else
   puts 'No search for you!'
 end
 
 puts 'Enabling Search...'
-search.enable
+Flipper.enable(:search)
+
+# check if search is enabled
+if Flipper.enabled?(:search)
+  puts 'Search away!'
+else
+  puts 'No search for you!'
+end
 ```
 
 Of course there are more [examples for you to peruse](examples/). You could also check out the [DSL](lib/flipper/dsl.rb) and [Feature](lib/flipper/feature.rb) classes for code/docs.

--- a/examples/basic.rb
+++ b/examples/basic.rb
@@ -3,25 +3,29 @@ require File.expand_path('../example_setup', __FILE__)
 require 'flipper'
 require 'flipper/adapters/memory'
 
-# pick an adapter
-adapter = Flipper::Adapters::Memory.new
+Flipper.configure do |config|
+  config.default do
+    # pick an adapter, this uses memory, any will do
+    adapter = Flipper::Adapters::Memory.new
 
-# get a handy dsl instance
-flipper = Flipper.new(adapter)
-
-# grab a feature
-search = flipper[:search]
-
-perform = lambda do
-  # check if that feature is enabled
-  if search.enabled?
-    puts 'Search away!'
-  else
-    puts 'No search for you!'
+    # pass adapter to handy DSL instance
+    Flipper.new(adapter)
   end
 end
 
-perform.call
+# check if search is enabled
+if Flipper.enabled?(:search)
+  puts 'Search away!'
+else
+  puts 'No search for you!'
+end
+
 puts 'Enabling Search...'
-search.enable
-perform.call
+Flipper.enable(:search)
+
+# check if search is enabled
+if Flipper.enabled?(:search)
+  puts 'Search away!'
+else
+  puts 'No search for you!'
+end

--- a/examples/configuring_default.rb
+++ b/examples/configuring_default.rb
@@ -10,86 +10,14 @@ Flipper.configure do |config|
   end
 end
 
-# create a thing with an identifier
-class Person
-  attr_reader :id
+puts Flipper.enabled?(:search) # => false
+Flipper.enable(:search)
+puts Flipper.enabled?(:search) # => true
+Flipper.disable(:search)
 
-  def initialize(id)
-    @id = id
-  end
+enabled_actor = Flipper::Actor.new("1")
+disabled_actor = Flipper::Actor.new("2")
+Flipper.enable_actor(:search, enabled_actor)
 
-  # Must respond to flipper_id
-  alias_method :flipper_id, :id
-end
-
-person = Person.new(1)
-
-puts "Stats are disabled by default\n\n"
-
-# is a feature enabled
-puts "Flipper.enabled? :stats: #{Flipper.enabled? :stats}"
-
-# is a feature on or off for a particular person
-puts "Flipper.enabled? :stats, person: #{Flipper.enabled? :stats, person}"
-
-puts "\n\nEnabling the stats feature"
-Flipper.enable :stats
-puts "Flipper.enabled? :stats: #{Flipper.enabled? :stats}"
-puts "Flipper.enabled? :stats, person: #{Flipper.enabled? :stats, person}"
-
-puts "\n\nDisabling the stats feature"
-Flipper.enable :stats
-
-# get at a feature
-puts "\nYou can also get an individual feature like this:\nstats = Flipper[:stats]\n\n"
-stats = Flipper[:stats]
-
-# is that feature enabled
-puts "stats.enabled?: #{stats.enabled?}"
-
-# is that feature enabled for a particular person
-puts "stats.enabled? person: #{stats.enabled? person}"
-
-# enable a feature by name
-puts "\nEnabling stats\n\n"
-Flipper.enable :stats
-
-# or, you can use the feature to enable
-stats.enable
-
-puts "stats.enabled?: #{stats.enabled?}"
-puts "stats.enabled? person: #{stats.enabled? person}"
-
-# oh, no, let's turn this baby off
-puts "\nDisabling stats\n\n"
-Flipper.disable :stats
-
-# or we can disable using feature obviously
-stats.disable
-
-puts "stats.enabled?: #{stats.enabled?}"
-puts "stats.enabled? person: #{stats.enabled? person}"
-puts
-
-# get an instance of the percentage of time type set to 5
-puts Flipper.time(5).inspect
-
-# get an instance of the percentage of actors type set to 15
-puts Flipper.actors(15).inspect
-
-# get an instance of an actor using an object that responds to flipper_id
-responds_to_flipper_id = Struct.new(:flipper_id).new(10)
-puts Flipper.actor(responds_to_flipper_id).inspect
-
-# get an instance of an actor using an object
-thing = Struct.new(:flipper_id).new(22)
-puts Flipper.actor(thing).inspect
-
-# register a top level group
-admins = Flipper.register(:admins) { |actor|
-  actor.respond_to?(:admin?) && actor.admin?
-}
-puts admins.inspect
-
-# get instance of registered group by name
-puts Flipper.group(:admins).inspect
+puts Flipper.enabled?(:search, enabled_actor)
+puts Flipper.enabled?(:search, disabled_actor)

--- a/examples/configuring_default.rb
+++ b/examples/configuring_default.rb
@@ -3,6 +3,7 @@ require File.expand_path('../example_setup', __FILE__)
 require 'flipper'
 require 'flipper/adapters/memory'
 
+# sets up default adapter so Flipper works like Flipper::DSL
 Flipper.configure do |config|
   config.default do
     Flipper.new Flipper::Adapters::Memory.new

--- a/examples/configuring_default.rb
+++ b/examples/configuring_default.rb
@@ -1,0 +1,94 @@
+require File.expand_path('../example_setup', __FILE__)
+
+require 'flipper'
+require 'flipper/adapters/memory'
+
+Flipper.configure do |config|
+  config.default do
+    Flipper.new Flipper::Adapters::Memory.new
+  end
+end
+
+# create a thing with an identifier
+class Person
+  attr_reader :id
+
+  def initialize(id)
+    @id = id
+  end
+
+  # Must respond to flipper_id
+  alias_method :flipper_id, :id
+end
+
+person = Person.new(1)
+
+puts "Stats are disabled by default\n\n"
+
+# is a feature enabled
+puts "Flipper.enabled? :stats: #{Flipper.enabled? :stats}"
+
+# is a feature on or off for a particular person
+puts "Flipper.enabled? :stats, person: #{Flipper.enabled? :stats, person}"
+
+puts "\n\nEnabling the stats feature"
+Flipper.enable :stats
+puts "Flipper.enabled? :stats: #{Flipper.enabled? :stats}"
+puts "Flipper.enabled? :stats, person: #{Flipper.enabled? :stats, person}"
+
+puts "\n\nDisabling the stats feature"
+Flipper.enable :stats
+
+# get at a feature
+puts "\nYou can also get an individual feature like this:\nstats = Flipper[:stats]\n\n"
+stats = Flipper[:stats]
+
+# is that feature enabled
+puts "stats.enabled?: #{stats.enabled?}"
+
+# is that feature enabled for a particular person
+puts "stats.enabled? person: #{stats.enabled? person}"
+
+# enable a feature by name
+puts "\nEnabling stats\n\n"
+Flipper.enable :stats
+
+# or, you can use the feature to enable
+stats.enable
+
+puts "stats.enabled?: #{stats.enabled?}"
+puts "stats.enabled? person: #{stats.enabled? person}"
+
+# oh, no, let's turn this baby off
+puts "\nDisabling stats\n\n"
+Flipper.disable :stats
+
+# or we can disable using feature obviously
+stats.disable
+
+puts "stats.enabled?: #{stats.enabled?}"
+puts "stats.enabled? person: #{stats.enabled? person}"
+puts
+
+# get an instance of the percentage of time type set to 5
+puts Flipper.time(5).inspect
+
+# get an instance of the percentage of actors type set to 15
+puts Flipper.actors(15).inspect
+
+# get an instance of an actor using an object that responds to flipper_id
+responds_to_flipper_id = Struct.new(:flipper_id).new(10)
+puts Flipper.actor(responds_to_flipper_id).inspect
+
+# get an instance of an actor using an object
+thing = Struct.new(:flipper_id).new(22)
+puts Flipper.actor(thing).inspect
+
+# register a top level group
+admins = Flipper.register(:admins) { |actor|
+  actor.respond_to?(:admin?) && actor.admin?
+}
+puts admins.inspect
+
+# get instance of registered group by name
+puts Flipper.group(:admins).inspect

--- a/lib/flipper.rb
+++ b/lib/flipper.rb
@@ -1,12 +1,42 @@
+require "forwardable"
+
 module Flipper
+  extend self
+  extend Forwardable
+
   # Private: The namespace for all instrumented events.
   InstrumentationNamespace = :flipper
 
+  # Public: Raised when Flipper default instance is accessed without first
+  # setting the default_adapter.
+  class DefaultAdapterNotSet < StandardError; end
+
   # Public: Start here. Given an adapter returns a handy DSL to all the flipper
   # goodness. To see supported options, check out dsl.rb.
-  def self.new(adapter, options = {})
+  def new(adapter, options = {})
     DSL.new(adapter, options)
   end
+
+  def default_adapter
+    @default_adapter || raise(DefaultAdapterNotSet, "Default adapter not set")
+  end
+
+  def default_adapter=(default_adapter)
+    @default_adapter = default_adapter
+  end
+
+  def instance
+    @instance ||= new(default_adapter)
+  end
+
+  def_delegators :instance,
+    :enabled?, :enable, :disable, :bool, :boolean,
+    :enable_actor, :disable_actor, :actor,
+    :enable_group, :disable_group,
+    :enable_percentage_of_actors, :disable_percentage_of_actors, :actors, :percentage_of_actors,
+    :enable_percentage_of_time, :disable_percentage_of_time, :time, :percentage_of_time,
+    :features, :feature, :[], :preload, :preload_all,
+    :add, :remove, :import
 
   # Public: Use this to register a group by name.
   #
@@ -22,7 +52,7 @@ module Flipper
   #
   # Returns a Flipper::Group.
   # Raises Flipper::DuplicateGroup if the group is already registered.
-  def self.register(name, &block)
+  def register(name, &block)
     group = Types::Group.new(name, &block)
     groups_registry.add(group.name, group)
     group
@@ -31,28 +61,28 @@ module Flipper
   end
 
   # Public: Returns a Set of registered Types::Group instances.
-  def self.groups
+  def groups
     groups_registry.values.to_set
   end
 
   # Public: Returns a Set of symbols where each symbol is a registered
   # group name. If you just want the names, this is more efficient than doing
   # `Flipper.groups.map(&:name)`.
-  def self.group_names
+  def group_names
     groups_registry.keys.to_set
   end
 
   # Public: Clears the group registry.
   #
   # Returns nothing.
-  def self.unregister_groups
+  def unregister_groups
     groups_registry.clear
   end
 
   # Public: Check if a group exists
   #
   # Returns boolean
-  def self.group_exists?(name)
+  def group_exists?(name)
     groups_registry.key?(name)
   end
 
@@ -65,17 +95,17 @@ module Flipper
   #   Flipper.group(:admins)
   #
   # Returns Flipper::Group.
-  def self.group(name)
+  def group(name)
     groups_registry.get(name) || Types::Group.new(name)
   end
 
   # Internal: Registry of all groups_registry.
-  def self.groups_registry
+  def groups_registry
     @groups_registry ||= Registry.new
   end
 
   # Internal: Change the groups_registry registry.
-  def self.groups_registry=(registry)
+  def groups_registry=(registry)
     @groups_registry = registry
   end
 end

--- a/lib/flipper.rb
+++ b/lib/flipper.rb
@@ -20,7 +20,7 @@ module Flipper
   #   end
   #
   # Yields Flipper::Configuration instance.
-  def configure(&block)
+  def configure
     yield configuration if block_given?
   end
 
@@ -47,13 +47,15 @@ module Flipper
   # Public: All the methods delegated to instance. These should match the
   # interface of Flipper::DSL.
   def_delegators :instance,
-    :enabled?, :enable, :disable, :bool, :boolean,
-    :enable_actor, :disable_actor, :actor,
-    :enable_group, :disable_group,
-    :enable_percentage_of_actors, :disable_percentage_of_actors, :actors, :percentage_of_actors,
-    :enable_percentage_of_time, :disable_percentage_of_time, :time, :percentage_of_time,
-    :features, :feature, :[], :preload, :preload_all,
-    :add, :remove, :import
+                 :enabled?, :enable, :disable, :bool, :boolean,
+                 :enable_actor, :disable_actor, :actor,
+                 :enable_group, :disable_group,
+                 :enable_percentage_of_actors, :disable_percentage_of_actors,
+                 :actors, :percentage_of_actors,
+                 :enable_percentage_of_time, :disable_percentage_of_time,
+                 :time, :percentage_of_time,
+                 :features, :feature, :[], :preload, :preload_all,
+                 :add, :remove, :import
 
   # Public: Use this to register a group by name.
   #

--- a/lib/flipper.rb
+++ b/lib/flipper.rb
@@ -1,7 +1,7 @@
 require "forwardable"
 
 module Flipper
-  extend self
+  extend self # rubocop:disable Style/ModuleFunction
   extend Forwardable
 
   # Private: The namespace for all instrumented events.

--- a/lib/flipper.rb
+++ b/lib/flipper.rb
@@ -41,7 +41,7 @@ module Flipper
   #
   # Returns Flipper::DSL instance.
   def instance
-    Thread.current[:flipper_instance] ||= configuration.default_instance
+    Thread.current[:flipper_instance] ||= configuration.default
   end
 
   # Public: All the methods delegated to instance. These should match the

--- a/lib/flipper.rb
+++ b/lib/flipper.rb
@@ -7,26 +7,26 @@ module Flipper
   # Private: The namespace for all instrumented events.
   InstrumentationNamespace = :flipper
 
-  # Public: Raised when Flipper default instance is accessed without first
-  # setting the default_adapter.
-  class DefaultAdapterNotSet < StandardError; end
-
   # Public: Start here. Given an adapter returns a handy DSL to all the flipper
   # goodness. To see supported options, check out dsl.rb.
   def new(adapter, options = {})
     DSL.new(adapter, options)
   end
 
-  def default_adapter
-    @default_adapter || raise(DefaultAdapterNotSet, "Default adapter not set")
+  def configure(&block)
+    yield configuration if block_given?
   end
 
-  def default_adapter=(default_adapter)
-    @default_adapter = default_adapter
+  def configuration
+    @configuration ||= Configuration.new
+  end
+
+  def configuration=(configuration)
+    @configuration = configuration
   end
 
   def instance
-    @instance ||= new(default_adapter)
+    Thread.current[:flipper_instance] ||= configuration.default_instance
   end
 
   def_delegators :instance,
@@ -111,6 +111,7 @@ module Flipper
 end
 
 require 'flipper/actor'
+require 'flipper/configuration'
 require 'flipper/adapter'
 require 'flipper/dsl'
 require 'flipper/errors'

--- a/lib/flipper.rb
+++ b/lib/flipper.rb
@@ -13,22 +13,39 @@ module Flipper
     DSL.new(adapter, options)
   end
 
+  # Public: Configure flipper.
+  #
+  #   Flipper.configure do |config|
+  #     config.default { ... }
+  #   end
+  #
+  # Yields Flipper::Configuration instance.
   def configure(&block)
     yield configuration if block_given?
   end
 
+  # Public: Returns Flipper::Configuration instance.
   def configuration
     @configuration ||= Configuration.new
   end
 
+  # Public: Sets Flipper::Configuration instance.
   def configuration=(configuration)
     @configuration = configuration
   end
 
+  # Public: Default per thread flipper instance if configured. You should not
+  # need to use this directly as most of the Flipper::DSL methods are delegated
+  # from Flipper module itself. Instead of doing Flipper.instance.enabled?(:search),
+  # you can use Flipper.enabled?(:search) for the same result.
+  #
+  # Returns Flipper::DSL instance.
   def instance
     Thread.current[:flipper_instance] ||= configuration.default_instance
   end
 
+  # Public: All the methods delegated to instance. These should match the
+  # interface of Flipper::DSL.
   def_delegators :instance,
     :enabled?, :enable, :disable, :bool, :boolean,
     :enable_actor, :disable_actor, :actor,

--- a/lib/flipper/configuration.rb
+++ b/lib/flipper/configuration.rb
@@ -1,10 +1,10 @@
 module Flipper
   class Configuration
     def initialize
-      @default = -> {
+      @default = lambda do
         require "flipper/adapters/memory"
         Flipper.new Flipper::Adapters::Memory.new
-      }
+      end
     end
 
     def default(&block)

--- a/lib/flipper/configuration.rb
+++ b/lib/flipper/configuration.rb
@@ -4,10 +4,18 @@ module Flipper
       @default = lambda { raise DefaultNotSet }
     end
 
+    # Controls the default instance for flipper. Defaults to raising an error.
+    #
+    # Flipper::Configuration.new.default do
+    #   require "flipper/adapters/memory"
+    #   Flipper.new(Flipper::Adapters::Memory.new)
+    # end
     def default(&block)
       @default = block
     end
 
+    # Public: Returns the result of default block invocation, which should
+    # always be a Flipper::DSL instance. This can be set with default method.
     def default_instance
       @default.call
     end

--- a/lib/flipper/configuration.rb
+++ b/lib/flipper/configuration.rb
@@ -1,7 +1,7 @@
 module Flipper
   class Configuration
     def initialize
-      @default = lambda { raise DefaultNotSet }
+      @default = -> { raise DefaultNotSet }
     end
 
     # Controls the default instance for flipper. When used with a block it

--- a/lib/flipper/configuration.rb
+++ b/lib/flipper/configuration.rb
@@ -1,10 +1,7 @@
 module Flipper
   class Configuration
     def initialize
-      @default = lambda do
-        require "flipper/adapters/memory"
-        Flipper.new Flipper::Adapters::Memory.new
-      end
+      @default = lambda { raise DefaultNotSet }
     end
 
     def default(&block)

--- a/lib/flipper/configuration.rb
+++ b/lib/flipper/configuration.rb
@@ -4,20 +4,29 @@ module Flipper
       @default = lambda { raise DefaultNotSet }
     end
 
-    # Controls the default instance for flipper. Defaults to raising an error.
+    # Controls the default instance for flipper. When used with a block it
+    # assigns a new default block to use to generate an instance. When used
+    # without a block, it performs a block invocation and returns the result.
     #
-    # Flipper::Configuration.new.default do
-    #   require "flipper/adapters/memory"
-    #   Flipper.new(Flipper::Adapters::Memory.new)
-    # end
+    #   configuration = Flipper::Configuration.new
+    #   configuration.default # => raises DefaultNotSet error.
+    #
+    #   # sets the default block to generate a new instance using Memory adapter
+    #   configuration.default do
+    #     require "flipper/adapters/memory"
+    #     Flipper.new(Flipper::Adapters::Memory.new)
+    #   end
+    #
+    #   configuration.default # => Flipper::DSL instance using Memory adapter
+    #
+    # Returns result of default block invocation if called without block. If
+    # called with block, assigns the default block.
     def default(&block)
-      @default = block
-    end
-
-    # Public: Returns the result of default block invocation, which should
-    # always be a Flipper::DSL instance. This can be set with default method.
-    def default_instance
-      @default.call
+      if block_given?
+        @default = block
+      else
+        @default.call
+      end
     end
   end
 end

--- a/lib/flipper/configuration.rb
+++ b/lib/flipper/configuration.rb
@@ -1,0 +1,18 @@
+module Flipper
+  class Configuration
+    def initialize
+      @default = -> {
+        require "flipper/adapters/memory"
+        Flipper.new Flipper::Adapters::Memory.new
+      }
+    end
+
+    def default(&block)
+      @default = block
+    end
+
+    def default_instance
+      @default.call
+    end
+  end
+end

--- a/lib/flipper/errors.rb
+++ b/lib/flipper/errors.rb
@@ -11,4 +11,14 @@ module Flipper
 
   # Raised when attempting to declare a group name that has already been used.
   class DuplicateGroup < Error; end
+
+  # Raised when default instance not configured but there is an attempt to
+  # use it.
+  class DefaultNotSet < Flipper::Error
+    def initialize(message = nil)
+      default = "Default flipper instance not configured. See " \
+                "Flipper.configure for how to configure the default instance."
+      super(message || default)
+    end
+  end
 end

--- a/spec/flipper/configuration_spec.rb
+++ b/spec/flipper/configuration_spec.rb
@@ -2,15 +2,15 @@ require 'helper'
 require 'flipper/configuration'
 
 RSpec.describe Flipper::Configuration do
-  describe '#default_instance' do
+  describe '#default' do
     it 'raises if default not configured' do
-      expect { subject.default_instance }.to raise_error(Flipper::DefaultNotSet)
+      expect { subject.default }.to raise_error(Flipper::DefaultNotSet)
     end
 
-    it 'can be set using default' do
+    it 'can be set default' do
       instance = Flipper.new(Flipper::Adapters::Memory.new)
       subject.default { instance }
-      expect(subject.default_instance).to be(instance)
+      expect(subject.default).to be(instance)
     end
   end
 end

--- a/spec/flipper/configuration_spec.rb
+++ b/spec/flipper/configuration_spec.rb
@@ -1,0 +1,16 @@
+require 'helper'
+require 'flipper/configuration'
+
+RSpec.describe Flipper::Configuration do
+  describe '#default_instance' do
+    it 'defaults to new DSL instance' do
+      expect(subject.default_instance).to be_instance_of(Flipper::DSL)
+    end
+
+    it 'can be overriden using default' do
+      instance = Flipper.new(Flipper::Adapters::Memory.new)
+      subject.default { instance }
+      expect(subject.default_instance).to be(instance)
+    end
+  end
+end

--- a/spec/flipper/configuration_spec.rb
+++ b/spec/flipper/configuration_spec.rb
@@ -3,11 +3,11 @@ require 'flipper/configuration'
 
 RSpec.describe Flipper::Configuration do
   describe '#default_instance' do
-    it 'defaults to new DSL instance' do
-      expect(subject.default_instance).to be_instance_of(Flipper::DSL)
+    it 'raises if default not configured' do
+      expect { subject.default_instance }.to raise_error(Flipper::DefaultNotSet)
     end
 
-    it 'can be overriden using default' do
+    it 'can be set using default' do
       instance = Flipper.new(Flipper::Adapters::Memory.new)
       subject.default { instance }
       expect(subject.default_instance).to be(instance)

--- a/spec/flipper_spec.rb
+++ b/spec/flipper_spec.rb
@@ -10,7 +10,7 @@ RSpec.describe Flipper do
 
   describe '.configure' do
     it 'yield configuration instance' do
-      Flipper.configure do |config|
+      described_class.configure do |config|
         expect(config).to be_instance_of(Flipper::Configuration)
       end
     end
@@ -18,26 +18,26 @@ RSpec.describe Flipper do
 
   describe '.configuration' do
     it 'returns configuration instance' do
-      expect(Flipper.configuration).to be_instance_of(Flipper::Configuration)
+      expect(described_class.configuration).to be_instance_of(Flipper::Configuration)
     end
   end
 
   describe '.configuration=' do
     it "sets configuration instance" do
       configuration = Flipper::Configuration.new
-      Flipper.configuration = configuration
-      expect(Flipper.configuration).to be(configuration)
+      described_class.configuration = configuration
+      expect(described_class.configuration).to be(configuration)
     end
   end
 
   describe '.instance' do
     it 'returns DSL instance using result of default invocation' do
-      instance = Flipper.new(Flipper::Adapters::Memory.new)
-      Flipper.configure do |config|
+      instance = described_class.new(Flipper::Adapters::Memory.new)
+      described_class.configure do |config|
         config.default { instance }
       end
-      expect(Flipper.instance).to be(instance)
-      expect(Flipper.instance).to be(Flipper.instance) # memoized
+      expect(described_class.instance).to be(instance)
+      expect(described_class.instance).to be(described_class.instance) # memoized
     end
   end
 
@@ -46,133 +46,133 @@ RSpec.describe Flipper do
     let(:actor) { Flipper::Actor.new("1") }
 
     before do
-      Flipper.configure do |config|
-        config.default { Flipper.new(Flipper::Adapters::Memory.new) }
+      described_class.configure do |config|
+        config.default { described_class.new(Flipper::Adapters::Memory.new) }
       end
     end
 
     it 'delegates enabled? to instance' do
-      expect(Flipper.enabled?(:search)).to eq(Flipper.instance.enabled?(:search))
-      Flipper.instance.enable(:search)
-      expect(Flipper.enabled?(:search)).to eq(Flipper.instance.enabled?(:search))
+      expect(described_class.enabled?(:search)).to eq(described_class.instance.enabled?(:search))
+      described_class.instance.enable(:search)
+      expect(described_class.enabled?(:search)).to eq(described_class.instance.enabled?(:search))
     end
 
     it 'delegates enable to instance' do
-      Flipper.enable(:search)
-      expect(Flipper.instance.enabled?(:search)).to be(true)
+      described_class.enable(:search)
+      expect(described_class.instance.enabled?(:search)).to be(true)
     end
 
     it 'delegates disable to instance' do
-      Flipper.disable(:search)
-      expect(Flipper.instance.enabled?(:search)).to be(false)
+      described_class.disable(:search)
+      expect(described_class.instance.enabled?(:search)).to be(false)
     end
 
     it 'delegates bool to instance' do
-      expect(Flipper.bool).to eq(Flipper.instance.bool)
+      expect(described_class.bool).to eq(described_class.instance.bool)
     end
 
     it 'delegates boolean to instance' do
-      expect(Flipper.boolean).to eq(Flipper.instance.boolean)
+      expect(described_class.boolean).to eq(described_class.instance.boolean)
     end
 
     it 'delegates enable_actor to instance' do
-      Flipper.enable_actor(:search, actor)
-      expect(Flipper.instance.enabled?(:search, actor)).to be(true)
+      described_class.enable_actor(:search, actor)
+      expect(described_class.instance.enabled?(:search, actor)).to be(true)
     end
 
     it 'delegates disable_actor to instance' do
-      Flipper.disable_actor(:search, actor)
-      expect(Flipper.instance.enabled?(:search, actor)).to be(false)
+      described_class.disable_actor(:search, actor)
+      expect(described_class.instance.enabled?(:search, actor)).to be(false)
     end
 
     it 'delegates actor to instance' do
-      expect(Flipper.actor(actor)).to eq(Flipper.instance.actor(actor))
+      expect(described_class.actor(actor)).to eq(described_class.instance.actor(actor))
     end
 
     it 'delegates enable_group to instance' do
-      Flipper.enable_group(:search, group)
-      expect(Flipper.instance[:search].enabled_groups).to include(group)
+      described_class.enable_group(:search, group)
+      expect(described_class.instance[:search].enabled_groups).to include(group)
     end
 
     it 'delegates disable_group to instance' do
-      Flipper.disable_group(:search, group)
-      expect(Flipper.instance[:search].enabled_groups).to_not include(group)
+      described_class.disable_group(:search, group)
+      expect(described_class.instance[:search].enabled_groups).not_to include(group)
     end
 
     it 'delegates enable_percentage_of_actors to instance' do
-      Flipper.enable_percentage_of_actors(:search, 5)
-      expect(Flipper.instance[:search].percentage_of_actors_value).to be(5)
+      described_class.enable_percentage_of_actors(:search, 5)
+      expect(described_class.instance[:search].percentage_of_actors_value).to be(5)
     end
 
     it 'delegates disable_percentage_of_actors to instance' do
-      Flipper.disable_percentage_of_actors(:search)
-      expect(Flipper.instance[:search].percentage_of_actors_value).to be(0)
+      described_class.disable_percentage_of_actors(:search)
+      expect(described_class.instance[:search].percentage_of_actors_value).to be(0)
     end
 
     it 'delegates actors to instance' do
-      expect(Flipper.actors(5)).to eq(Flipper.instance.actors(5))
+      expect(described_class.actors(5)).to eq(described_class.instance.actors(5))
     end
 
     it 'delegates percentage_of_actors to instance' do
-      expect(Flipper.percentage_of_actors(5)).to eq(Flipper.instance.percentage_of_actors(5))
+      expect(described_class.percentage_of_actors(5)).to eq(described_class.instance.percentage_of_actors(5))
     end
 
     it 'delegates enable_percentage_of_time to instance' do
-      Flipper.enable_percentage_of_time(:search, 5)
-      expect(Flipper.instance[:search].percentage_of_time_value).to be(5)
+      described_class.enable_percentage_of_time(:search, 5)
+      expect(described_class.instance[:search].percentage_of_time_value).to be(5)
     end
 
     it 'delegates disable_percentage_of_time to instance' do
-      Flipper.disable_percentage_of_time(:search)
-      expect(Flipper.instance[:search].percentage_of_time_value).to be(0)
+      described_class.disable_percentage_of_time(:search)
+      expect(described_class.instance[:search].percentage_of_time_value).to be(0)
     end
 
     it 'delegates time to instance' do
-      expect(Flipper.time(56)).to eq(Flipper.instance.time(56))
+      expect(described_class.time(56)).to eq(described_class.instance.time(56))
     end
 
     it 'delegates percentage_of_time to instance' do
-      expect(Flipper.percentage_of_time(56)).to eq(Flipper.instance.percentage_of_time(56))
+      expect(described_class.percentage_of_time(56)).to eq(described_class.instance.percentage_of_time(56))
     end
 
     it 'delegates features to instance' do
-      Flipper.instance.add(:search)
-      expect(Flipper.features).to eq(Flipper.instance.features)
-      expect(Flipper.features).to include(Flipper.instance[:search])
+      described_class.instance.add(:search)
+      expect(described_class.features).to eq(described_class.instance.features)
+      expect(described_class.features).to include(described_class.instance[:search])
     end
 
     it 'delegates feature to instance' do
-      expect(Flipper.feature(:search)).to eq(Flipper.instance.feature(:search))
+      expect(described_class.feature(:search)).to eq(described_class.instance.feature(:search))
     end
 
     it 'delegates [] to instance' do
-      expect(Flipper[:search]).to eq(Flipper.instance[:search])
+      expect(described_class[:search]).to eq(described_class.instance[:search])
     end
 
     it 'delegates preload to instance' do
-      Flipper.instance.enable(:search)
-      expect(Flipper.preload([:search])).to eq(Flipper.instance.preload([:search]))
+      described_class.instance.enable(:search)
+      expect(described_class.preload([:search])).to eq(described_class.instance.preload([:search]))
     end
 
     it 'delegates preload_all to instance' do
-      Flipper.instance.enable(:search)
-      Flipper.instance.enable(:stats)
-      expect(Flipper.preload_all).to eq(Flipper.instance.preload_all)
+      described_class.instance.enable(:search)
+      described_class.instance.enable(:stats)
+      expect(described_class.preload_all).to eq(described_class.instance.preload_all)
     end
 
     it 'delegates add to instance' do
-      expect(Flipper.add(:search)).to eq(Flipper.instance.add(:search))
+      expect(described_class.add(:search)).to eq(described_class.instance.add(:search))
     end
 
     it 'delegates remove to instance' do
-      expect(Flipper.remove(:search)).to eq(Flipper.instance.remove(:search))
+      expect(described_class.remove(:search)).to eq(described_class.instance.remove(:search))
     end
 
     it 'delegates import to instance' do
-      other = Flipper.new(Flipper::Adapters::Memory.new)
+      other = described_class.new(Flipper::Adapters::Memory.new)
       other.enable(:search)
-      Flipper.import(other)
-      expect(Flipper.enabled?(:search)).to be(true)
+      described_class.import(other)
+      expect(described_class.enabled?(:search)).to be(true)
     end
   end
 

--- a/spec/flipper_spec.rb
+++ b/spec/flipper_spec.rb
@@ -116,4 +116,159 @@ RSpec.describe Flipper do
             ])
     end
   end
+
+  describe '.default_adapter' do
+    it 'raises when not set' do
+      expect { Flipper.default_adapter }.to raise_error(Flipper::DefaultAdapterNotSet)
+    end
+
+    it 'returns default adapter if set' do
+      adapter = Flipper::Adapters::Memory.new
+      Flipper.default_adapter = adapter
+      expect(Flipper.default_adapter).to eq(adapter)
+    end
+  end
+
+  describe '.instance' do
+    it 'returns new DSL instance using default_adapter' do
+      adapter = Flipper::Adapters::Memory.new
+      Flipper.default_adapter = adapter
+      expect(Flipper.instance).to be_instance_of(Flipper::DSL)
+      expect(Flipper.instance).to be(Flipper.instance)
+    end
+  end
+
+  describe "delegation to instance" do
+    let(:group) { Flipper::Types::Group.new(:admins) }
+    let(:actor) { Flipper::Actor.new("1") }
+
+    before do
+      adapter = Flipper::Adapters::Memory.new
+      Flipper.default_adapter = adapter
+    end
+
+    it 'delegates enabled? to instance' do
+      expect(Flipper.enabled?(:search)).to eq(Flipper.instance.enabled?(:search))
+      Flipper.instance.enable(:search)
+      expect(Flipper.enabled?(:search)).to eq(Flipper.instance.enabled?(:search))
+    end
+
+    it 'delegates enable to instance' do
+      Flipper.enable(:search)
+      expect(Flipper.instance.enabled?(:search)).to be(true)
+    end
+
+    it 'delegates disable to instance' do
+      Flipper.disable(:search)
+      expect(Flipper.instance.enabled?(:search)).to be(false)
+    end
+
+    it 'delegates bool to instance' do
+      expect(Flipper.bool).to eq(Flipper.instance.bool)
+    end
+
+    it 'delegates boolean to instance' do
+      expect(Flipper.boolean).to eq(Flipper.instance.boolean)
+    end
+
+    it 'delegates enable_actor to instance' do
+      Flipper.enable_actor(:search, actor)
+      expect(Flipper.instance.enabled?(:search, actor)).to be(true)
+    end
+
+    it 'delegates disable_actor to instance' do
+      Flipper.disable_actor(:search, actor)
+      expect(Flipper.instance.enabled?(:search, actor)).to be(false)
+    end
+
+    it 'delegates actor to instance' do
+      expect(Flipper.actor(actor)).to eq(Flipper.instance.actor(actor))
+    end
+
+    it 'delegates enable_group to instance' do
+      Flipper.enable_group(:search, group)
+      expect(Flipper.instance[:search].enabled_groups).to include(group)
+    end
+
+    it 'delegates disable_group to instance' do
+      Flipper.disable_group(:search, group)
+      expect(Flipper.instance[:search].enabled_groups).to_not include(group)
+    end
+
+    it 'delegates enable_percentage_of_actors to instance' do
+      Flipper.enable_percentage_of_actors(:search, 5)
+      expect(Flipper.instance[:search].percentage_of_actors_value).to be(5)
+    end
+
+    it 'delegates disable_percentage_of_actors to instance' do
+      Flipper.disable_percentage_of_actors(:search)
+      expect(Flipper.instance[:search].percentage_of_actors_value).to be(0)
+    end
+
+    it 'delegates actors to instance' do
+      expect(Flipper.actors(5)).to eq(Flipper.instance.actors(5))
+    end
+
+    it 'delegates percentage_of_actors to instance' do
+      expect(Flipper.percentage_of_actors(5)).to eq(Flipper.instance.percentage_of_actors(5))
+    end
+
+    it 'delegates enable_percentage_of_time to instance' do
+      Flipper.enable_percentage_of_time(:search, 5)
+      expect(Flipper.instance[:search].percentage_of_time_value).to be(5)
+    end
+
+    it 'delegates disable_percentage_of_time to instance' do
+      Flipper.disable_percentage_of_time(:search)
+      expect(Flipper.instance[:search].percentage_of_time_value).to be(0)
+    end
+
+    it 'delegates time to instance' do
+      expect(Flipper.time(56)).to eq(Flipper.instance.time(56))
+    end
+
+    it 'delegates percentage_of_time to instance' do
+      expect(Flipper.percentage_of_time(56)).to eq(Flipper.instance.percentage_of_time(56))
+    end
+
+    it 'delegates features to instance' do
+      Flipper.instance.add(:search)
+      expect(Flipper.features).to eq(Flipper.instance.features)
+      expect(Flipper.features).to include(Flipper.instance[:search])
+    end
+
+    it 'delegates feature to instance' do
+      expect(Flipper.feature(:search)).to eq(Flipper.instance.feature(:search))
+    end
+
+    it 'delegates [] to instance' do
+      expect(Flipper[:search]).to eq(Flipper.instance[:search])
+    end
+
+    it 'delegates preload to instance' do
+      Flipper.instance.enable(:search)
+      expect(Flipper.preload([:search])).to eq(Flipper.instance.preload([:search]))
+    end
+
+    it 'delegates preload_all to instance' do
+      Flipper.instance.enable(:search)
+      Flipper.instance.enable(:stats)
+      expect(Flipper.preload_all).to eq(Flipper.instance.preload_all)
+    end
+
+    it 'delegates add to instance' do
+      expect(Flipper.add(:search)).to eq(Flipper.instance.add(:search))
+    end
+
+    it 'delegates remove to instance' do
+      expect(Flipper.remove(:search)).to eq(Flipper.instance.remove(:search))
+    end
+
+    it 'delegates import to instance' do
+      other = Flipper.new(Flipper::Adapters::Memory.new)
+      other.enable(:search)
+      Flipper.import(other)
+      expect(Flipper.enabled?(:search)).to be(true)
+    end
+  end
 end

--- a/spec/flipper_spec.rb
+++ b/spec/flipper_spec.rb
@@ -8,133 +8,36 @@ RSpec.describe Flipper do
     end
   end
 
-  describe '.group_exists' do
-    it 'returns true if the group is already created' do
-      group = described_class.register('admins', &:admin?)
-      expect(described_class.group_exists?(:admins)).to eq(true)
-    end
-
-    it 'returns false when the group is not yet registered' do
-      expect(described_class.group_exists?(:non_existing)).to eq(false)
-    end
-  end
-
-  describe '.groups_registry' do
-    it 'returns a registry instance' do
-      expect(described_class.groups_registry).to be_instance_of(Flipper::Registry)
-    end
-  end
-
-  describe '.groups_registry=' do
-    it 'sets groups_registry registry' do
-      registry = Flipper::Registry.new
-      described_class.groups_registry = registry
-      expect(described_class.instance_variable_get('@groups_registry')).to eq(registry)
-    end
-  end
-
-  describe '.register' do
-    it 'adds a group to the group_registry' do
-      registry = Flipper::Registry.new
-      described_class.groups_registry = registry
-      group = described_class.register(:admins, &:admin?)
-      expect(registry.get(:admins)).to eq(group)
-    end
-
-    it 'adds a group to the group_registry for string name' do
-      registry = Flipper::Registry.new
-      described_class.groups_registry = registry
-      group = described_class.register('admins', &:admin?)
-      expect(registry.get(:admins)).to eq(group)
-    end
-
-    it 'raises exception if group already registered' do
-      described_class.register(:admins) {}
-
-      expect do
-        described_class.register(:admins) {}
-      end.to raise_error(Flipper::DuplicateGroup, 'Group :admins has already been registered')
-    end
-  end
-
-  describe '.unregister_groups' do
-    it 'clear group registry' do
-      expect(described_class.groups_registry).to receive(:clear)
-      described_class.unregister_groups
-    end
-  end
-
-  describe '.group' do
-    context 'for registered group' do
-      before do
-        @group = described_class.register(:admins) {}
-      end
-
-      it 'returns group' do
-        expect(described_class.group(:admins)).to eq(@group)
-      end
-
-      it 'returns group with string key' do
-        expect(described_class.group('admins')).to eq(@group)
-      end
-    end
-
-    context 'for unregistered group' do
-      before do
-        @group = described_class.group(:cats)
-      end
-
-      it 'returns group' do
-        expect(@group).to be_instance_of(Flipper::Types::Group)
-        expect(@group.name).to eq(:cats)
-      end
-
-      it 'does not add group to registry' do
-        expect(described_class.group_exists?(@group.name)).to be(false)
+  describe '.configure' do
+    it 'yield configuration instance' do
+      Flipper.configure do |config|
+        expect(config).to be_instance_of(Flipper::Configuration)
       end
     end
   end
 
-  describe '.groups' do
-    it 'returns array of group instances' do
-      admins = described_class.register(:admins, &:admin?)
-      preview_features = described_class.register(:preview_features, &:preview_features?)
-      expect(described_class.groups).to eq(Set[
-              admins,
-              preview_features,
-            ])
+  describe '.configuration' do
+    it 'returns configuration instance' do
+      expect(Flipper.configuration).to be_instance_of(Flipper::Configuration)
     end
   end
 
-  describe '.group_names' do
-    it 'returns array of group names' do
-      described_class.register(:admins, &:admin?)
-      described_class.register(:preview_features, &:preview_features?)
-      expect(described_class.group_names).to eq(Set[
-              :admins,
-              :preview_features,
-            ])
-    end
-  end
-
-  describe '.default_adapter' do
-    it 'raises when not set' do
-      expect { Flipper.default_adapter }.to raise_error(Flipper::DefaultAdapterNotSet)
-    end
-
-    it 'returns default adapter if set' do
-      adapter = Flipper::Adapters::Memory.new
-      Flipper.default_adapter = adapter
-      expect(Flipper.default_adapter).to eq(adapter)
+  describe '.configuration=' do
+    it "sets configuration instance" do
+      configuration = Flipper::Configuration.new
+      Flipper.configuration = configuration
+      expect(Flipper.configuration).to be(configuration)
     end
   end
 
   describe '.instance' do
-    it 'returns new DSL instance using default_adapter' do
-      adapter = Flipper::Adapters::Memory.new
-      Flipper.default_adapter = adapter
-      expect(Flipper.instance).to be_instance_of(Flipper::DSL)
-      expect(Flipper.instance).to be(Flipper.instance)
+    it 'returns DSL instance using result of default invocation' do
+      instance = Flipper.new(Flipper::Adapters::Memory.new)
+      Flipper.configure do |config|
+        config.default { instance }
+      end
+      expect(Flipper.instance).to be(instance)
+      expect(Flipper.instance).to be(Flipper.instance) # memoized
     end
   end
 
@@ -143,8 +46,9 @@ RSpec.describe Flipper do
     let(:actor) { Flipper::Actor.new("1") }
 
     before do
-      adapter = Flipper::Adapters::Memory.new
-      Flipper.default_adapter = adapter
+      Flipper.configure do |config|
+        config.default { Flipper.new(Flipper::Adapters::Memory.new) }
+      end
     end
 
     it 'delegates enabled? to instance' do
@@ -269,6 +173,115 @@ RSpec.describe Flipper do
       other.enable(:search)
       Flipper.import(other)
       expect(Flipper.enabled?(:search)).to be(true)
+    end
+  end
+
+  describe '.register' do
+    it 'adds a group to the group_registry' do
+      registry = Flipper::Registry.new
+      described_class.groups_registry = registry
+      group = described_class.register(:admins, &:admin?)
+      expect(registry.get(:admins)).to eq(group)
+    end
+
+    it 'adds a group to the group_registry for string name' do
+      registry = Flipper::Registry.new
+      described_class.groups_registry = registry
+      group = described_class.register('admins', &:admin?)
+      expect(registry.get(:admins)).to eq(group)
+    end
+
+    it 'raises exception if group already registered' do
+      described_class.register(:admins) {}
+
+      expect do
+        described_class.register(:admins) {}
+      end.to raise_error(Flipper::DuplicateGroup, 'Group :admins has already been registered')
+    end
+  end
+
+  describe '.groups' do
+    it 'returns array of group instances' do
+      admins = described_class.register(:admins, &:admin?)
+      preview_features = described_class.register(:preview_features, &:preview_features?)
+      expect(described_class.groups).to eq(Set[
+              admins,
+              preview_features,
+            ])
+    end
+  end
+
+  describe '.group_names' do
+    it 'returns array of group names' do
+      described_class.register(:admins, &:admin?)
+      described_class.register(:preview_features, &:preview_features?)
+      expect(described_class.group_names).to eq(Set[
+              :admins,
+              :preview_features,
+            ])
+    end
+  end
+
+  describe '.unregister_groups' do
+    it 'clear group registry' do
+      expect(described_class.groups_registry).to receive(:clear)
+      described_class.unregister_groups
+    end
+  end
+
+  describe '.group_exists' do
+    it 'returns true if the group is already created' do
+      group = described_class.register('admins', &:admin?)
+      expect(described_class.group_exists?(:admins)).to eq(true)
+    end
+
+    it 'returns false when the group is not yet registered' do
+      expect(described_class.group_exists?(:non_existing)).to eq(false)
+    end
+  end
+
+  describe '.group' do
+    context 'for registered group' do
+      before do
+        @group = described_class.register(:admins) {}
+      end
+
+      it 'returns group' do
+        expect(described_class.group(:admins)).to eq(@group)
+      end
+
+      it 'returns group with string key' do
+        expect(described_class.group('admins')).to eq(@group)
+      end
+    end
+
+    context 'for unregistered group' do
+      before do
+        @group = described_class.group(:cats)
+      end
+
+      it 'returns group' do
+        expect(@group).to be_instance_of(Flipper::Types::Group)
+        expect(@group.name).to eq(:cats)
+      end
+
+      it 'does not add group to registry' do
+        expect(described_class.group_exists?(@group.name)).to be(false)
+      end
+    end
+  end
+
+  describe '.groups_registry' do
+    it 'returns a registry instance' do
+      expect(described_class.groups_registry).to be_instance_of(Flipper::Registry)
+    end
+  end
+
+  describe '.groups_registry=' do
+    it 'sets groups_registry registry' do
+      registry = Flipper::Registry.new
+      described_class.groups_registry = registry
+      expect(described_class.instance_variable_get('@groups_registry')).to eq(registry)
     end
   end
 end

--- a/spec/flipper_spec.rb
+++ b/spec/flipper_spec.rb
@@ -114,7 +114,8 @@ RSpec.describe Flipper do
     end
 
     it 'delegates percentage_of_actors to instance' do
-      expect(described_class.percentage_of_actors(5)).to eq(described_class.instance.percentage_of_actors(5))
+      expected = described_class.instance.percentage_of_actors(5)
+      expect(described_class.percentage_of_actors(5)).to eq(expected)
     end
 
     it 'delegates enable_percentage_of_time to instance' do
@@ -132,7 +133,8 @@ RSpec.describe Flipper do
     end
 
     it 'delegates percentage_of_time to instance' do
-      expect(described_class.percentage_of_time(56)).to eq(described_class.instance.percentage_of_time(56))
+      expected = described_class.instance.percentage_of_time(56)
+      expect(described_class.percentage_of_time(56)).to eq(expected)
     end
 
     it 'delegates features to instance' do

--- a/spec/helper.rb
+++ b/spec/helper.rb
@@ -22,6 +22,7 @@ Dir[FlipperRoot.join('spec/support/**/*.rb')].each { |f| require f }
 RSpec.configure do |config|
   config.before(:example) do
     Flipper.unregister_groups
+    Flipper.default_adapter = nil
   end
 
   config.disable_monkey_patching!

--- a/spec/helper.rb
+++ b/spec/helper.rb
@@ -22,7 +22,7 @@ Dir[FlipperRoot.join('spec/support/**/*.rb')].each { |f| require f }
 RSpec.configure do |config|
   config.before(:example) do
     Flipper.unregister_groups
-    Flipper.default_adapter = nil
+    Flipper.configuration = nil
   end
 
   config.disable_monkey_patching!


### PR DESCRIPTION
This adds a tidy little spot to configure the default flipper instance. This has long been a thing people have to think about to use flipper. Rarely do people use multiple flipper instances in the same app, and if they want to they still can, but at least now it is wrapped up for most people.

```ruby 
# these requires and the configure could sit in an initializer
require 'flipper'
require 'flipper/adapters/memory'

Flipper.configure do |config|
  config.default { Flipper.new(Flipper::Adapters::Memory.new) }
end

puts Flipper.enabled?(:search)
Flipper.enable(:search)
puts Flipper.enabled?(:search)
Flipper.disable(:search)
```

`default` is configured with a block. This makes it so it can either return a single instance no matter what or generate an instance safe for a thread, if necessary. A top level method `Flipper.instance` exists to memoize an instance of the default per thread. 

```ruby
module Flipper
  def instance
    Thread.current[:flipper_instance] ||= configuration.default
  end
end
```

Each thread should get its own flipper instance with this, which should keep things thread safe without much work. This seemed easier than synchronizing everywhere. Since Flipper::DSL instances are light, it seemed like a fine trade off. Let me know if you have any different thoughts.

All of the DSL methods (save `group` which is already top level in `Flipper` module) are now delegated to `Flipper.instance`. This makes it so instead of doing:

```ruby
Flipper.instance.enabled?(:search)
```

You can do:

```ruby
Flipper.enabled?(:search)
```

...which is shorter and easier to remember. The list of methods delegated at this time is [here](https://github.com/jnunemaker/flipper/blob/316cbc1dab5fbd2d1cd6a174aa47128d8d622dfa/lib/flipper.rb#L49).

I'll let this sit for a day or so. Please drop any comments. If I've already merged, feel free to continue to drop comments and I'll follow up with subsequent PRs to address.

fixes #243
xref #261 