### PR TITLE
Implement UI::Configuration so users can customize text

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,7 @@ rvm:
   - 2.2
   - 2.3
 bundler_args: --without guard
-before_script: gem install bundler -v 1.10.6 && sudo service redis-server status && sudo service mongodb status
+before_script: gem install bundler -v 1.10.6 && sudo service redis-server status
 script: bundle exec rubocop && bundle exec rake
 services:
   - redis-server

--- a/lib/flipper/ui/configuration.rb
+++ b/lib/flipper/ui/configuration.rb
@@ -1,0 +1,23 @@
+require 'flipper/ui/configuration/option'
+
+module Flipper
+  module UI
+    class Configuration
+      attr_reader :actors,
+                  :boolean,
+                  :delete,
+                  :groups,
+                  :percentage_of_actors,
+                  :percentage_of_time
+
+      def initialize
+        @actors = Option.new("Enable actors using the form above.")
+        @boolean = Option.new("Enable or disable this feature for <strong>everyone</strong> with one click.")
+        @groups = Option.new("Enable groups using the form above.")
+        @percentage_of_actors = Option.new("Percentage of actors functions independently of percentage of time. If you enable 50% of Actors and 25% of Time then the feature will always be enabled for 50% of users and occasionally enabled 25% of the time for everyone.")
+        @percentage_of_time = Option.new("Percentage of actors functions independently of percentage of time. If you enable 50% of Actors and 25% of Time then the feature will always be enabled for 50% of users and occasionally enabled 25% of the time for everyone.")
+        @delete = Option.new("Deleting a feature removes it from the list of features and disables it for everyone.")
+      end
+    end
+  end
+end

--- a/lib/flipper/ui/configuration/option.rb
+++ b/lib/flipper/ui/configuration/option.rb
@@ -1,0 +1,11 @@
+module Flipper
+  module UI
+    class Option
+      attr_accessor :info
+
+      def initialize(info)
+        @info = info
+      end
+    end
+  end
+end


### PR DESCRIPTION
* First spike at #63  allowing users to customize UI text via a Flipper::UI::Configuration, similar to how ActiveAdmin and RailsAdmin handle customization. Right now it just allows customzing a few things but could add more gradually.

In the flipper initializer a user would then:
```
Flipper::UI.configure do |c|
  c.percentage_of_actors.info = "My custom percentage of actors info text"
  c.percentage_of_time.info = "my custom percentage of time info text"
  c.groups.info = "My custom groups info text"
  c.actors.info = "My custom actors info text"
  c.delete.info = "My custom delete info text"
end
```
which would render:

<img width="1008" alt="screen shot 2017-09-05 at 5 54 57 pm" src="https://user-images.githubusercontent.com/3260042/30089685-3b0b81c2-9263-11e7-91b0-5534cf78a047.png">

Without the configure block it will default to the existing flipper ui text.

I also have a branch where I implemented it more with a block style you could manipulate it with the following:

```
Flipper::UI.configure do
  percentage_of_actors do
    info "My custom percentage of actors info text"
  end

  percentage_of_time do
    info "...."
  end
end
```
but it felt a little magical and not as straight forward for the user - maybe some combination of the two would be cool. Although the more I look at this the more I like the block style it separates each section nicely, especially if more options are added:
```
percentage_of_time do 
  info ""
  foo ""
  bar ""
end
```

Would love to hear everyones thoughts

* Removes `sudo services mongo status` from .travis.yml because seemed to be raising an exception failing the build.  I [ran master]( https://travis-ci.org/jnunemaker/flipper/jobs/273300570) and saw it failing there too.  Removing it seems to be okay, but maybe I don't have context on why its there and there's a different solution.