### PR TITLE
Remove ui/public/ from code climate results

### DIFF
--- a/.codeclimate.yml
+++ b/.codeclimate.yml
@@ -1,0 +1,2 @@
+exclude_patterns:
+  - "lib/flipper/ui/public"


### PR DESCRIPTION
* Code Climate is analyzing files under lib/flipper/ui/public/ which is
mostly vendored js/css giving us an F!

![screen shot 2017-12-04 at 7 25 14 am](https://user-images.githubusercontent.com/3260042/33560379-6b62f808-d8c4-11e7-9702-3b09d49d0ecd.png)