### PR TITLE
Allow feature removal from the UI to be disabled

### DIFF
--- a/lib/flipper/ui.rb
+++ b/lib/flipper/ui.rb
@@ -24,14 +24,19 @@ module Flipper
 
       # Public: Is feature creation allowed from the UI? Defaults to true. If
       # set to false, users of the UI cannot create features. All feature
-      # creation will need to be done through the conigured flipper instance.
+      # creation will need to be done through the configured flipper instance.
       attr_accessor :feature_creation_enabled
+
+      # Public: Is feature deletion allowed from the UI? Defaults to true. If
+      # set to false, users won't be able to delete features from the UI.
+      attr_accessor :feature_removal_enabled
 
       # Public: Set attributes on this instance to customize UI text
       attr_reader :configuration
     end
 
     self.feature_creation_enabled = true
+    self.feature_removal_enabled = true
 
     def self.root
       @root ||= Pathname(__FILE__).dirname.expand_path.join('ui')

--- a/lib/flipper/ui/actions/feature.rb
+++ b/lib/flipper/ui/actions/feature.rb
@@ -21,6 +21,15 @@ module Flipper
         end
 
         def delete
+          unless Flipper::UI.feature_removal_enabled
+            status 403
+
+            breadcrumb 'Home', '/'
+            breadcrumb 'Features', '/features'
+
+            halt view_response(:feature_removal_disabled)
+          end
+
           feature_name = Rack::Utils.unescape(request.path.split('/').last)
           feature = flipper[feature_name]
           feature.remove

--- a/lib/flipper/ui/views/feature.erb
+++ b/lib/flipper/ui/views/feature.erb
@@ -192,19 +192,21 @@
   </div>
 </div>
 
-<div class="panel panel-danger">
-  <div class="panel-heading">
-    <h3 class="panel-title"><%= Flipper::UI.configuration.delete.title %></h3>
-  </div>
-  <div class="panel-body">
-    <p>
-      <%= Flipper::UI.configuration.delete.description %>
-    </p>
+<% if Flipper::UI.feature_removal_enabled %>
+  <div class="panel panel-danger">
+    <div class="panel-heading">
+      <h3 class="panel-title"><%= Flipper::UI.configuration.delete.title %></h3>
+    </div>
+    <div class="panel-body">
+      <p>
+        <%= Flipper::UI.configuration.delete.description %>
+      </p>
 
-    <form action="<%= script_name %>/features/<%= @feature.key %>" method="post" onsubmit="return confirm('Are you sure you want to remove <%= @feature.key %> from the list of features and disable it for everyone?')">
-      <%== csrf_input_tag %>
-      <input type="hidden" name="_method" value="DELETE">
-      <button type="submit" name="action" value="Delete" class="btn btn-danger tooltipped tooltipped-ne" aria-label="Remove feature from list of features and disable it.">Delete</button>
-    </form>
+      <form action="<%= script_name %>/features/<%= @feature.key %>" method="post" onsubmit="return confirm('Are you sure you want to remove <%= @feature.key %> from the list of features and disable it for everyone?')">
+        <%== csrf_input_tag %>
+        <input type="hidden" name="_method" value="DELETE">
+        <button type="submit" name="action" value="Delete" class="btn btn-danger tooltipped tooltipped-ne" aria-label="Remove feature from list of features and disable it.">Delete</button>
+      </form>
+    </div>
   </div>
-</div>
+<% end %>

--- a/lib/flipper/ui/views/feature_removal_disabled.erb
+++ b/lib/flipper/ui/views/feature_removal_disabled.erb
@@ -1,0 +1,3 @@
+<div class="flash flash-error">
+  Feature removal from the UI is disabled. To enable, you'll need to set <code>Flipper::UI.feature_removal_enabled = true</code> wherever flipper is running from.
+</div>

--- a/spec/flipper/ui/actions/feature_spec.rb
+++ b/spec/flipper/ui/actions/feature_spec.rb
@@ -28,6 +28,23 @@ RSpec.describe Flipper::UI::Actions::Feature do
       expect(last_response.status).to be(302)
       expect(last_response.headers['Location']).to eq('/features')
     end
+
+    context 'when feature_removal_enabled is set to false' do
+      around do |example|
+        @original_feature_removal_enabled = Flipper::UI.feature_removal_enabled
+        Flipper::UI.feature_removal_enabled = false
+        example.run
+        Flipper::UI.feature_removal_enabled = @original_feature_removal_enabled
+      end
+
+      it 'returns with 403 status' do
+        expect(last_response.status).to be(403)
+      end
+
+      it 'renders feature removal disabled template' do
+        expect(last_response.body).to include('Feature removal from the UI is disabled')
+      end
+    end
   end
 
   describe 'POST /features/:feature with _method=DELETE' do


### PR DESCRIPTION
This change allows the `Danger Zone` + `Delete Feature` button to be removed from the Flipper UI.

I thought it was a good idea do have it, because sometimes adding or removing features is a job for developers only, who might want to do it only via console, rake tasks, migrations or seeds.

What do you guys think?
  