### PR TITLE
Implement UI::Configuration so users can customize Flipper UI text

### DIFF
--- a/lib/flipper/ui.rb
+++ b/lib/flipper/ui.rb
@@ -12,6 +12,7 @@ require 'flipper'
 require 'flipper/middleware/setup_env'
 require 'flipper/middleware/memoizer'
 require 'flipper/ui/middleware'
+require 'flipper/ui/configuration'
 
 module Flipper
   module UI
@@ -25,6 +26,9 @@ module Flipper
       # set to false, users of the UI cannot create features. All feature
       # creation will need to be done through the conigured flipper instance.
       attr_accessor :feature_creation_enabled
+
+      # Public: Set attributes on this instance to customize UI text
+      attr_reader :configuration
     end
 
     self.feature_creation_enabled = true
@@ -48,6 +52,15 @@ module Flipper
       klass = self
       builder.define_singleton_method(:inspect) { klass.inspect } # pretty rake routes output
       builder
+    end
+
+    # Public: yields configuration instance for customizing UI text
+    def self.configure
+      yield(configuration)
+    end
+
+    def self.configuration
+      @configuration ||= ::Flipper::UI::Configuration.new
     end
   end
 end

--- a/lib/flipper/ui/configuration.rb
+++ b/lib/flipper/ui/configuration.rb
@@ -1,0 +1,21 @@
+require 'flipper/ui/configuration/option'
+
+module Flipper
+  module UI
+    class Configuration
+      attr_reader :actors,
+                  :delete,
+                  :groups,
+                  :percentage_of_actors,
+                  :percentage_of_time
+
+      def initialize
+        @actors = Option.new("Actors", "Enable actors using the form above.")
+        @groups = Option.new("Groups", "Enable groups using the form above.")
+        @percentage_of_actors = Option.new("Percentage of Actors", "Percentage of actors functions independently of percentage of time. If you enable 50% of Actors and 25% of Time then the feature will always be enabled for 50% of users and occasionally enabled 25% of the time for everyone.")
+        @percentage_of_time = Option.new("Percentage of Time", "Percentage of actors functions independently of percentage of time. If you enable 50% of Actors and 25% of Time then the feature will always be enabled for 50% of users and occasionally enabled 25% of the time for everyone.")
+        @delete = Option.new("Danger Zone", "Deleting a feature removes it from the list of features and disables it for everyone.")
+      end
+    end
+  end
+end

--- a/lib/flipper/ui/configuration/option.rb
+++ b/lib/flipper/ui/configuration/option.rb
@@ -1,0 +1,12 @@
+module Flipper
+  module UI
+    class Option
+      attr_accessor :title, :description
+
+      def initialize(title, description)
+        @title = title
+        @description = description
+      end
+    end
+  end
+end

--- a/lib/flipper/ui/views/feature.erb
+++ b/lib/flipper/ui/views/feature.erb
@@ -37,7 +37,7 @@
     <div class="column one-half">
       <div class="panel panel-default">
         <div class="panel-heading">
-          <h3 class="panel-title">Percentage of Actors</h3>
+          <h3 class="panel-title"><%= Flipper::UI.configuration.percentage_of_actors.title %></h3>
         </div>
         <div class="panel-body">
           <form action="<%= script_name %>/features/<%= @feature.key %>/percentage_of_actors" method="post">
@@ -56,14 +56,14 @@
             <input type="text" name="value" <% if @feature.percentage_of_actors_value > 0 %>value="<%= @feature.percentage_of_actors_value %>"<% end %> placeholder="custom (ie: 26, 32, etc.)" class="input-mini">
             <input type="submit" name="action" value="Enable" class="btn btn-sm">
           </form>
-          <p class="help"><small>Percentage of actors functions independently of percentage of time. If you enable 50% of Actors and 25% of Time then the feature will always be enabled for 50% of users and occasionally enabled 25% of the time for everyone.</small></p>
+          <p class="help"><small><%= Flipper::UI.configuration.percentage_of_actors.description %></small></p>
         </div>
       </div>
     </div>
     <div class="column one-half">
       <div class="panel panel-default">
         <div class="panel-heading">
-          <h3 class="panel-title">Percentage of Time</h3>
+          <h3 class="panel-title"><%= Flipper::UI.configuration.percentage_of_time.title %></h3>
         </div>
         <div class="panel-body">
           <form action="<%= script_name %>/features/<%= @feature.key %>/percentage_of_time" method="post">
@@ -83,7 +83,7 @@
             <input type="submit" name="action" value="Enable" class="btn btn-sm">
           </form>
 
-          <p class="help"><small>Percentage of time functions independently of percentage of actors. If you enable 50% of Actors and 25% of Time then the feature will always be enabled for 50% of users and occasionally enabled 25% of the time for everyone.</small></p>
+          <p class="help"><small><%= Flipper::UI.configuration.actors.description %></small></p>
         </div>
       </div>
     </div>
@@ -110,7 +110,7 @@
               <input type="submit" value="Add Group" class="btn btn-sm">
             </form>
           <% end %>
-          <h3 class="panel-title">Groups</h3>
+          <h3 class="panel-title"><%= Flipper::UI.configuration.groups.title %></h3>
         </div>
         <% if @feature.groups_value.empty? %>
           <div class="blankslate">
@@ -118,7 +118,7 @@
             <span class="mega-octicon octicon-squirrel"></span>
             <span class="mega-octicon octicon-zap"></span>
             <h3>No Enabled Groups</h3>
-            <p>Enable groups using the form above.</p>
+            <p><%= Flipper::UI.configuration.groups.description %></p>
           </div>
         <% else %>
           <ul class="list-group">
@@ -154,7 +154,7 @@
             <input type="text" name="value" placeholder="ie: User:6" class="input-mini">
             <input type="submit" value="Add Actor" class="btn btn-sm">
           </form>
-          <h3 class="panel-title">Actors</h3>
+          <h3 class="panel-title"><%= Flipper::UI.configuration.actors.title %></h3>
         </div>
         <% if @feature.actors_value.empty? %>
           <div class="blankslate">
@@ -162,7 +162,7 @@
             <span class="mega-octicon octicon-squirrel"></span>
             <span class="mega-octicon octicon-zap"></span>
             <h3>No Enabled Actors</h3>
-            <p>Enable actors using the form above.</p>
+            <p><%= Flipper::UI.configuration.actors.description %></p>
           </div>
         <% else %>
           <ul class="list-group">
@@ -194,11 +194,11 @@
 
 <div class="panel panel-danger">
   <div class="panel-heading">
-    <h3 class="panel-title">Danger Zone</h3>
+    <h3 class="panel-title"><%= Flipper::UI.configuration.delete.title %></h3>
   </div>
   <div class="panel-body">
     <p>
-      Deleting a feature removes it from the list of features and disables it for everyone.
+      <%= Flipper::UI.configuration.delete.description %>
     </p>
 
     <form action="<%= script_name %>/features/<%= @feature.key %>" method="post" onsubmit="return confirm('Are you sure you want to remove <%= @feature.key %> from the list of features and disable it for everyone?')">

--- a/spec/flipper/ui/configuration_spec.rb
+++ b/spec/flipper/ui/configuration_spec.rb
@@ -1,0 +1,45 @@
+require 'helper'
+
+RSpec.describe Flipper::UI::Configuration do
+  let(:configuration) { described_class.new }
+
+  describe "#actors" do
+    it "has default text" do
+      expect(configuration.actors.title).to eq("Actors")
+      expect(configuration.actors.description).to eq("Enable actors using the form above.")
+    end
+
+    it "can be updated" do
+      configuration.actors.title = "Actors Section"
+      expect(configuration.actors.title).to eq("Actors Section")
+    end
+  end
+
+  describe "#groups" do
+    it "has default text" do
+      expect(configuration.groups.title).to eq("Groups")
+      expect(configuration.groups.description).to eq("Enable groups using the form above.")
+    end
+  end
+
+  describe "#percentage_of_actors" do
+    it "has default text" do
+      expect(configuration.percentage_of_actors.title).to eq("Percentage of Actors")
+      expect(configuration.percentage_of_actors.description).to eq("Percentage of actors functions independently of percentage of time. If you enable 50% of Actors and 25% of Time then the feature will always be enabled for 50% of users and occasionally enabled 25% of the time for everyone.")
+    end
+  end
+
+  describe "#percentage_of_time" do
+    it "has default text" do
+      expect(configuration.percentage_of_time.title).to eq("Percentage of Time")
+      expect(configuration.percentage_of_time.description).to eq("Percentage of actors functions independently of percentage of time. If you enable 50% of Actors and 25% of Time then the feature will always be enabled for 50% of users and occasionally enabled 25% of the time for everyone.")
+    end
+  end
+
+  describe "#delete" do
+    it "has default text" do
+      expect(configuration.delete.title).to eq("Danger Zone")
+      expect(configuration.delete.description).to eq("Deleting a feature removes it from the list of features and disables it for everyone.")
+    end
+  end
+end

--- a/spec/flipper/ui_spec.rb
+++ b/spec/flipper/ui_spec.rb
@@ -146,4 +146,12 @@ RSpec.describe Flipper::UI do
       described_class.feature_creation_enabled = @original_feature_creation_enabled
     end
   end
+
+  describe 'configure' do
+    it 'yields configuration instance' do
+      described_class.configure do |config|
+        expect(config).to be_instance_of(Flipper::UI::Configuration)
+      end
+    end
+  end
 end


### PR DESCRIPTION
spike on #63 to allow users to customize the Flipper UI text, curious what everyone thinks.


```
Flipper::UI.configure do |c|
  c.percentage_of_actors.title = "% of Actors"
  c.percentage_of_actors.description = "percentage of actors rule :)"

  c.actors.description = "Enable any actor by entering that actor's flipper_id"

  c.delete.title = "DO NOT PRESS!"
  c.delete.description = "Who knows what will happen?!"
end
```

results in:
<img width="1003" alt="screen shot 2017-11-17 at 8 19 50 am" src="https://user-images.githubusercontent.com/3260042/32951587-0954eec0-cb70-11e7-98df-6a4f79e6bc37.png">

I also played with the idea of making the configuration have a bit cleaner dsl something like. the latter is cleaner, but the above is simpler, would be cool to hear thoughts on this:

```
Flipper::UI.configure do |c|

  c.actors do
    title ""
    description ""
  end
  
end
```
