### PR TITLE
cache-store => cache_store

### DIFF
--- a/docs/Optimization.md
+++ b/docs/Optimization.md
@@ -102,7 +102,7 @@ Rails applications can cache Flipper calls in any [ActiveSupport::Cache::Store](
 
 Add this line to your application's Gemfile:
 
-    gem 'flipper-cache-store'
+    gem 'flipper-cache_store'
 
 And then execute:
 
@@ -110,7 +110,7 @@ And then execute:
 
 Or install it yourself with:
 
-    $ gem install flipper-cache-store
+    $ gem install flipper-cache_store
 
 Example using the CacheStore adapter with ActiveSupport's [MemoryStore](http://api.rubyonrails.org/classes/ActiveSupport/Cache/MemoryStore.html), Flipper's [Memory adapter](https://github.com/jnunemaker/flipper/blob/master/lib/flipper/adapters/memory.rb), and a TTL of 5 minutes.
 

--- a/docs/cache_store/README.md
+++ b/docs/cache_store/README.md
@@ -6,7 +6,7 @@ A [CacheStore](http://api.rubyonrails.org/classes/ActiveSupport/Cache/Store.html
 
 Add this line to your application's Gemfile:
 
-    gem 'flipper-cache-store'
+    gem 'flipper-cache_store'
 
 And then execute:
 
@@ -14,7 +14,7 @@ And then execute:
 
 Or install it yourself with:
 
-    $ gem install flipper-cache-store
+    $ gem install flipper-cache_store
 
 ## Usage
 

--- a/flipper-cache_store.gemspec
+++ b/flipper-cache_store.gemspec
@@ -8,14 +8,14 @@ end
 Gem::Specification.new do |gem|
   gem.authors       = ['John Nunemaker']
   gem.email         = ['nunemaker@gmail.com']
-  gem.summary       = 'ActiveSupport::Cache::Store adapter for Flipper'
-  gem.description   = 'ActiveSupport::Cache::Store adapter for Flipper'
+  gem.summary       = 'ActiveSupport::Cache store adapter for Flipper'
+  gem.description   = 'ActiveSupport::Cache store adapter for Flipper'
   gem.license       = 'MIT'
   gem.homepage      = 'https://github.com/jnunemaker/flipper'
 
   gem.files         = `git ls-files`.split("\n").select(&flipper_cache_store_files) + ['lib/flipper/version.rb']
   gem.test_files    = `git ls-files -- {test,spec,features}/*`.split("\n").select(&flipper_cache_store_files)
-  gem.name          = 'flipper-cache-store'
+  gem.name          = 'flipper-cache_store'
   gem.require_paths = ['lib']
   gem.version       = Flipper::VERSION
 

--- a/lib/flipper-cache_store.rb
+++ b/lib/flipper-cache_store.rb
@@ -1,0 +1,1 @@
+require 'flipper/adapters/cache_store'


### PR DESCRIPTION
This matches active_record and ruby idioms in general. Mixing dash and underscore is a bit more ugly but matches [rubygems guidelines](http://guides.rubygems.org/name-your-gem/):

```
net-http-digest_auth	require 'net/http/digest_auth'	Net::HTTP::DigestAuth
```