### PR TITLE
Moneta adapter

### DIFF
--- a/flipper-moneta.gemspec
+++ b/flipper-moneta.gemspec
@@ -1,0 +1,24 @@
+# -*- encoding: utf-8 -*-
+require File.expand_path('../lib/flipper/version', __FILE__)
+
+flipper_moneta_files = lambda do |file|
+  file =~ /moneta/
+end
+
+Gem::Specification.new do |gem|
+  gem.authors       = ['John Nunemaker']
+  gem.email         = ['nunemaker@gmail.com']
+  gem.summary       = 'Moneta adapter for Flipper'
+  gem.description   = 'Moneta adapter for Flipper'
+  gem.license       = 'MIT'
+  gem.homepage      = 'https://github.com/jnunemaker/flipper'
+
+  gem.files         = `git ls-files`.split("\n").select(&flipper_moneta_files) + ['lib/flipper/version.rb']
+  gem.test_files    = `git ls-files -- {test,spec,features}/*`.split("\n").select(&flipper_moneta_files)
+  gem.name          = 'flipper-moneta'
+  gem.require_paths = ['lib']
+  gem.version       = Flipper::VERSION
+
+  gem.add_dependency 'flipper', "~> #{Flipper::VERSION}"
+  gem.add_dependency 'moneta', '>= 0.7.19'
+end

--- a/lib/flipper/adapters/moneta.rb
+++ b/lib/flipper/adapters/moneta.rb
@@ -1,0 +1,177 @@
+module Flipper
+  module Adapters
+    class Moneta
+      include ::Flipper::Adapter
+
+      FeaturesKey = :features
+
+      # Public: The name of the adapter.
+      attr_reader :name
+
+      # Public
+      def initialize(moneta)
+        @moneta = moneta
+        @name = :moneta
+      end
+
+      def features
+        read_feature_keys
+      end
+
+      # Public: Adds a feature to the set of known features.
+      def add(feature)
+        @moneta[FeaturesKey.to_s] ||= Set.new
+        @moneta[FeaturesKey.to_s] = @moneta[FeaturesKey.to_s].add(feature.key)
+        true
+      end
+
+      # Public: Removes a feature from the set of known features and clears
+      # all the values for the feature.
+      def remove(feature)
+        @moneta[FeaturesKey.to_s] ||= Set.new
+        @moneta[FeaturesKey.to_s] = @moneta[FeaturesKey.to_s].delete(feature.key)
+        clear(feature)
+        true
+      end
+
+      # Public: Clears all the gate values for a feature.
+      def clear(feature)
+        feature.gates.each do |gate|
+          delete key(feature, gate)
+        end
+        true
+      end
+
+      # Public
+      def get(feature)
+        read_feature(feature)
+      end
+
+      def get_multi(features)
+        read_many_features(features)
+      end
+
+      def get_all
+        features = read_feature_keys.map do |key|
+          Flipper::Feature.new(key, self)
+        end
+
+        read_many_features(features)
+      end
+
+      # Public
+      def enable(feature, gate, thing)
+        case gate.data_type
+        when :boolean, :integer
+          write key(feature, gate), thing.value.to_s
+        when :set
+          set_add key(feature, gate), thing.value.to_s
+        else
+          raise "#{gate} is not supported by this adapter yet"
+        end
+
+        true
+      end
+
+      # Public
+      def disable(feature, gate, thing)
+        case gate.data_type
+        when :boolean
+          clear(feature)
+        when :integer
+          write key(feature, gate), thing.value.to_s
+        when :set
+          set_delete key(feature, gate), thing.value.to_s
+        else
+          raise "#{gate} is not supported by this adapter yet"
+        end
+
+        true
+      end
+
+      # Public
+      def inspect
+        attributes = [
+          'name=:memory',
+          "source=#{@moneta.inspect}",
+        ]
+        "#<#{self.class.name}:#{object_id} #{attributes.join(', ')}>"
+      end
+
+      private
+
+      def read_feature_keys
+        set_members(FeaturesKey)
+      end
+
+      # Private
+      def key(feature, gate)
+        "feature/#{feature.key}/#{gate.key}"
+      end
+
+      def read_many_features(features)
+        result = {}
+        features.each do |feature|
+          result[feature.key] = read_feature(feature)
+        end
+        result
+      end
+
+      def read_feature(feature)
+        result = {}
+
+        feature.gates.each do |gate|
+          result[gate.key] =
+            case gate.data_type
+            when :boolean, :integer
+              read key(feature, gate)
+            when :set
+              set_members key(feature, gate)
+            else
+              raise "#{gate} is not supported by this adapter yet"
+            end
+        end
+
+        result
+      end
+
+      # Private
+      def read(key)
+        @moneta[key.to_s]
+      end
+
+      # Private
+      def write(key, value)
+        @moneta[key.to_s] = value.to_s
+      end
+
+      # Private
+      def delete(key)
+        @moneta.delete(key.to_s)
+      end
+
+      # Private
+      def set_add(key, value)
+        ensure_set_initialized(key)
+        @moneta[key.to_s] = @moneta[key.to_s].add(value.to_s)
+      end
+
+      # Private
+      def set_delete(key, value)
+        ensure_set_initialized(key)
+        @moneta[key.to_s] = @moneta[key.to_s].delete(value.to_s)
+      end
+
+      # Private
+      def set_members(key)
+        ensure_set_initialized(key)
+        @moneta[key.to_s]
+      end
+
+      # Private
+      def ensure_set_initialized(key)
+        @moneta[key.to_s] ||= Set.new
+      end
+    end
+  end
+end

--- a/spec/flipper/adapters/moneta_spec.rb
+++ b/spec/flipper/adapters/moneta_spec.rb
@@ -1,10 +1,9 @@
 require 'helper'
-require 'moneta'
 require 'flipper/adapters/moneta'
 require 'flipper/spec/shared_adapter_specs'
 
 RSpec.describe Flipper::Adapters::Moneta do
-  let(:moneta) {  Moneta.new(:Memory) }
+  let(:moneta) { Moneta.new(:Memory) }
   subject { described_class.new(moneta) }
 
   it_should_behave_like 'a flipper adapter'

--- a/spec/flipper/adapters/moneta_spec.rb
+++ b/spec/flipper/adapters/moneta_spec.rb
@@ -1,0 +1,11 @@
+require 'helper'
+require 'moneta'
+require 'flipper/adapters/moneta'
+require 'flipper/spec/shared_adapter_specs'
+
+RSpec.describe Flipper::Adapters::Moneta do
+  let(:moneta) {  Moneta.new(:Memory) }
+  subject { described_class.new(moneta) }
+
+  it_should_behave_like 'a flipper adapter'
+end


### PR DESCRIPTION
#307 

I almost thought we could pass in a Moneta instance to the memory adapter as its source and it would work because the Moneta api is very similar to Hash, but it turns out Moneta returns copies of objects, which is why [set_add](https://github.com/jnunemaker/flipper/compare/moneta-adapter?expand=1#diff-975176d71feb497dd53ac5b6311196eaR145) and set_delete need to be implemented a little different than the memory adapter.  This is pretty much the memory adapter with a few tweaks.

* The earliest version that passes *flipper/adapters/moneta_spec.rb* is Moneta [0.7.19](https://github.com/jnunemaker/flipper/compare/moneta-adapter?expand=1#diff-f66ab524b960774a9c36616b5c0a9187R23). Not sure if we should require that dependency or 1.0? Would be cool to hear ya thoughts!

* moneta is very cool and this opens the door to so many data stores