### PR TITLE
Fix double enable of actor/group unique error

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -43,3 +43,6 @@ RSpec/InstanceVariable:
 
 Style/AccessorMethodName:
   Enabled: false
+
+Lint/HandleExceptions:
+  Enabled: false

--- a/lib/flipper/adapters/active_record.rb
+++ b/lib/flipper/adapters/active_record.rb
@@ -136,6 +136,8 @@ module Flipper
         end
 
         true
+      rescue ::ActiveRecord::RecordNotUnique
+        true
       end
 
       # Public: Disables a gate for a given thing.

--- a/lib/flipper/adapters/active_record.rb
+++ b/lib/flipper/adapters/active_record.rb
@@ -181,6 +181,8 @@ module Flipper
           g.value = thing.value.to_s
         end
       rescue ::ActiveRecord::RecordNotUnique
+      rescue ::ActiveRecord::StatementInvalid => error
+        raise unless error.message =~ /unique/i
       end
 
       def result_for_feature(feature, db_gates)

--- a/lib/flipper/adapters/sequel.rb
+++ b/lib/flipper/adapters/sequel.rb
@@ -137,6 +137,8 @@ module Flipper
         end
 
         true
+      rescue ::Sequel::UniqueConstraintViolation
+        true
       end
 
       # Public: Disables a gate for a given thing.

--- a/lib/flipper/adapters/sequel.rb
+++ b/lib/flipper/adapters/sequel.rb
@@ -127,17 +127,17 @@ module Flipper
               key: gate.key.to_s,
             }
             @gate_class.where(args).delete
-
             @gate_class.create(gate_attrs(feature, gate, thing))
           end
         when :set
-          @gate_class.create(gate_attrs(feature, gate, thing))
+          begin
+            @gate_class.create(gate_attrs(feature, gate, thing))
+          rescue ::Sequel::UniqueConstraintViolation
+          end
         else
           unsupported_data_type gate.data_type
         end
 
-        true
-      rescue ::Sequel::UniqueConstraintViolation
         true
       end
 

--- a/lib/flipper/spec/shared_adapter_specs.rb
+++ b/lib/flipper/spec/shared_adapter_specs.rb
@@ -258,4 +258,15 @@ RSpec.shared_examples_for 'a flipper adapter' do
     expect(stats).to eq(subject.default_config.merge(boolean: 'true'))
     expect(search).to eq(subject.default_config)
   end
+
+  it 'can double enable an actor without error' do
+    actor = Flipper::Actor.new('Flipper::Actor;22')
+    expect(subject.enable(feature, actor_gate, flipper.actor(actor))).to eq(true)
+    expect(subject.enable(feature, actor_gate, flipper.actor(actor))).to eq(true)
+  end
+
+  it 'can double enable a group without error' do
+    expect(subject.enable(feature, group_gate, flipper.group(:admins))).to eq(true)
+    expect(subject.enable(feature, group_gate, flipper.group(:admins))).to eq(true)
+  end
 end

--- a/lib/flipper/test/shared_adapter_test.rb
+++ b/lib/flipper/test/shared_adapter_test.rb
@@ -253,6 +253,17 @@ module Flipper
         assert_equal @adapter.default_config.merge(boolean: 'true'), stats
         assert_equal @adapter.default_config, search
       end
+
+      def test_can_double_enable_an_actor_without_error
+        actor = Flipper::Actor.new('Flipper::Actor;22')
+        assert_equal true, @adapter.enable(@feature, @actor_gate, @flipper.actor(actor))
+        assert_equal true, @adapter.enable(@feature, @actor_gate, @flipper.actor(actor))
+      end
+
+      def test_can_double_enable_a_group_without_error
+        assert_equal true, @adapter.enable(@feature, @group_gate, @flipper.group(:admins))
+        assert_equal true, @adapter.enable(@feature, @group_gate, @flipper.group(:admins))
+      end
     end
   end
 end


### PR DESCRIPTION
As reported in https://github.com/jnunemaker/flipper/issues/296#issuecomment-339997906:

> One issue I had to work around was that double-enabling a feature for an actor or group threw a Postgres exception for violating the index_flipper_gates_on_feature_key_and_key_and_value unique constraint on the gates table. So I've got an enable_once wrapper that does a check-and-set to avoid the exception in the initializer that sets up basic rules and the rake tasks that perform administration.

This fixes that for Active Record and Sequel by adding shared adapter tests and swallowing the unique errors. I think this is fine as enabling something that is already enabled should return the same result as enabling it the first time.