### PR TITLE
ActiveSupportCacheStore

### DIFF
--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -151,7 +151,7 @@ Style/FileName:
   Exclude:
     - 'lib/flipper-active_record.rb'
     - 'lib/flipper-api.rb'
-    - 'lib/flipper-cache_store.rb'
+    - 'lib/flipper-active_support_cache_store.rb'
     - 'lib/flipper-cloud.rb'
     - 'lib/flipper-dalli.rb'
     - 'lib/flipper-mongo.rb'

--- a/docs/Adapters.md
+++ b/docs/Adapters.md
@@ -5,7 +5,7 @@ I plan on supporting the adapters in the flipper repo. Other adapters are welcom
 ## Officially Supported
 
 * [ActiveRecord adapter](https://github.com/jnunemaker/flipper/blob/master/docs/active_record) - Rails 3, 4, and 5.
-* [CacheStore adapter](https://github.com/jnunemaker/flipper/blob/master/docs/cache_store) - ActiveSupport::Cache::Store
+* [ActiveSupportCacheStore adapter](https://github.com/jnunemaker/flipper/blob/master/docs/active_support_cache_store) - ActiveSupport::Cache::Store
 * [Cassanity adapter](https://github.com/jnunemaker/flipper-cassanity)
 * [Http adapter](https://github.com/jnunemaker/flipper/blob/master/docs/http)
 * [memory adapter](https://github.com/jnunemaker/flipper/blob/master/lib/flipper/adapters/memory.rb) – great for tests

--- a/docs/Optimization.md
+++ b/docs/Optimization.md
@@ -87,13 +87,13 @@ Example using the RedisCache adapter with the Memory adapter and a TTL of 4800 s
   flipper = Flipper.new(adapter)
 ```
 
-### CacheStore
+### ActiveSupportCacheStore
 
 Rails applications can cache Flipper calls in any [ActiveSupport::Cache::Store](http://api.rubyonrails.org/classes/ActiveSupport/Cache/Store.html) implementation.
 
 Add this line to your application's Gemfile:
 
-    gem 'flipper-cache_store'
+    gem 'flipper-active_support_cache_store'
 
 And then execute:
 
@@ -101,18 +101,18 @@ And then execute:
 
 Or install it yourself with:
 
-    $ gem install flipper-cache_store
+    $ gem install flipper-active_support_cache_store
 
-Example using the CacheStore adapter with ActiveSupport's [MemoryStore](http://api.rubyonrails.org/classes/ActiveSupport/Cache/MemoryStore.html), Flipper's [Memory adapter](https://github.com/jnunemaker/flipper/blob/master/lib/flipper/adapters/memory.rb), and a TTL of 5 minutes.
+Example using the ActiveSupportCacheStore adapter with ActiveSupport's [MemoryStore](http://api.rubyonrails.org/classes/ActiveSupport/Cache/MemoryStore.html), Flipper's [Memory adapter](https://github.com/jnunemaker/flipper/blob/master/lib/flipper/adapters/memory.rb), and a TTL of 5 minutes.
 
 ```ruby
 require 'active_support/cache'
 require 'flipper/adapters/memory'
-require 'flipper/adapters/cache_store'
+require 'flipper/adapters/active_support_cache_store'
 
 memory_adapter = Flipper::Adapters::Memory.new
 cache = ActiveSupport::Cache::MemoryStore.new
-adapter = Flipper::Adapters::CacheStore.new(memory_adapter, cache, expires_in: 5.minutes)
+adapter = Flipper::Adapters::ActiveSupportCacheStore.new(memory_adapter, cache, expires_in: 5.minutes)
 flipper = Flipper.new(adapter)
 ```
 

--- a/docs/active_support_cache_store/README.md
+++ b/docs/active_support_cache_store/README.md
@@ -1,12 +1,12 @@
-# Flipper CacheStore
+# Flipper ActiveSupportCacheStore
 
-A [CacheStore](http://api.rubyonrails.org/classes/ActiveSupport/Cache/Store.html) adapter for [Flipper](https://github.com/jnunemaker/flipper).
+A [ActiveSupportCacheStore](http://api.rubyonrails.org/classes/ActiveSupport/Cache/Store.html) adapter for [Flipper](https://github.com/jnunemaker/flipper).
 
 ## Installation
 
 Add this line to your application's Gemfile:
 
-    gem 'flipper-cache_store'
+    gem 'flipper-active_support_cache_store'
 
 And then execute:
 
@@ -14,18 +14,18 @@ And then execute:
 
 Or install it yourself with:
 
-    $ gem install flipper-cache_store
+    $ gem install flipper-active_support_cache_store
 
 ## Usage
 
 ```ruby
 require 'active_support/cache'
 require 'flipper/adapters/memory'
-require 'flipper/adapters/cache_store'
+require 'flipper/adapters/active_support_cache_store'
 
 memory_adapter = Flipper::Adapters::Memory.new
 cache = ActiveSupport::Cache::MemoryStore.new
-adapter = Flipper::Adapters::CacheStore.new(memory_adapter, cache, expires_in: 5.minutes)
+adapter = Flipper::Adapters::ActiveSupportCacheStore.new(memory_adapter, cache, expires_in: 5.minutes)
 flipper = Flipper.new(adapter)
 ```
 Setting `expires_in` is optional and will set an expiration time on Flipper cache keys.  If specified, all flipper keys will use this `expires_in` over the `expires_in` passed to your ActiveSupport cache constructor.
@@ -41,11 +41,11 @@ Each key is namespaced under `flipper/v1/feature/`
 ```ruby
 require 'active_support/cache'
 require 'flipper/adapters/memory'
-require 'flipper/adapters/cache_store'
+require 'flipper/adapters/active_support_cache_store'
 
 memory_adapter = Flipper::Adapters::Memory.new
 cache = ActiveSupport::Cache::MemoryStore.new
-adapter = Flipper::Adapters::CacheStore.new(memory_adapter, cache)
+adapter = Flipper::Adapters::ActiveSupportCacheStore.new(memory_adapter, cache)
 flipper = Flipper.new(adapter)
 
 # Register a few groups.

--- a/examples/cloud/cached_in_memory.rb
+++ b/examples/cloud/cached_in_memory.rb
@@ -1,7 +1,7 @@
 require File.expand_path('../../example_setup', __FILE__)
 
 require 'flipper/cloud'
-require 'flipper/adapters/cache_store'
+require 'flipper/adapters/active_support_cache_store'
 require 'active_support/cache'
 require 'active_support/cache/memory_store'
 
@@ -13,7 +13,7 @@ Flipper.configure do |config|
     Flipper::Cloud.new(token) do |cloud|
       cloud.debug_output = STDOUT
       cloud.adapter do |adapter|
-        Flipper::Adapters::CacheStore.new(adapter,
+        Flipper::Adapters::ActiveSupportCacheStore.new(adapter,
           ActiveSupport::Cache::MemoryStore.new, {expires_in: 5.seconds})
       end
     end

--- a/flipper-active_support_cache_store.gemspec
+++ b/flipper-active_support_cache_store.gemspec
@@ -15,7 +15,7 @@ Gem::Specification.new do |gem|
 
   gem.files         = `git ls-files`.split("\n").select(&flipper_active_support_cache_store_files) + ['lib/flipper/version.rb']
   gem.test_files    = `git ls-files -- {test,spec,features}/*`.split("\n").select(&flipper_active_support_cache_store_files)
-  gem.name          = 'flipper-cache-store'
+  gem.name          = 'flipper-active_support_cache_store'
   gem.require_paths = ['lib']
   gem.version       = Flipper::VERSION
 

--- a/flipper-active_support_cache_store.gemspec
+++ b/flipper-active_support_cache_store.gemspec
@@ -1,8 +1,8 @@
 # -*- encoding: utf-8 -*-
 require File.expand_path('../lib/flipper/version', __FILE__)
 
-flipper_cache_store_files = lambda do |file|
-  file =~ /cache_store/
+flipper_active_support_cache_store_files = lambda do |file|
+  file =~ /active_support_cache_store/
 end
 
 Gem::Specification.new do |gem|
@@ -13,9 +13,9 @@ Gem::Specification.new do |gem|
   gem.license       = 'MIT'
   gem.homepage      = 'https://github.com/jnunemaker/flipper'
 
-  gem.files         = `git ls-files`.split("\n").select(&flipper_cache_store_files) + ['lib/flipper/version.rb']
-  gem.test_files    = `git ls-files -- {test,spec,features}/*`.split("\n").select(&flipper_cache_store_files)
-  gem.name          = 'flipper-cache_store'
+  gem.files         = `git ls-files`.split("\n").select(&flipper_active_support_cache_store_files) + ['lib/flipper/version.rb']
+  gem.test_files    = `git ls-files -- {test,spec,features}/*`.split("\n").select(&flipper_active_support_cache_store_files)
+  gem.name          = 'flipper-cache-store'
   gem.require_paths = ['lib']
   gem.version       = Flipper::VERSION
 

--- a/lib/flipper-active_support_cache_store.rb
+++ b/lib/flipper-active_support_cache_store.rb
@@ -1,0 +1,1 @@
+require 'flipper/adapters/active_support_cache_store'

--- a/lib/flipper-cache_store.rb
+++ b/lib/flipper-cache_store.rb
@@ -1,1 +1,0 @@
-require 'flipper/adapters/cache_store'

--- a/lib/flipper/adapters/active_support_cache_store.rb
+++ b/lib/flipper/adapters/active_support_cache_store.rb
@@ -1,9 +1,9 @@
 module Flipper
   module Adapters
     # Public: Adapter that wraps another adapter with the ability to cache
-    # adapter calls in ActiveSupport::CacheStore caches.
+    # adapter calls in ActiveSupport::ActiveSupportCacheStore caches.
     #
-    class CacheStore
+    class ActiveSupportCacheStore
       include ::Flipper::Adapter
 
       Version = 'v1'.freeze
@@ -24,7 +24,7 @@ module Flipper
       # Public
       def initialize(adapter, cache, expires_in: nil)
         @adapter = adapter
-        @name = :cache_store
+        @name = :active_support_cache_store
         @cache = cache
         @write_options = {}
         @write_options.merge!(expires_in: expires_in) if expires_in

--- a/spec/flipper/adapters/active_support_cache_store_spec.rb
+++ b/spec/flipper/adapters/active_support_cache_store_spec.rb
@@ -1,10 +1,10 @@
 require 'helper'
 require 'active_support/cache'
 require 'flipper/adapters/memory'
-require 'flipper/adapters/cache_store'
+require 'flipper/adapters/active_support_cache_store'
 require 'flipper/spec/shared_adapter_specs'
 
-RSpec.describe Flipper::Adapters::CacheStore do
+RSpec.describe Flipper::Adapters::ActiveSupportCacheStore do
   let(:memory_adapter) { Flipper::Adapters::Memory.new }
   let(:cache) { ActiveSupport::Cache::MemoryStore.new }
   let(:adapter) { described_class.new(memory_adapter, cache) }
@@ -43,8 +43,8 @@ RSpec.describe Flipper::Adapters::CacheStore do
   end
 
   describe '#name' do
-    it 'is cache_store' do
-      expect(subject.name).to be(:cache_store)
+    it 'is active_support_cache_store' do
+      expect(subject.name).to be(:active_support_cache_store)
     end
   end
 end


### PR DESCRIPTION
flipper-cache_store is owned by someone else so I can't rename the gem to that as I tried in #295. This fixes that by prefixing it with AS which makes sense any way.