### PR TITLE
Avoid Reaching into Adapter

### DIFF
--- a/lib/flipper.rb
+++ b/lib/flipper.rb
@@ -64,7 +64,8 @@ module Flipper
                  :enable_percentage_of_time, :disable_percentage_of_time,
                  :time, :percentage_of_time,
                  :features, :feature, :[], :preload, :preload_all,
-                 :adapter, :add, :remove, :import
+                 :adapter, :add, :remove, :import,
+                 :memoize=, :memoizing?
 
   # Public: Use this to register a group by name.
   #

--- a/lib/flipper/api/v1/actions/clear_feature.rb
+++ b/lib/flipper/api/v1/actions/clear_feature.rb
@@ -11,7 +11,7 @@ module Flipper
           def delete
             feature_name = Rack::Utils.unescape(path_parts[-2])
             feature = flipper[feature_name]
-            flipper.adapter.clear(feature)
+            feature.clear
             json_response({}, 204)
           end
         end

--- a/lib/flipper/api/v1/actions/features.rb
+++ b/lib/flipper/api/v1/actions/features.rb
@@ -35,7 +35,7 @@ module Flipper
           def post
             feature_name = params.fetch('name') { json_error_response(:name_invalid) }
             feature = flipper[feature_name]
-            flipper.adapter.add(feature)
+            feature.add
             decorated_feature = Decorators::Feature.new(feature)
             json_response(decorated_feature.as_json, 200)
           end

--- a/lib/flipper/dsl.rb
+++ b/lib/flipper/dsl.rb
@@ -1,13 +1,18 @@
+require 'forwardable'
 require 'flipper/adapters/memoizable'
 require 'flipper/instrumenters/noop'
 
 module Flipper
   class DSL
+    extend Forwardable
+
     # Private
     attr_reader :adapter
 
     # Private: What is being used to instrument all the things.
     attr_reader :instrumenter
+
+    def_delegators :@adapter, :memoize=, :memoizing?
 
     # Public: Returns a new instance of the DSL.
     #

--- a/lib/flipper/feature.rb
+++ b/lib/flipper/feature.rb
@@ -83,6 +83,13 @@ module Flipper
       instrument(:remove) { adapter.remove(self) }
     end
 
+    # Public: Clears all gate values for this feature.
+    #
+    # Returns the result of Adapter#clear.
+    def clear
+      instrument(:clear) { adapter.clear(self) }
+    end
+
     # Public: Check if a feature is enabled for a thing.
     #
     # Returns true if enabled, false if not.

--- a/lib/flipper/feature.rb
+++ b/lib/flipper/feature.rb
@@ -6,6 +6,7 @@ require 'flipper/gate_values'
 require 'flipper/instrumenters/noop'
 
 module Flipper
+  # rubocop:disable Metrics/ClassLength
   class Feature
     # Private: The name of feature instrumentation events.
     InstrumentationName = "feature_operation.#{InstrumentationNamespace}".freeze

--- a/lib/flipper/middleware/memoizer.rb
+++ b/lib/flipper/middleware/memoizer.rb
@@ -52,8 +52,8 @@ module Flipper
       def memoized_call(env)
         reset_on_body_close = false
         flipper = env.fetch(@env_key) { Flipper }
-        original = flipper.adapter.memoizing?
-        flipper.adapter.memoize = true
+        original = flipper.memoizing?
+        flipper.memoize = true
 
         flipper.preload_all if @opts[:preload_all]
 
@@ -63,12 +63,12 @@ module Flipper
 
         response = @app.call(env)
         response[2] = Rack::BodyProxy.new(response[2]) do
-          flipper.adapter.memoize = original
+          flipper.memoize = original
         end
         reset_on_body_close = true
         response
       ensure
-        flipper.adapter.memoize = original if flipper && !reset_on_body_close
+        flipper.memoize = original if flipper && !reset_on_body_close
       end
     end
   end

--- a/lib/flipper/ui/actions/feature.rb
+++ b/lib/flipper/ui/actions/feature.rb
@@ -23,7 +23,7 @@ module Flipper
         def delete
           feature_name = Rack::Utils.unescape(request.path.split('/').last)
           feature = flipper[feature_name]
-          flipper.adapter.remove(feature)
+          feature.remove
           redirect_to '/features'
         end
       end

--- a/lib/flipper/ui/actions/features.rb
+++ b/lib/flipper/ui/actions/features.rb
@@ -40,7 +40,8 @@ module Flipper
             redirect_to("/features/new?error=#{error}")
           end
 
-          flipper.adapter.add(flipper[value])
+          feature = flipper[value]
+          feature.add
 
           redirect_to "/features/#{Rack::Utils.escape_path(value)}"
         end

--- a/lib/flipper/ui/configuration.rb
+++ b/lib/flipper/ui/configuration.rb
@@ -12,9 +12,9 @@ module Flipper
       def initialize
         @actors = Option.new("Actors", "Enable actors using the form above.")
         @groups = Option.new("Groups", "Enable groups using the form above.")
-        @percentage_of_actors = Option.new("Percentage of Actors", "Percentage of actors functions independently of percentage of time. If you enable 50% of Actors and 25% of Time then the feature will always be enabled for 50% of users and occasionally enabled 25% of the time for everyone.")
-        @percentage_of_time = Option.new("Percentage of Time", "Percentage of actors functions independently of percentage of time. If you enable 50% of Actors and 25% of Time then the feature will always be enabled for 50% of users and occasionally enabled 25% of the time for everyone.")
-        @delete = Option.new("Danger Zone", "Deleting a feature removes it from the list of features and disables it for everyone.")
+        @percentage_of_actors = Option.new("Percentage of Actors", "Percentage of actors functions independently of percentage of time. If you enable 50% of Actors and 25% of Time then the feature will always be enabled for 50% of users and occasionally enabled 25% of the time for everyone.") # rubocop:disable Metrics/LineLength
+        @percentage_of_time = Option.new("Percentage of Time", "Percentage of actors functions independently of percentage of time. If you enable 50% of Actors and 25% of Time then the feature will always be enabled for 50% of users and occasionally enabled 25% of the time for everyone.") # rubocop:disable Metrics/LineLength
+        @delete = Option.new("Danger Zone", "Deleting a feature removes it from the list of features and disables it for everyone.") # rubocop:disable Metrics/LineLength
       end
     end
   end

--- a/spec/flipper/dsl_spec.rb
+++ b/spec/flipper/dsl_spec.rb
@@ -329,4 +329,21 @@ RSpec.describe Flipper::DSL do
       subject.import(destination_flipper)
     end
   end
+
+  describe '#memoize=' do
+    it 'delegates to adapter' do
+      expect(subject.adapter).to_not be_memoizing
+      subject.memoize = true
+      expect(subject.adapter).to be_memoizing
+    end
+  end
+
+  describe '#memoizing?' do
+    it 'delegates to adapter' do
+      subject.memoize = false
+      expect(subject.adapter.memoizing?).to eq(subject.memoizing?)
+      subject.memoize = true
+      expect(subject.adapter.memoizing?).to eq(subject.memoizing?)
+    end
+  end
 end

--- a/spec/flipper/dsl_spec.rb
+++ b/spec/flipper/dsl_spec.rb
@@ -332,7 +332,7 @@ RSpec.describe Flipper::DSL do
 
   describe '#memoize=' do
     it 'delegates to adapter' do
-      expect(subject.adapter).to_not be_memoizing
+      expect(subject.adapter).not_to be_memoizing
       subject.memoize = true
       expect(subject.adapter).to be_memoizing
     end

--- a/spec/flipper/feature_spec.rb
+++ b/spec/flipper/feature_spec.rb
@@ -111,7 +111,7 @@ RSpec.describe Flipper::Feature do
       subject.enable
       expect(subject).to be_enabled
       subject.clear
-      expect(subject).to_not be_enabled
+      expect(subject).not_to be_enabled
     end
   end
 

--- a/spec/flipper/feature_spec.rb
+++ b/spec/flipper/feature_spec.rb
@@ -106,6 +106,15 @@ RSpec.describe Flipper::Feature do
     end
   end
 
+  describe '#clear' do
+    it 'clears feature using adapter' do
+      subject.enable
+      expect(subject).to be_enabled
+      subject.clear
+      expect(subject).to_not be_enabled
+    end
+  end
+
   describe '#inspect' do
     it 'returns easy to read string representation' do
       string = subject.inspect
@@ -231,6 +240,17 @@ RSpec.describe Flipper::Feature do
       expect(event.name).to eq('feature_operation.flipper')
       expect(event.payload[:feature_name]).to eq(:search)
       expect(event.payload[:operation]).to eq(:remove)
+      expect(event.payload[:result]).not_to be_nil
+    end
+
+    it 'is recorded for clear' do
+      subject.clear
+
+      event = instrumenter.events.last
+      expect(event).not_to be_nil
+      expect(event.name).to eq('feature_operation.flipper')
+      expect(event.payload[:feature_name]).to eq(:search)
+      expect(event.payload[:operation]).to eq(:clear)
       expect(event.payload[:result]).not_to be_nil
     end
 

--- a/spec/flipper/middleware/memoizer_spec.rb
+++ b/spec/flipper/middleware/memoizer_spec.rb
@@ -18,7 +18,7 @@ RSpec.describe Flipper::Middleware::Memoizer do
   let(:env) { { 'flipper' => flipper } }
 
   after do
-    flipper.adapter.memoize = nil
+    flipper.memoize = nil
   end
 
   it 'raises if initialized with app and flipper instance' do
@@ -51,9 +51,9 @@ RSpec.describe Flipper::Middleware::Memoizer do
       middleware = described_class.new(app)
       body = middleware.call(env).last
 
-      expect(flipper.adapter.memoizing?).to eq(true)
+      expect(flipper.memoizing?).to eq(true)
       body.close
-      expect(flipper.adapter.memoizing?).to eq(false)
+      expect(flipper.memoizing?).to eq(false)
     end
 
     it 'clears local cache after body close' do
@@ -231,7 +231,7 @@ RSpec.describe Flipper::Middleware::Memoizer do
         middleware = described_class.new(app)
         middleware.call(env)
       rescue RuntimeError
-        expect(flipper.adapter.memoizing?).to be(false)
+        expect(flipper.memoizing?).to be(false)
       end
     end
   end

--- a/spec/flipper/ui/configuration_spec.rb
+++ b/spec/flipper/ui/configuration_spec.rb
@@ -25,21 +25,21 @@ RSpec.describe Flipper::UI::Configuration do
   describe "#percentage_of_actors" do
     it "has default text" do
       expect(configuration.percentage_of_actors.title).to eq("Percentage of Actors")
-      expect(configuration.percentage_of_actors.description).to eq("Percentage of actors functions independently of percentage of time. If you enable 50% of Actors and 25% of Time then the feature will always be enabled for 50% of users and occasionally enabled 25% of the time for everyone.")
+      expect(configuration.percentage_of_actors.description).to eq("Percentage of actors functions independently of percentage of time. If you enable 50% of Actors and 25% of Time then the feature will always be enabled for 50% of users and occasionally enabled 25% of the time for everyone.") # rubocop:disable Metrics/LineLength
     end
   end
 
   describe "#percentage_of_time" do
     it "has default text" do
       expect(configuration.percentage_of_time.title).to eq("Percentage of Time")
-      expect(configuration.percentage_of_time.description).to eq("Percentage of actors functions independently of percentage of time. If you enable 50% of Actors and 25% of Time then the feature will always be enabled for 50% of users and occasionally enabled 25% of the time for everyone.")
+      expect(configuration.percentage_of_time.description).to eq("Percentage of actors functions independently of percentage of time. If you enable 50% of Actors and 25% of Time then the feature will always be enabled for 50% of users and occasionally enabled 25% of the time for everyone.") # rubocop:disable Metrics/LineLength
     end
   end
 
   describe "#delete" do
     it "has default text" do
       expect(configuration.delete.title).to eq("Danger Zone")
-      expect(configuration.delete.description).to eq("Deleting a feature removes it from the list of features and disables it for everyone.")
+      expect(configuration.delete.description).to eq("Deleting a feature removes it from the list of features and disables it for everyone.") # rubocop:disable Metrics/LineLength
     end
   end
 end

--- a/spec/flipper_spec.rb
+++ b/spec/flipper_spec.rb
@@ -201,6 +201,16 @@ RSpec.describe Flipper do
     it 'delegates adapter to instance' do
       expect(described_class.adapter).to eq(described_class.instance.adapter)
     end
+
+    it 'delegates memoize= to instance' do
+      expect(described_class.adapter.memoizing?).to be(false)
+      described_class.memoize = true
+      expect(described_class.adapter.memoizing?).to be(true)
+    end
+
+    it 'delegates memoizing? to instance' do
+      expect(described_class.memoizing?).to eq(described_class.adapter.memoizing?)
+    end
   end
 
   describe '.register' do


### PR DESCRIPTION
This delegates `#memoize=` and `#memoizing?` on `Flipper::DSL` and `Flipper` which makes it so we don't have to reach for Flipper.adapter in order to use these in the memoizer middleware, which feels better. I also snagged other places we were doing flipper.adapter.whatever and used methods that already existed (e.g. `add` and `remove`) or added what was necessary (e.g. `clear`) to `Flipper::Feature` to avoid it. Nothing big, just feels a little better.