### PR TITLE
Add Flipper.instance writer method

### DIFF
--- a/lib/flipper.rb
+++ b/lib/flipper.rb
@@ -32,7 +32,7 @@ module Flipper
   # Public: Sets Flipper::Configuration instance.
   def configuration=(configuration)
     # need to reset flipper instance if configuration changes
-    Thread.current[:flipper_instance] = nil
+    self.instance = nil
     @configuration = configuration
   end
 
@@ -44,6 +44,13 @@ module Flipper
   # Returns Flipper::DSL instance.
   def instance
     Thread.current[:flipper_instance] ||= configuration.default
+  end
+
+  # Public: Set the flipper instance. It is most common to use the
+  # Configuration#default to set this instance, but for things like the test
+  # environment, this writer is actually useful.
+  def instance=(flipper)
+    Thread.current[:flipper_instance] = flipper
   end
 
   # Public: All the methods delegated to instance. These should match the

--- a/spec/flipper_spec.rb
+++ b/spec/flipper_spec.rb
@@ -54,6 +54,14 @@ RSpec.describe Flipper do
     end
   end
 
+  describe '.instance=' do
+    it 'updates Flipper.instance' do
+      instance = described_class.new(Flipper::Adapters::Memory.new)
+      Flipper.instance = instance
+      expect(described_class.instance).to be(instance)
+    end
+  end
+
   describe "delegation to instance" do
     let(:group) { Flipper::Types::Group.new(:admins) }
     let(:actor) { Flipper::Actor.new("1") }

--- a/spec/flipper_spec.rb
+++ b/spec/flipper_spec.rb
@@ -57,7 +57,7 @@ RSpec.describe Flipper do
   describe '.instance=' do
     it 'updates Flipper.instance' do
       instance = described_class.new(Flipper::Adapters::Memory.new)
-      Flipper.instance = instance
+      described_class.instance = instance
       expect(described_class.instance).to be(instance)
     end
   end


### PR DESCRIPTION
Tiny little doodad to update the Flipper.instance explicitly. Primarily useful for testing where you can just use the memory adapter like:

```ruby
# in setup, before, or whatever your test framework calls it
Flipper.instance = Flipper.new(Flipper::Adapters::Memory.new)
```