### PR TITLE
Active Record get_all Fix

### DIFF
--- a/lib/flipper/adapters/active_record.rb
+++ b/lib/flipper/adapters/active_record.rb
@@ -91,7 +91,8 @@ module Flipper
       def get_all
         rows = ::ActiveRecord::Base.connection.select_all <<-SQL
           SELECT ff.key AS feature_key, fg.key, fg.value
-          FROM flipper_features ff LEFT JOIN flipper_gates fg ON ff.key = fg.feature_key
+          FROM #{@feature_class.table_name} ff
+          LEFT JOIN #{@gate_class.table_name} fg ON ff.key = fg.feature_key
         SQL
         db_gates = rows.map { |row| Gate.new(row) }
         grouped_db_gates = db_gates.group_by(&:feature_key)

--- a/lib/flipper/adapters/sequel.rb
+++ b/lib/flipper/adapters/sequel.rb
@@ -98,9 +98,9 @@ module Flipper
 
       def get_all
         db_gates = @gate_class.fetch(<<-SQL).to_a
-          SELECT g.*
-          FROM #{@gate_class.table_name} g
-            INNER JOIN #{@feature_class.table_name} f ON f.key = g.feature_key
+          SELECT ff.key AS feature_key, fg.key, fg.value
+          FROM #{@feature_class.table_name} ff
+          LEFT JOIN #{@gate_class.table_name} fg ON ff.key = fg.feature_key
         SQL
         grouped_db_gates = db_gates.group_by(&:feature_key)
         result = Hash.new { |hash, key| hash[key] = default_config }

--- a/lib/flipper/spec/shared_adapter_specs.rb
+++ b/lib/flipper/spec/shared_adapter_specs.rb
@@ -259,6 +259,15 @@ RSpec.shared_examples_for 'a flipper adapter' do
     expect(search).to eq(subject.default_config)
   end
 
+  it 'includes explicitly disabled features when getting all features' do
+    flipper.enable(:stats)
+    flipper.enable(:search)
+    flipper.disable(:search)
+
+    result = subject.get_all
+    expect(result.keys.sort).to eq(%w(search stats))
+  end
+
   it 'can double enable an actor without error' do
     actor = Flipper::Actor.new('Flipper::Actor;22')
     expect(subject.enable(feature, actor_gate, flipper.actor(actor))).to eq(true)

--- a/lib/flipper/test/shared_adapter_test.rb
+++ b/lib/flipper/test/shared_adapter_test.rb
@@ -254,6 +254,15 @@ module Flipper
         assert_equal @adapter.default_config, search
       end
 
+      def test_includes_explicitly_disabled_features_when_getting_all_features
+        @flipper.enable(:stats)
+        @flipper.enable(:search)
+        @flipper.disable(:search)
+
+        result = @adapter.get_all
+        assert_equal %w(search stats), result.keys.sort
+      end
+
       def test_can_double_enable_an_actor_without_error
         actor = Flipper::Actor.new('Flipper::Actor;22')
         assert_equal true, @adapter.enable(@feature, @actor_gate, @flipper.actor(actor))

--- a/spec/flipper/adapters/active_record_spec.rb
+++ b/spec/flipper/adapters/active_record_spec.rb
@@ -45,16 +45,4 @@ RSpec.describe Flipper::Adapters::ActiveRecord do
   end
 
   it_should_behave_like 'a flipper adapter'
-
-  describe '.get_all' do
-    it 'includes features in features table but not in gates table' do
-      flipper = Flipper.new(subject)
-      flipper.enable(:stats)
-      flipper.enable(:search)
-      flipper.disable(:search)
-
-      result = subject.get_all
-      expect(result.keys.sort).to eq(%w(search stats))
-    end
-  end
 end

--- a/spec/flipper/adapters/active_record_spec.rb
+++ b/spec/flipper/adapters/active_record_spec.rb
@@ -45,4 +45,16 @@ RSpec.describe Flipper::Adapters::ActiveRecord do
   end
 
   it_should_behave_like 'a flipper adapter'
+
+  describe '.get_all' do
+    it 'includes features in features table but not in gates table' do
+      flipper = Flipper.new(subject)
+      flipper.enable(:stats)
+      flipper.enable(:search)
+      flipper.disable(:search)
+
+      result = subject.get_all
+      expect(result.keys.sort).to eq(%w(search stats))
+    end
+  end
 end


### PR DESCRIPTION
Fixes the sequel and active record adapters to include even disabled features in get_all. The issue was using an inner join between feature and gate tables, which means features in the feature table but not in the gate table (because they were fully disabled) were not represented in get_all. 

fixes https://github.com/jnunemaker/flipper/issues/324
  