### PR TITLE
All The Get Alls

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -40,3 +40,6 @@ Style/TrailingCommaInLiteral:
 
 RSpec/InstanceVariable:
   Enabled: false
+
+Style/AccessorMethodName:
+  Enabled: false

--- a/lib/flipper/adapters/active_record.rb
+++ b/lib/flipper/adapters/active_record.rb
@@ -86,6 +86,17 @@ module Flipper
         result
       end
 
+      def get_all
+        db_gates = @gate_class.joins("INNER JOIN #{@feature_class.table_name} on #{@feature_class.table_name}.key = #{@gate_class.table_name}.feature_key").all.to_a
+        grouped_db_gates = db_gates.group_by(&:feature_key)
+        result = Hash.new { |hash, key| hash[key] = default_config }
+        features = grouped_db_gates.keys.map { |key| Flipper::Feature.new(key, self) }
+        features.each do |feature|
+          result[feature.key] = result_for_feature(feature, grouped_db_gates[feature.key])
+        end
+        result
+      end
+
       # Public: Enables a gate for a given thing.
       #
       # feature - The Flipper::Feature for the gate.

--- a/lib/flipper/adapters/active_record.rb
+++ b/lib/flipper/adapters/active_record.rb
@@ -87,7 +87,11 @@ module Flipper
       end
 
       def get_all
-        db_gates = @gate_class.joins("INNER JOIN #{@feature_class.table_name} on #{@feature_class.table_name}.key = #{@gate_class.table_name}.feature_key").all.to_a
+        joins = <<-EOJ
+          INNER JOIN #{@feature_class.table_name} ON
+          #{@feature_class.table_name}.key = #{@gate_class.table_name}.feature_key"
+        EOJ
+        db_gates = @gate_class.joins(joins).all.to_a
         grouped_db_gates = db_gates.group_by(&:feature_key)
         result = Hash.new { |hash, key| hash[key] = default_config }
         features = grouped_db_gates.keys.map { |key| Flipper::Feature.new(key, self) }

--- a/lib/flipper/adapters/active_record.rb
+++ b/lib/flipper/adapters/active_record.rb
@@ -88,8 +88,8 @@ module Flipper
 
       def get_all
         joins = <<-EOJ
-          INNER JOIN #{@feature_class.table_name} ON
-          #{@feature_class.table_name}.key = #{@gate_class.table_name}.feature_key"
+          INNER JOIN #{@feature_class.table_name}
+          ON #{@feature_class.table_name}.key = #{@gate_class.table_name}.feature_key
         EOJ
         db_gates = @gate_class.joins(joins).all.to_a
         grouped_db_gates = db_gates.group_by(&:feature_key)

--- a/lib/flipper/adapters/active_support_cache_store.rb
+++ b/lib/flipper/adapters/active_support_cache_store.rb
@@ -9,7 +9,7 @@ module Flipper
       Version = 'v1'.freeze
       Namespace = "flipper/#{Version}".freeze
       FeaturesKey = "#{Namespace}/features".freeze
-      GetAllKey = "#{Namespace}/get_all"
+      GetAllKey = "#{Namespace}/get_all".freeze
 
       # Private
       def self.key_for(key)

--- a/lib/flipper/adapters/memoizable.rb
+++ b/lib/flipper/adapters/memoizable.rb
@@ -19,6 +19,11 @@ module Flipper
       # Internal: The adapter this adapter is wrapping.
       attr_reader :adapter
 
+      # Private
+      def self.key_for(key)
+        "feature/#{key}"
+      end
+
       # Public
       def initialize(adapter, cache = nil)
         super(adapter)
@@ -26,7 +31,6 @@ module Flipper
         @name = :memoizable
         @cache = cache || {}
         @memoize = false
-        @all_fetched = false
       end
 
       # Public
@@ -63,7 +67,7 @@ module Flipper
       # Public
       def get(feature)
         if memoizing?
-          cache.fetch(feature.key) { cache[feature.key] = @adapter.get(feature) }
+          cache.fetch(key_for(feature.key)) { cache[key_for(feature.key)] = @adapter.get(feature) }
         else
           @adapter.get(feature)
         end
@@ -72,18 +76,18 @@ module Flipper
       # Public
       def get_multi(features)
         if memoizing?
-          uncached_features = features.reject { |feature| cache[feature.key] }
+          uncached_features = features.reject { |feature| cache[key_for(feature.key)] }
 
           if uncached_features.any?
             response = @adapter.get_multi(uncached_features)
             response.each do |key, hash|
-              cache[key] = hash
+              cache[key_for(key)] = hash
             end
           end
 
           result = {}
           features.each do |feature|
-            result[feature.key] = cache[feature.key]
+            result[feature.key] = cache[key_for(feature.key)]
           end
           result
         else
@@ -93,20 +97,14 @@ module Flipper
 
       def get_all
         if memoizing?
-          unless @all_fetched
-            result = @adapter.get_all
-            result.each do |key, value|
-              cache[key] = value
+          cache.fetch(:flipper_get_all) do
+            response = @adapter.get_all
+            response.each do |key, hash|
+              cache[key_for(key)] = hash
             end
-            cache[FeaturesKey] = result.keys.to_set
-            @all_fetched = true
+            cache[FeaturesKey] = response.keys.to_set
+            cache[:flipper_get_all] = response
           end
-
-          result = {}
-          features.each do |key|
-            result[key] = cache[key]
-          end
-          result
         else
           @adapter.get_all
         end
@@ -130,7 +128,6 @@ module Flipper
       #
       # value - The Boolean that decides if local caching is on.
       def memoize=(value)
-        @all_fetched = false
         cache.clear
         @memoize = value
       end
@@ -142,8 +139,12 @@ module Flipper
 
       private
 
+      def key_for(key)
+        self.class.key_for(key)
+      end
+
       def expire_feature(feature)
-        cache.delete(feature.key) if memoizing?
+        cache.delete(key_for(feature.key)) if memoizing?
       end
 
       def expire_features_set

--- a/lib/flipper/adapters/memoizable.rb
+++ b/lib/flipper/adapters/memoizable.rb
@@ -119,9 +119,9 @@ module Flipper
           # result in N+1 adapter calls.
           response.default_proc = ->(memo, key) { memo[key] = default_config }
           response
-       else
-         @adapter.get_all
-       end
+        else
+          @adapter.get_all
+        end
       end
 
       # Public

--- a/lib/flipper/adapters/memoizable.rb
+++ b/lib/flipper/adapters/memoizable.rb
@@ -97,13 +97,20 @@ module Flipper
 
       def get_all
         if memoizing?
-          cache.fetch(:flipper_get_all) do
+          if cache[:all_memoized]
+            result = {}
+            cache[FeaturesKey].each do |key|
+              result[key] = cache[key_for(key)]
+            end
+            result
+          else
             response = @adapter.get_all
             response.each do |key, hash|
               cache[key_for(key)] = hash
             end
             cache[FeaturesKey] = response.keys.to_set
-            cache[:flipper_get_all] = response
+            cache[:all_memoized] = true
+            response
           end
         else
           @adapter.get_all

--- a/lib/flipper/adapters/memoizable.rb
+++ b/lib/flipper/adapters/memoizable.rb
@@ -98,28 +98,28 @@ module Flipper
 
       def get_all
         response = if memoizing?
-          if cache[GetAllKey]
-            hash = {}
-            cache[FeaturesKey].each do |key|
-              hash[key] = cache[key_for(key)]
-            end
-            hash
-          else
-            adapter_response = @adapter.get_all
-            adapter_response.each do |key, hash|
-              cache[key_for(key)] = hash
-            end
-            cache[FeaturesKey] = adapter_response.keys.to_set
-            cache[GetAllKey] = true
-            adapter_response
-          end
-        else
-          @adapter.get_all
-        end
+                     if cache[GetAllKey]
+                       hash = {}
+                       cache[FeaturesKey].each do |key|
+                         hash[key] = cache[key_for(key)]
+                       end
+                       hash
+                     else
+                       adapter_response = @adapter.get_all
+                       adapter_response.each do |key, value|
+                         cache[key_for(key)] = value
+                       end
+                       cache[FeaturesKey] = adapter_response.keys.to_set
+                       cache[GetAllKey] = true
+                       adapter_response
+                     end
+                   else
+                     @adapter.get_all
+                   end
 
         # Ensures that looking up other features that do not exist doesn't
         # result in N+1 adapter calls.
-        response.default_proc = ->(hash, key) { hash[key] = default_config }
+        response.default_proc = ->(memo, key) { memo[key] = default_config }
         response
       end
 

--- a/lib/flipper/adapters/memoizable.rb
+++ b/lib/flipper/adapters/memoizable.rb
@@ -104,7 +104,6 @@ module Flipper
             cache[FeaturesKey].each do |key|
               response[key] = cache[key_for(key)]
             end
-            response
           else
             response = @adapter.get_all
             response.each do |key, value|
@@ -112,7 +111,6 @@ module Flipper
             end
             cache[FeaturesKey] = response.keys.to_set
             cache[GetAllKey] = true
-            response
           end
 
           # Ensures that looking up other features that do not exist doesn't

--- a/lib/flipper/adapters/memory.rb
+++ b/lib/flipper/adapters/memory.rb
@@ -59,9 +59,9 @@ module Flipper
       end
 
       def get_all
-        features = set_members(FeaturesKey).map { |key|
+        features = set_members(FeaturesKey).map do |key|
           Flipper::Feature.new(key, self)
-        }
+        end
 
         result = {}
         features.each do |feature|

--- a/lib/flipper/adapters/memory.rb
+++ b/lib/flipper/adapters/memory.rb
@@ -47,20 +47,26 @@ module Flipper
 
       # Public
       def get(feature)
+        result_for_feature(feature)
+      end
+
+      def get_multi(features)
         result = {}
-
-        feature.gates.each do |gate|
-          result[gate.key] =
-            case gate.data_type
-            when :boolean, :integer
-              read key(feature, gate)
-            when :set
-              set_members key(feature, gate)
-            else
-              raise "#{gate} is not supported by this adapter yet"
-            end
+        features.each do |feature|
+          result[feature.key] = result_for_feature(feature)
         end
+        result
+      end
 
+      def get_all
+        features = set_members(FeaturesKey).map { |key|
+          Flipper::Feature.new(key, self)
+        }
+
+        result = {}
+        features.each do |feature|
+          result[feature.key] = result_for_feature(feature)
+        end
         result
       end
 
@@ -106,6 +112,24 @@ module Flipper
       # Private
       def key(feature, gate)
         "#{feature.key}/#{gate.key}"
+      end
+
+      def result_for_feature(feature)
+        result = {}
+
+        feature.gates.each do |gate|
+          result[gate.key] =
+            case gate.data_type
+            when :boolean, :integer
+              read key(feature, gate)
+            when :set
+              set_members key(feature, gate)
+            else
+              raise "#{gate} is not supported by this adapter yet"
+            end
+        end
+
+        result
       end
 
       # Private

--- a/lib/flipper/adapters/mongo.rb
+++ b/lib/flipper/adapters/mongo.rb
@@ -20,7 +20,7 @@ module Flipper
 
       # Public: The set of known features.
       def features
-        find(FeaturesKey).fetch('features') { Set.new }.to_set
+        read_feature_keys
       end
 
       # Public: Adds a feature to the set of known features.
@@ -51,12 +51,12 @@ module Flipper
       end
 
       def get_multi(features)
-        docs = find_many(features.map(&:key))
-        result = {}
-        features.each do |feature|
-          result[feature.key] = result_for_feature(feature, docs[feature.key])
-        end
-        result
+        read_many_features(features)
+      end
+
+      def get_all
+        features = read_feature_keys.map { |key| Flipper::Feature.new(key, self) }
+        read_many_features(features)
       end
 
       # Public: Enables a gate for a given thing.
@@ -103,6 +103,21 @@ module Flipper
         end
 
         true
+      end
+
+      private
+
+      def read_feature_keys
+        find(FeaturesKey).fetch('features') { Set.new }.to_set
+      end
+
+      def read_many_features(features)
+        docs = find_many(features.map(&:key))
+        result = {}
+        features.each do |feature|
+          result[feature.key] = result_for_feature(feature, docs[feature.key])
+        end
+        result
       end
 
       # Private

--- a/lib/flipper/adapters/pstore.rb
+++ b/lib/flipper/adapters/pstore.rb
@@ -94,7 +94,6 @@ module Flipper
 
       # Public
       def disable(feature, gate, thing)
-
         case gate.data_type
         when :boolean
           clear(feature)

--- a/lib/flipper/adapters/pstore.rb
+++ b/lib/flipper/adapters/pstore.rb
@@ -25,59 +25,68 @@ module Flipper
 
       # Public: The set of known features.
       def features
-        set_members FeaturesKey
+        @store.transaction do
+          read_feature_keys
+        end
       end
 
       # Public: Adds a feature to the set of known features.
       def add(feature)
-        set_add FeaturesKey, feature.key
+        @store.transaction do
+          set_add FeaturesKey, feature.key
+        end
         true
       end
 
       # Public: Removes a feature from the set of known features and clears
       # all the values for the feature.
       def remove(feature)
-        set_delete FeaturesKey, feature.key
-        clear(feature)
+        @store.transaction do
+          set_delete FeaturesKey, feature.key
+          clear_gates(feature)
+        end
         true
       end
 
       # Public: Clears all the gate values for a feature.
       def clear(feature)
-        feature.gates.each do |gate|
-          delete key(feature, gate)
+        @store.transaction do
+          clear_gates(feature)
         end
         true
       end
 
       # Public
       def get(feature)
-        result = {}
-
-        feature.gates.each do |gate|
-          result[gate.key] =
-            case gate.data_type
-            when :boolean, :integer
-              read key(feature, gate)
-            when :set
-              set_members key(feature, gate)
-            else
-              raise "#{gate} is not supported by this adapter yet"
-            end
+        @store.transaction do
+          result_for_feature(feature)
         end
+      end
 
-        result
+      def get_multi(features)
+        @store.transaction do
+          read_many_features(features)
+        end
+      end
+
+      def get_all
+        @store.transaction do
+          features = read_feature_keys.map { |key| Flipper::Feature.new(key, self) }
+          read_many_features(features)
+        end
       end
 
       # Public
       def enable(feature, gate, thing)
-        case gate.data_type
-        when :boolean, :integer
-          write key(feature, gate), thing.value.to_s
-        when :set
-          set_add key(feature, gate), thing.value.to_s
-        else
-          raise "#{gate} is not supported by this adapter yet"
+        @store.transaction do
+          case gate.data_type
+          when :boolean, :integer
+            write key(feature, gate), thing.value.to_s
+          when :set
+            set_add key(feature, gate), thing.value.to_s
+          else
+            raise "#{gate} is not supported by this adapter yet"
+          end
         end
 
         true
@@ -85,13 +94,18 @@ module Flipper
 
       # Public
       def disable(feature, gate, thing)
+
         case gate.data_type
         when :boolean
           clear(feature)
         when :integer
-          write key(feature, gate), thing.value.to_s
+          @store.transaction do
+            write key(feature, gate), thing.value.to_s
+          end
         when :set
-          set_delete key(feature, gate), thing.value.to_s
+          @store.transaction do
+            set_delete key(feature, gate), thing.value.to_s
+          end
         else
           raise "#{gate} is not supported by this adapter yet"
         end
@@ -111,6 +125,42 @@ module Flipper
 
       private
 
+      def clear_gates(feature)
+        feature.gates.each do |gate|
+          delete key(feature, gate)
+        end
+      end
+
+      def read_feature_keys
+        set_members FeaturesKey
+      end
+
+      def read_many_features(features)
+        result = {}
+        features.each do |feature|
+          result[feature.key] = result_for_feature(feature)
+        end
+        result
+      end
+
+      def result_for_feature(feature)
+        result = {}
+
+        feature.gates.each do |gate|
+          result[gate.key] =
+            case gate.data_type
+            when :boolean, :integer
+              read key(feature, gate)
+            when :set
+              set_members key(feature, gate)
+            else
+              raise "#{gate} is not supported by this adapter yet"
+            end
+        end
+
+        result
+      end
+
       # Private
       def key(feature, gate)
         "#{feature.key}/#{gate.key}"
@@ -118,23 +168,17 @@ module Flipper
 
       # Private
       def read(key)
-        @store.transaction do
-          @store[key.to_s]
-        end
+        @store[key.to_s]
       end
 
       # Private
       def write(key, value)
-        @store.transaction do
-          @store[key.to_s] = value.to_s
-        end
+        @store[key.to_s] = value.to_s
       end
 
       # Private
       def delete(key)
-        @store.transaction do
-          @store.delete(key.to_s)
-        end
+        @store.delete(key.to_s)
       end
 
       # Private
@@ -154,14 +198,13 @@ module Flipper
       # Private
       def set_members(key)
         key = key.to_s
-        @store.transaction do
-          @store[key] ||= Set.new
 
-          if block_given?
-            yield @store[key]
-          else
-            @store[key]
-          end
+        @store[key] ||= Set.new
+
+        if block_given?
+          yield @store[key]
+        else
+          @store[key]
         end
       end
     end

--- a/lib/flipper/adapters/read_only.rb
+++ b/lib/flipper/adapters/read_only.rb
@@ -27,6 +27,14 @@ module Flipper
         @adapter.get(feature)
       end
 
+      def get_multi(features)
+        @adapter.get_multi(features)
+      end
+
+      def get_all
+        @adapter.get_all
+      end
+
       def add(_feature)
         raise WriteAttempted
       end

--- a/lib/flipper/adapters/redis_cache.rb
+++ b/lib/flipper/adapters/redis_cache.rb
@@ -10,6 +10,7 @@ module Flipper
       Version = 'v1'.freeze
       Namespace = "flipper/#{Version}".freeze
       FeaturesKey = "#{Namespace}/features".freeze
+      GetAllKey = "#{Namespace}/get_all".freeze
 
       # Private
       def self.key_for(key)
@@ -32,9 +33,7 @@ module Flipper
 
       # Public
       def features
-        fetch(FeaturesKey) do
-          @adapter.features
-        end
+        read_feature_keys
       end
 
       # Public
@@ -67,20 +66,22 @@ module Flipper
       end
 
       def get_multi(features)
-        keys = features.map(&:key)
-        result = Hash[keys.zip(multi_cache_get(keys))]
-        uncached_features = features.reject do |feature|
-          result[feature.key]
-        end
+        read_many_features(features)
+      end
 
-        if uncached_features.any?
-          response = @adapter.get_multi(uncached_features)
+      def get_all
+        if @cache.setnx(GetAllKey, Time.now.to_i)
+          @cache.expire(GetAllKey, @ttl)
+          response = @adapter.get_all
           response.each do |key, value|
-            set_with_ttl(key_for(key), value)
-            result[key] = value
+            set_with_ttl key_for(key), value
           end
+          set_with_ttl FeaturesKey, response.keys.to_set
+          response
+        else
+          features = read_feature_keys.map { |key| Flipper::Feature.new(key, self) }
+          read_many_features(features)
         end
-        result
       end
 
       # Public
@@ -103,13 +104,37 @@ module Flipper
         self.class.key_for(key)
       end
 
+      def read_feature_keys
+        fetch(FeaturesKey) { @adapter.features }
+      end
+
+      def read_many_features(features)
+        keys = features.map(&:key)
+        cache_result = Hash[keys.zip(multi_cache_get(keys))]
+        uncached_features = features.reject { |feature| cache_result[feature.key] }
+
+        if uncached_features.any?
+          response = @adapter.get_multi(uncached_features)
+          response.each do |key, value|
+            set_with_ttl(key_for(key), value)
+            cache_result[key] = value
+          end
+        end
+
+        result = {}
+        features.each do |feature|
+          result[feature.key] = cache_result[feature.key]
+        end
+        result
+      end
+
       def fetch(key)
         cached = @cache.get(key)
         if cached
           Marshal.load(cached)
         else
           to_cache = yield
-          set_with_ttl(key, to_cache)
+          set_with_ttl(key_for(key), to_cache)
           to_cache
         end
       end

--- a/lib/flipper/adapters/sequel.rb
+++ b/lib/flipper/adapters/sequel.rb
@@ -96,6 +96,21 @@ module Flipper
         result
       end
 
+      def get_all
+        db_gates = @gate_class.fetch(<<-SQL).to_a
+          SELECT g.*
+          FROM #{@gate_class.table_name} g
+            INNER JOIN #{@feature_class.table_name} f ON f.key = g.feature_key
+        SQL
+        grouped_db_gates = db_gates.group_by(&:feature_key)
+        result = Hash.new { |hash, key| hash[key] = default_config }
+        features = grouped_db_gates.keys.map { |key| Flipper::Feature.new(key, self) }
+        features.each do |feature|
+          result[feature.key] = result_for_feature(feature, grouped_db_gates[feature.key])
+        end
+        result
+      end
+
       # Public: Enables a gate for a given thing.
       #
       # feature - The Flipper::Feature for the gate.

--- a/lib/flipper/adapters/sequel.rb
+++ b/lib/flipper/adapters/sequel.rb
@@ -8,7 +8,8 @@ module Flipper
       include ::Flipper::Adapter
 
       begin
-        old, ::Sequel::Model.require_valid_table = ::Sequel::Model.require_valid_table, false
+        old = ::Sequel::Model.require_valid_table
+        ::Sequel::Model.require_valid_table = false
 
         # Private: Do not use outside of this adapter.
         class Feature < ::Sequel::Model(:flipper_features)

--- a/lib/flipper/adapters/sequel.rb
+++ b/lib/flipper/adapters/sequel.rb
@@ -7,18 +7,24 @@ module Flipper
     class Sequel
       include ::Flipper::Adapter
 
-      # Private: Do not use outside of this adapter.
-      class Feature < ::Sequel::Model(:flipper_features)
-        unrestrict_primary_key
+      begin
+        old, ::Sequel::Model.require_valid_table = ::Sequel::Model.require_valid_table, false
 
-        plugin :timestamps, update_on_create: true
-      end
+        # Private: Do not use outside of this adapter.
+        class Feature < ::Sequel::Model(:flipper_features)
+          unrestrict_primary_key
 
-      # Private: Do not use outside of this adapter.
-      class Gate < ::Sequel::Model(:flipper_gates)
-        unrestrict_primary_key
+          plugin :timestamps, update_on_create: true
+        end
 
-        plugin :timestamps, update_on_create: true
+        # Private: Do not use outside of this adapter.
+        class Gate < ::Sequel::Model(:flipper_gates)
+          unrestrict_primary_key
+
+          plugin :timestamps, update_on_create: true
+        end
+      ensure
+        ::Sequel::Model.require_valid_table = old
       end
 
       # Public: The name of the adapter.

--- a/spec/flipper/adapters/active_support_cache_store_spec.rb
+++ b/spec/flipper/adapters/active_support_cache_store_spec.rb
@@ -1,13 +1,16 @@
 require 'helper'
 require 'active_support/cache'
 require 'flipper/adapters/memory'
+require 'flipper/adapters/operation_logger'
 require 'flipper/adapters/active_support_cache_store'
 require 'flipper/spec/shared_adapter_specs'
 
 RSpec.describe Flipper::Adapters::ActiveSupportCacheStore do
-  let(:memory_adapter) { Flipper::Adapters::Memory.new }
+  let(:memory_adapter) do
+    Flipper::Adapters::OperationLogger.new(Flipper::Adapters::Memory.new)
+  end
   let(:cache) { ActiveSupport::Cache::MemoryStore.new }
-  let(:adapter) { described_class.new(memory_adapter, cache) }
+  let(:adapter) { described_class.new(memory_adapter, cache, expires_in: 10.seconds) }
   let(:flipper) { Flipper.new(adapter) }
 
   subject { adapter }
@@ -31,6 +34,8 @@ RSpec.describe Flipper::Adapters::ActiveSupportCacheStore do
       stats.enable
       search.enable
 
+      memory_adapter.reset
+
       adapter.get(stats)
       expect(cache.read(described_class.key_for(search))).to be(nil)
       expect(cache.read(described_class.key_for(other))).to be(nil)
@@ -39,6 +44,37 @@ RSpec.describe Flipper::Adapters::ActiveSupportCacheStore do
 
       expect(cache.read(described_class.key_for(search))[:boolean]).to eq('true')
       expect(cache.read(described_class.key_for(other))[:boolean]).to be(nil)
+
+      adapter.get_multi([stats, search, other])
+      adapter.get_multi([stats, search, other])
+      expect(memory_adapter.count(:get_multi)).to eq(1)
+    end
+  end
+
+  describe '#get_all' do
+    let(:stats) { flipper[:stats] }
+    let(:search) { flipper[:search] }
+
+    before do
+      stats.enable
+      search.add
+    end
+
+    it 'warms all features' do
+      adapter.get_all
+      expect(cache.read(described_class.key_for(stats))[:boolean]).to eq('true')
+      expect(cache.read(described_class.key_for(search))[:boolean]).to be(nil)
+      expect(cache.read(described_class::GetAllKey)).to be_within(2).of(Time.now.to_i)
+    end
+
+    it 'returns same result when already cached' do
+      expect(adapter.get_all).to eq(adapter.get_all)
+    end
+
+    it 'only invokes one call to wrapped adapter' do
+      memory_adapter.reset
+      5.times { adapter.get_all }
+      expect(memory_adapter.count(:get_all)).to eq(1)
     end
   end
 

--- a/spec/flipper/adapters/active_support_cache_store_spec.rb
+++ b/spec/flipper/adapters/active_support_cache_store_spec.rb
@@ -1,5 +1,6 @@
 require 'helper'
 require 'active_support/cache'
+require 'active_support/cache/dalli_store'
 require 'flipper/adapters/memory'
 require 'flipper/adapters/operation_logger'
 require 'flipper/adapters/active_support_cache_store'
@@ -9,11 +10,15 @@ RSpec.describe Flipper::Adapters::ActiveSupportCacheStore do
   let(:memory_adapter) do
     Flipper::Adapters::OperationLogger.new(Flipper::Adapters::Memory.new)
   end
-  let(:cache) { ActiveSupport::Cache::MemoryStore.new }
+  let(:cache) { ActiveSupport::Cache::DalliStore.new }
   let(:adapter) { described_class.new(memory_adapter, cache, expires_in: 10.seconds) }
   let(:flipper) { Flipper.new(adapter) }
 
   subject { adapter }
+
+  before do
+    cache.clear
+  end
 
   it_should_behave_like 'a flipper adapter'
 

--- a/spec/flipper/adapters/dalli_spec.rb
+++ b/spec/flipper/adapters/dalli_spec.rb
@@ -1,10 +1,13 @@
 require 'helper'
 require 'flipper/adapters/memory'
+require 'flipper/adapters/operation_logger'
 require 'flipper/adapters/dalli'
 require 'flipper/spec/shared_adapter_specs'
 
 RSpec.describe Flipper::Adapters::Dalli do
-  let(:memory_adapter) { Flipper::Adapters::Memory.new }
+  let(:memory_adapter) do
+    Flipper::Adapters::OperationLogger.new(Flipper::Adapters::Memory.new)
+  end
   let(:cache)   { Dalli::Client.new(ENV['MEMCACHED_URL'] || '127.0.0.1:11211') }
   let(:adapter) { described_class.new(memory_adapter, cache) }
   let(:flipper) { Flipper.new(adapter) }
@@ -34,6 +37,8 @@ RSpec.describe Flipper::Adapters::Dalli do
       stats.enable
       search.enable
 
+      memory_adapter.reset
+
       adapter.get(stats)
       expect(cache.get(described_class.key_for(search))).to be(nil)
       expect(cache.get(described_class.key_for(other))).to be(nil)
@@ -42,6 +47,37 @@ RSpec.describe Flipper::Adapters::Dalli do
 
       expect(cache.get(described_class.key_for(search))[:boolean]).to eq('true')
       expect(cache.get(described_class.key_for(other))[:boolean]).to be(nil)
+
+      adapter.get_multi([stats, search, other])
+      adapter.get_multi([stats, search, other])
+      expect(memory_adapter.count(:get_multi)).to eq(1)
+    end
+  end
+
+  describe '#get_all' do
+    let(:stats) { flipper[:stats] }
+    let(:search) { flipper[:search] }
+
+    before do
+      stats.enable
+      search.add
+    end
+
+    it 'warms all features' do
+      adapter.get_all
+      expect(cache.get(described_class.key_for(stats))[:boolean]).to eq('true')
+      expect(cache.get(described_class.key_for(search))[:boolean]).to be(nil)
+      expect(cache.get(described_class::GetAllKey)).to be_within(2).of(Time.now.to_i)
+    end
+
+    it 'returns same result when already cached' do
+      expect(adapter.get_all).to eq(adapter.get_all)
+    end
+
+    it 'only invokes one call to wrapped adapter' do
+      memory_adapter.reset
+      5.times { adapter.get_all }
+      expect(memory_adapter.count(:get_all)).to eq(1)
     end
   end
 

--- a/spec/flipper/adapters/memoizable_spec.rb
+++ b/spec/flipper/adapters/memoizable_spec.rb
@@ -147,6 +147,14 @@ RSpec.describe Flipper::Adapters::Memoizable do
         instance.get_all
         expect(adapter.count(:get_all)).to be(1)
       end
+
+      it 'returns default_config for unknown feature keys' do
+        first = subject.get_all
+        expect(first['doesntexist']).to eq(subject.default_config)
+
+        second = subject.get_all
+        expect(second['doesntexist']).to eq(subject.default_config)
+      end
     end
 
     context "with memoization disabled" do
@@ -174,6 +182,14 @@ RSpec.describe Flipper::Adapters::Memoizable do
 
         instance.get_all
         expect(adapter.count(:get_all)).to be(2)
+      end
+
+      it 'returns default_config for unknown feature keys' do
+        first = subject.get_all
+        expect(first['doesntexist']).to eq(subject.default_config)
+
+        second = subject.get_all
+        expect(second['doesntexist']).to eq(subject.default_config)
       end
     end
   end

--- a/spec/flipper/adapters/memoizable_spec.rb
+++ b/spec/flipper/adapters/memoizable_spec.rb
@@ -136,7 +136,6 @@ RSpec.describe Flipper::Adapters::Memoizable do
 
       it 'only calls get_all once for memoized adapter' do
         adapter = Flipper::Adapters::OperationLogger.new(Flipper::Adapters::Memory.new)
-        flipper = Flipper.new(adapter)
         cache = {}
         instance = described_class.new(adapter, cache)
         instance.memoize = true
@@ -172,7 +171,6 @@ RSpec.describe Flipper::Adapters::Memoizable do
 
       it 'calls get_all every time for memoized adapter' do
         adapter = Flipper::Adapters::OperationLogger.new(Flipper::Adapters::Memory.new)
-        flipper = Flipper.new(adapter)
         cache = {}
         instance = described_class.new(adapter, cache)
         instance.memoize = false

--- a/spec/flipper/adapters/memoizable_spec.rb
+++ b/spec/flipper/adapters/memoizable_spec.rb
@@ -66,7 +66,7 @@ RSpec.describe Flipper::Adapters::Memoizable do
       it 'memoizes feature' do
         feature = flipper[:stats]
         result = subject.get(feature)
-        expect(cache[feature.key]).to be(result)
+        expect(cache[described_class.key_for(feature.key)]).to be(result)
       end
     end
 
@@ -95,8 +95,8 @@ RSpec.describe Flipper::Adapters::Memoizable do
         features = names.map { |name| flipper[name] }
         results = subject.get_multi(features)
         features.each do |feature|
-          expect(cache[feature.key]).not_to be(nil)
-          expect(cache[feature.key]).to be(results[feature.key])
+          expect(cache[described_class.key_for(feature.key)]).not_to be(nil)
+          expect(cache[described_class.key_for(feature.key)]).to be(results[feature.key])
         end
       end
     end
@@ -127,8 +127,8 @@ RSpec.describe Flipper::Adapters::Memoizable do
         features = names.map { |name| flipper[name].tap(&:enable) }
         results = subject.get_all
         features.each do |feature|
-          expect(cache[feature.key]).not_to be(nil)
-          expect(cache[feature.key]).to be(results[feature.key])
+          expect(cache[described_class.key_for(feature.key)]).not_to be(nil)
+          expect(cache[described_class.key_for(feature.key)]).to be(results[feature.key])
         end
         expect(cache[subject.class::FeaturesKey]).to eq(names.map(&:to_s).to_set)
       end
@@ -158,9 +158,9 @@ RSpec.describe Flipper::Adapters::Memoizable do
       it 'unmemoizes feature' do
         feature = flipper[:stats]
         gate = feature.gate(:boolean)
-        cache[feature.key] = { some: 'thing' }
+        cache[described_class.key_for(feature.key)] = { some: 'thing' }
         subject.enable(feature, gate, flipper.bool)
-        expect(cache[feature.key]).to be_nil
+        expect(cache[described_class.key_for(feature.key)]).to be_nil
       end
     end
 
@@ -188,9 +188,9 @@ RSpec.describe Flipper::Adapters::Memoizable do
       it 'unmemoizes feature' do
         feature = flipper[:stats]
         gate = feature.gate(:boolean)
-        cache[feature.key] = { some: 'thing' }
+        cache[described_class.key_for(feature.key)] = { some: 'thing' }
         subject.disable(feature, gate, flipper.bool)
-        expect(cache[feature.key]).to be_nil
+        expect(cache[described_class.key_for(feature.key)]).to be_nil
       end
     end
 
@@ -272,9 +272,9 @@ RSpec.describe Flipper::Adapters::Memoizable do
 
       it 'unmemoizes the feature' do
         feature = flipper[:stats]
-        cache[feature.key] = { some: 'thing' }
+        cache[described_class.key_for(feature.key)] = { some: 'thing' }
         subject.remove(feature)
-        expect(cache[feature.key]).to be_nil
+        expect(cache[described_class.key_for(feature.key)]).to be_nil
       end
     end
 
@@ -297,9 +297,9 @@ RSpec.describe Flipper::Adapters::Memoizable do
 
       it 'unmemoizes feature' do
         feature = flipper[:stats]
-        cache[feature.key] = { some: 'thing' }
+        cache[described_class.key_for(feature.key)] = { some: 'thing' }
         subject.clear(feature)
-        expect(cache[feature.key]).to be_nil
+        expect(cache[described_class.key_for(feature.key)]).to be_nil
       end
     end
 

--- a/spec/flipper/adapters/memoizable_spec.rb
+++ b/spec/flipper/adapters/memoizable_spec.rb
@@ -182,12 +182,12 @@ RSpec.describe Flipper::Adapters::Memoizable do
         expect(adapter.count(:get_all)).to be(2)
       end
 
-      it 'returns default_config for unknown feature keys' do
+      it 'returns nil for unknown feature keys' do
         first = subject.get_all
-        expect(first['doesntexist']).to eq(subject.default_config)
+        expect(first['doesntexist']).to be(nil)
 
         second = subject.get_all
-        expect(second['doesntexist']).to eq(subject.default_config)
+        expect(second['doesntexist']).to be(nil)
       end
     end
   end

--- a/spec/flipper/adapters/redis_cache_spec.rb
+++ b/spec/flipper/adapters/redis_cache_spec.rb
@@ -1,20 +1,20 @@
 require 'helper'
 require 'flipper/adapters/memory'
+require 'flipper/adapters/operation_logger'
 require 'flipper/adapters/redis_cache'
 require 'flipper/spec/shared_adapter_specs'
 
 RSpec.describe Flipper::Adapters::RedisCache do
   let(:client) do
     options = {}
-
     options[:url] = ENV['REDIS_URL'] if ENV['REDIS_URL']
-
     Redis.new(options)
   end
 
-  let(:memory_adapter) { Flipper::Adapters::Memory.new }
-  let(:cache)   { Redis.new(url: ENV.fetch('REDIS_URL', 'redis://localhost:6379')) }
-  let(:adapter) { described_class.new(memory_adapter, cache) }
+  let(:memory_adapter) do
+    Flipper::Adapters::OperationLogger.new(Flipper::Adapters::Memory.new)
+  end
+  let(:adapter) { described_class.new(memory_adapter, client) }
   let(:flipper) { Flipper.new(adapter) }
 
   subject { adapter }
@@ -30,7 +30,7 @@ RSpec.describe Flipper::Adapters::RedisCache do
       feature = flipper[:stats]
       adapter.get(feature)
       adapter.remove(feature)
-      expect(cache.get(described_class.key_for(feature))).to be(nil)
+      expect(client.get(described_class.key_for(feature))).to be(nil)
     end
   end
 
@@ -42,17 +42,50 @@ RSpec.describe Flipper::Adapters::RedisCache do
       stats.enable
       search.enable
 
+      memory_adapter.reset
+
       adapter.get(stats)
-      expect(cache.get(described_class.key_for(search))).to be(nil)
-      expect(cache.get(described_class.key_for(other))).to be(nil)
+      expect(client.get(described_class.key_for(search))).to be(nil)
+      expect(client.get(described_class.key_for(other))).to be(nil)
 
       adapter.get_multi([stats, search, other])
 
       search_cache_value, other_cache_value = [search, other].map do |f|
-        Marshal.load(cache.get(described_class.key_for(f)))
+        Marshal.load(client.get(described_class.key_for(f)))
       end
       expect(search_cache_value[:boolean]).to eq('true')
       expect(other_cache_value[:boolean]).to be(nil)
+
+      adapter.get_multi([stats, search, other])
+      adapter.get_multi([stats, search, other])
+      expect(memory_adapter.count(:get_multi)).to eq(1)
+    end
+  end
+
+  describe '#get_all' do
+    let(:stats) { flipper[:stats] }
+    let(:search) { flipper[:search] }
+
+    before do
+      stats.enable
+      search.add
+    end
+
+    it 'warms all features' do
+      adapter.get_all
+      expect(Marshal.load(client.get(described_class.key_for(stats.key)))[:boolean]).to eq('true')
+      expect(Marshal.load(client.get(described_class.key_for(search.key)))[:boolean]).to be(nil)
+      expect(client.get(described_class::GetAllKey).to_i).to be_within(2).of(Time.now.to_i)
+    end
+
+    it 'returns same result when already cached' do
+      expect(adapter.get_all).to eq(adapter.get_all)
+    end
+
+    it 'only invokes one call to wrapped adapter' do
+      memory_adapter.reset
+      5.times { adapter.get_all }
+      expect(memory_adapter.count(:get_all)).to eq(1)
     end
   end
 

--- a/spec/flipper/middleware/memoizer_spec.rb
+++ b/spec/flipper/middleware/memoizer_spec.rb
@@ -1,7 +1,7 @@
 require 'helper'
 require 'rack/test'
 require 'active_support/cache'
-require 'active_support/cache/memory_store'
+require 'active_support/cache/dalli_store'
 require 'flipper/middleware/memoizer'
 require 'flipper/adapters/active_support_cache_store'
 require 'flipper/adapters/operation_logger'
@@ -344,7 +344,8 @@ RSpec.describe Flipper::Middleware::Memoizer do
     it 'eagerly caches known features for duration of request' do
       memory = Flipper::Adapters::Memory.new
       logged_memory = Flipper::Adapters::OperationLogger.new(memory)
-      cache = ActiveSupport::Cache::MemoryStore.new
+      cache = ActiveSupport::Cache::DalliStore.new
+      cache.clear
       cached = Flipper::Adapters::ActiveSupportCacheStore.new(logged_memory, cache, expires_in: 10)
       logged_cached = Flipper::Adapters::OperationLogger.new(cached)
       memo = {}

--- a/spec/flipper/middleware/memoizer_spec.rb
+++ b/spec/flipper/middleware/memoizer_spec.rb
@@ -141,6 +141,7 @@ RSpec.describe Flipper::Middleware::Memoizer do
       middleware = described_class.new(app, preload_all: true)
       middleware.call(env)
 
+      expect(adapter.operations.size).to be(1)
       expect(adapter.count(:get_all)).to be(1)
     end
 


### PR DESCRIPTION
In testing `preload_all` with Flipper::Cloud, I found that the memoizing and caching adapters weren't working correctly with `get_all` (which `preload_all` uses). Several things were subtly not right causing extra net/http calls. I added several specs that verify the number of network calls and tested externally with a few apps I control. This also adds get_all to all the adapters flipper supports out of the box. This ensures that when possible `preload_all` and `get_all` do the fewest network calls. 

There is some funny business with caching and get_all. The trick with get_all and caching is you don't know the features so you can't do a get_multi for all features. This left two obvious options:

1. wrap the entire get_all call with its own cache fetch block.
2. add an extra network call to avoid calling get_all more than necessary when using a caching adapter.

Option 1 meant get_all would be 1 network call which was dope. The downside was it would not share the primed caches from `get` and `get_multi`. Additionally, it would mean that all features would need to fit in a single cache value (usually 1MB with memcached). Probably fine, but I didn't want to make assumptions.

Option 2 was to do an unless exists `get_all` key. If the key was present, then we are moderately sure that both the set of feature keys and each feature is cached, so the cache adapters do at least 2 network calls (get the set of feature keys and then get_multi all the individual feature cache values). The upside is this shares the per feature cache values with get and get_multi. Another upside is that because the cache is per feature, having a lot of features won't overflow a single value like option 1. The downside of this is a minimum of 3 network calls. I guess I'm assuming that cache calls are super fast, so 3 small ones that share between many adapter methods is better than potentially 1 big one that doesn't share.