### PR TITLE
Autofocus on new feature text input

### DIFF
--- a/lib/flipper/ui/views/add_feature.erb
+++ b/lib/flipper/ui/views/add_feature.erb
@@ -11,7 +11,7 @@
   <div class="panel-body">
     <form action="<%= script_name %>/features" method="post">
       <%== csrf_input_tag %>
-      <input type="text" name="value" size="30" placeholder="ie: search, new_pricing, etc.">
+      <input type="text" name="value" size="30" placeholder="ie: search, new_pricing, etc." autofocus>
       <input type="submit" value="Add Feature" class="btn">
     </form>
     <p class="help">


### PR DESCRIPTION
Fix something that has been grinding my gears, not automatically focusing on the only text input on the page when clicking on _Add Feature_. Now it does:
![flipper_autofocus](https://user-images.githubusercontent.com/385232/32862600-851940ea-ca50-11e7-9d31-92a35913788d.gif)
