### PR TITLE
Test against ruby 2.4 travis.yml

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,7 @@ rvm:
   - 2.1
   - 2.2
   - 2.3
+  - 2.4
 bundler_args: --without guard
 before_script: gem install bundler -v 1.10.6 && sudo service redis-server status && sudo service mongodb status
 script: bundle exec rubocop && bundle exec rake

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,7 @@ rvm:
   - 2.3
   - 2.4
 bundler_args: --without guard
-before_script: gem install bundler -v 1.10.6 && sudo service redis-server status && sudo service mongodb status
+before_script: gem install bundler -v 1.10.6 && sudo service redis-server status
 script: bundle exec rubocop && bundle exec rake
 services:
   - redis-server


### PR DESCRIPTION
* Keep tests up to date with Ruby versions.

*  Ran into issues when trying to run master build (.e.g https://travis-ci.org/jnunemaker/flipper/builds/272896851).  Seeing error with: `mongodb: unrecognized service`.  Removing this from the .travis.yml seemed to fix the problem, but I don't have context on why that status check is there, so maybe there's a better solution.