### PR TITLE
Improve randomness uniformity

### DIFF
--- a/lib/flipper/gates/percentage_of_actors.rb
+++ b/lib/flipper/gates/percentage_of_actors.rb
@@ -25,17 +25,15 @@ module Flipper
       #
       # Returns true if gate open for thing, false if not.
       def open?(context)
+        return false unless Types::Actor.wrappable?(context.thing)
+
         percentage = context.values[key]
 
-        if Types::Actor.wrappable?(context.thing)
-          actor = Types::Actor.wrap(context.thing)
-          id = "#{context.feature_name}#{actor.value}"
-          # this is to support up to 3 decimal places in percentages
-          scaling_factor = 1_000
-          Zlib.crc32(id) % (100 * scaling_factor) < percentage * scaling_factor
-        else
-          false
-        end
+        actor = Types::Actor.wrap(context.thing)
+        id = "#{context.feature_name}#{actor.value}"
+        # this is to support up to 3 decimal places in percentages
+        scaling_factor = 1_000
+        Zlib.crc32(id) % (100 * scaling_factor) < percentage * scaling_factor
       end
 
       def protects?(thing)

--- a/lib/flipper/gates/percentage_of_actors.rb
+++ b/lib/flipper/gates/percentage_of_actors.rb
@@ -3,6 +3,8 @@ require 'zlib'
 module Flipper
   module Gates
     class PercentageOfActors < Gate
+      RAND_BASE = (2**32 - 1) / 100.0
+
       # Internal: The name of the gate. Used for instrumentation, etc.
       def name
         :percentage_of_actors
@@ -31,9 +33,8 @@ module Flipper
 
         actor = Types::Actor.wrap(context.thing)
         id = "#{context.feature_name}#{actor.value}"
-        # this is to support up to 3 decimal places in percentages
-        scaling_factor = 1_000
-        Zlib.crc32(id) % (100 * scaling_factor) < percentage * scaling_factor
+
+        Zlib.crc32(id) < RAND_BASE * percentage
       end
 
       def protects?(thing)


### PR DESCRIPTION
This PR is for improving the randomness calculation for the percentage of actors. It's a port of the implementation on https://github.com/fetlife/rollout/pull/120. 

As the new implementation reduces the fails in a really small decimal part, I haven't added a spec for this scenario. I also believe that it could become an expensive spec.

On the rollout implementation, [there is a benchmark exposing](https://github.com/fetlife/rollout/pull/120#issuecomment-308239660) the approximate accuracy of this implementation. 

Closes #272 