### PR TITLE
Typo in cut and paste instructions for rails

### DIFF
--- a/docs/ui/README.md
+++ b/docs/ui/README.md
@@ -33,7 +33,7 @@ Given that you've already initialized `Flipper` as per the [flipper](https://git
 ```ruby
 # config/routes.rb
 YourRailsApp::Application.routes.draw do
-  mount Flipper::UI.app(flipper) => '/flipper'
+  mount Flipper::UI.app(Flipper) => '/flipper'
 end
 ```
 


### PR DESCRIPTION
I'm evaluating flipper (and it's ui) and I've found out this typo while experimenting