### PR TITLE
Allow to use redis-adapter with redis 4.0.x

### DIFF
--- a/flipper-redis.gemspec
+++ b/flipper-redis.gemspec
@@ -20,5 +20,5 @@ Gem::Specification.new do |gem|
   gem.version       = Flipper::VERSION
 
   gem.add_dependency 'flipper', "~> #{Flipper::VERSION}"
-  gem.add_dependency 'redis', '>= 2.2', '< 4.0.0'
+  gem.add_dependency 'redis', '>= 2.2', '< 4.1.0'
 end


### PR DESCRIPTION
As [redis-rb 4.0.1](https://github.com/redis/redis-rb/releases/tag/v4.0.1) is now released, why don't allow to use it with flipper-redis adapter?