### PR TITLE
Rollout Adapter for importing rollout data into Flipper

### DIFF
--- a/flipper-rollout.gemspec
+++ b/flipper-rollout.gemspec
@@ -1,0 +1,25 @@
+# -*- encoding: utf-8 -*-
+require File.expand_path('../lib/flipper/version', __FILE__)
+
+flipper_rollout_files = lambda do |file|
+  file =~ /rollout/
+end
+
+Gem::Specification.new do |gem|
+  gem.authors       = ['John Nunemaker']
+  gem.email         = ['nunemaker@gmail.com']
+  gem.summary       = 'Rollout adapter for Flipper'
+  gem.description   = 'Rollout adapter for Flipper'
+  gem.license       = 'MIT'
+  gem.homepage      = 'https://github.com/jnunemaker/flipper'
+
+  gem.files         = `git ls-files`.split("\n").select(&flipper_rollout_files) + ['lib/flipper/version.rb']
+  gem.test_files    = `git ls-files -- {test,spec,features}/*`.split("\n").select(&flipper_rollout_files)
+  gem.name          = 'flipper-rollout'
+  gem.require_paths = ['lib']
+  gem.version       = Flipper::VERSION
+
+  gem.add_dependency 'flipper', "~> #{Flipper::VERSION}"
+  gem.add_dependency 'redis', '>= 2.2', '< 4.1.0'
+  gem.add_dependency 'rollout', "~> 2.0"
+end

--- a/lib/flipper/adapters/rollout.rb
+++ b/lib/flipper/adapters/rollout.rb
@@ -1,0 +1,71 @@
+module Flipper
+  module Adapters
+    class Rollout
+      class AdapterMethodNotSupportedError < Error
+        def initialize(message = 'unsupported method called for import adapter')
+          super(message)
+        end
+      end
+
+      # Public: The name of the adapter.
+      attr_reader :name
+
+      def initialize(rollout)
+        @rollout = rollout
+        @name = :rollout
+      end
+
+      # Public: The set of known features.
+      def features
+        @rollout.features
+      end
+
+      # Public: Gets the values for all gates for a given feature.
+      #
+      # Returns a Hash of Flipper::Gate#key => value.
+      def get(feature)
+        feature = @rollout.get(feature.key)
+        percentage = feature.percentage.zero? ? nil : feature.percentage
+        {
+          boolean: nil,
+          groups: Set.new(feature.groups),
+          actors: Set.new(feature.users),
+          percentage_of_actors: percentage,
+          percentage_of_time: nil,
+        }
+      end
+
+      def get_multi(_features)
+        raise AdapterMethodNotSupportedError
+      end
+
+      def get_all
+        raise AdapterMethodNotSupportedError
+      end
+
+      def add(_feature)
+        raise AdapterMethodNotSupportedError
+      end
+
+      def remove(_feature)
+        raise AdapterMethodNotSupportedError
+      end
+
+      def clear(_feature)
+        raise AdapterMethodNotSupportedError
+      end
+
+      def enable(_feature, _gate, _thing)
+        raise AdapterMethodNotSupportedError
+      end
+
+      def disable(_feature, _gate, _thing)
+        raise AdapterMethodNotSupportedError
+      end
+
+      def import(_source_adapter)
+        raise AdapterMethodNotSupportedError
+      end
+    end
+  end
+end

--- a/spec/flipper/adapters/rollout_spec.rb
+++ b/spec/flipper/adapters/rollout_spec.rb
@@ -1,0 +1,136 @@
+require 'helper'
+require 'redis'
+require 'rollout'
+require 'flipper/adapters/rollout'
+require 'flipper/adapters/memory'
+require 'flipper/spec/shared_adapter_specs'
+
+RSpec.describe Flipper::Adapters::Rollout do
+  let(:redis) { Redis.new }
+  let(:rollout) { Rollout.new(redis) }
+  let(:source_adapter) { described_class.new(rollout) }
+  let(:source_flipper) { Flipper.new(source_adapter) }
+  let(:destination_adapter) { Flipper::Adapters::Memory.new }
+  let(:destination_flipper) { Flipper.new(destination_adapter) }
+
+  before do
+    redis.flushdb
+  end
+
+  describe '#name' do
+    it 'has name that is a symbol' do
+      expect(source_adapter.name).not_to be_nil
+      expect(source_adapter.name).to be_instance_of(Symbol)
+    end
+  end
+
+  describe '#get' do
+    it 'returns hash of gate data' do
+      rollout.activate_user(:chat, Struct.new(:id).new(1))
+      rollout.activate_percentage(:chat, 20)
+      rollout.activate_group(:chat, :admins)
+      feature = Struct.new(:key).new(:chat)
+      expected = {
+        actors: Set.new(["1"]),
+        boolean: nil,
+        groups: Set.new([:admins]),
+        percentage_of_actors: 20.0,
+        percentage_of_time: nil,
+      }
+      expect(source_adapter.get(feature)).to eq(expected)
+    end
+  end
+
+  describe '#features' do
+    it 'returns all feature keys' do
+      rollout.activate(:chat)
+      rollout.activate(:messaging)
+      rollout.activate(:push_notifications)
+      expect(source_adapter.features).to match_array([:chat, :messaging, :push_notifications])
+    end
+  end
+
+  it 'can have one feature imported' do
+    rollout.activate(:search)
+    destination_flipper.import(source_flipper)
+    expect(destination_flipper.features.map(&:key)).to eq(["search"])
+  end
+
+  it 'can have multiple features imported' do
+    rollout.activate(:yep)
+    rollout.activate_group(:preview_features, :developers)
+    rollout.activate_group(:preview_features, :marketers)
+    rollout.activate_group(:preview_features, :company)
+    rollout.activate_group(:preview_features, :early_access)
+    rollout.activate_user(:preview_features, Struct.new(:id).new(1))
+    rollout.activate_user(:preview_features, Struct.new(:id).new(2))
+    rollout.activate_user(:preview_features, Struct.new(:id).new(3))
+    rollout.activate_percentage(:issues_next, 25)
+
+    destination_flipper.import(source_flipper)
+
+    feature = destination_flipper[:yep]
+    expect(feature.boolean_value).to eq(true)
+
+    feature = destination_flipper[:preview_features]
+    expect(feature.boolean_value).to be(false)
+    expect(feature.actors_value).to eq(Set['1', '2', '3'])
+    expected_groups = Set['developers', 'marketers', 'company', 'early_access']
+    expect(feature.groups_value).to eq(expected_groups)
+    expect(feature.percentage_of_actors_value).to be(0)
+
+    feature = destination_flipper[:issues_next]
+    expect(feature.boolean_value).to eq(false)
+    expect(feature.actors_value).to eq(Set.new)
+    expect(feature.groups_value).to eq(Set.new)
+    expect(feature.percentage_of_actors_value).to be(25.0)
+
+    feature = destination_flipper[:verbose_logging]
+    expect(feature.boolean_value).to eq(false)
+    expect(feature.actors_value).to eq(Set.new)
+    expect(feature.groups_value).to eq(Set.new)
+    expect(feature.percentage_of_actors_value).to be(0)
+  end
+
+  describe 'unsupported methods' do
+    it 'raises on get_multi' do
+      expect { source_adapter.get_multi([]) }
+        .to raise_error(Flipper::Adapters::Rollout::AdapterMethodNotSupportedError)
+    end
+
+    it 'raises on get_all' do
+      expect { source_adapter.get_all }
+        .to raise_error(Flipper::Adapters::Rollout::AdapterMethodNotSupportedError)
+    end
+
+    it 'raises on add' do
+      expect { source_adapter.add(:feature) }
+        .to raise_error(Flipper::Adapters::Rollout::AdapterMethodNotSupportedError)
+    end
+
+    it 'raises on remove' do
+      expect { source_adapter.remove(:feature) }
+        .to raise_error(Flipper::Adapters::Rollout::AdapterMethodNotSupportedError)
+    end
+
+    it 'raises on clear' do
+      expect { source_adapter.clear(:feature) }
+        .to raise_error(Flipper::Adapters::Rollout::AdapterMethodNotSupportedError)
+    end
+
+    it 'raises on enable' do
+      expect { source_adapter.enable(:feature, :gate, :thing) }
+        .to raise_error(Flipper::Adapters::Rollout::AdapterMethodNotSupportedError)
+    end
+
+    it 'raises on disable' do
+      expect { source_adapter.disable(:feature, :gate, :thing) }
+        .to raise_error(Flipper::Adapters::Rollout::AdapterMethodNotSupportedError)
+    end
+
+    it 'raises on import' do
+      expect { source_adapter.import(:source_adapter) }
+        .to raise_error(Flipper::Adapters::Rollout::AdapterMethodNotSupportedError)
+    end
+  end
+end


### PR DESCRIPTION
Addresses #308 

Adds an adapter to import Rollout data into Flipper

Rollout supports the equivalent to Flipper's
* groups
* actors
* percentage_of_actors
* boolean (sort of...via 100% percentage enabled)

Rollout does not support
* percentage_of_time

Importing only requires `features`, `get` to be implemented.

Questions/Notes:

* for the methods the adapter doesn't implement I'm thinking of raising an error similar to the read only adapter to make it clear that this adapter is only for importing since rollout doesn't have feature parity

* I'm testing ["can have one feature imported"`](https://github.com/jnunemaker/flipper/compare/rollout-adapter?expand=1#diff-ce5ff96d129103e0d6d194b6be39790dR59) type stuff where its not really testing the rollout adapter its really testing adapter.import, but I think it does give some assurance that things are being imported correctly.  Alternatively we could just assume import works given that `get`, `features` work which are also unit tested, but I do like the more thorough test.

* this will only work with rollout ~> 2.0 because the Rollout public api changed from 1 -> 2 and this is reflected in the [gemspec dependency](https://github.com/jnunemaker/flipper/compare/rollout-adapter?expand=1#diff-b6812c21ec89079fd92064a7e29a5673R24).

* Rollout 2.3[ introduced casting percentages](https://github.com/fetlife/rollout/commit/ac5f55bfd5aea59bf7c4c9cea189cacd49b7d290#diff-201938e8c8fb9ba71dea56ce449c387f) `to_f` before saving.  For flipper users using Flipper < 0.11 (before Flipper supported decimal percentages) the values between Rollout (decimal) and Flipper(integer) would be different, although I don't think this is a big deal?

* users importing Rollout data would need to reregister their groups since those are an evaluated block in memory