### PR TITLE
Rollout tweaks

### DIFF
--- a/docs/rollout/README.md
+++ b/docs/rollout/README.md
@@ -23,18 +23,25 @@ Or install it yourself with:
 
 ## Usage
 
-Assuming you've configured a [default Flipper instance](https://github.com/jnunemaker/flipper#user-content-examples)
-
 ```ruby
 require 'redis'
+require 'rollout'
+require 'flipper'
+require 'flipper/adapters/redis'
 require 'flipper/adapters/rollout'
 
+# setup redis, rollout and rollout flipper
 redis = Redis.new
 rollout = Rollout.new(redis)
-
 rollout_adapter = Flipper::Adapters::Rollout.new(rollout)
 rollout_flipper = Flipper.new(rollout_adapter)
 
+# setup flipper default instance
+Flipper.configure do |config|
+  config.default { Flipper.new(Flipper::Adapters::Redis.new(redis)) }
+end
+
+# import rollout into redis flipper
 Flipper.import(rollout_flipper)
 ```
 

--- a/examples/rollout/basic.rb
+++ b/examples/rollout/basic.rb
@@ -1,0 +1,32 @@
+require 'pathname'
+require 'logger'
+
+root_path = Pathname(__FILE__).dirname.join('..').expand_path
+lib_path  = root_path.join('lib')
+$:.unshift(lib_path)
+
+require 'redis'
+require 'rollout'
+require 'flipper'
+require 'flipper/adapters/rollout'
+
+redis = Redis.new
+rollout = Rollout.new(redis)
+rollout.activate(:stats)
+
+adapter = Flipper::Adapters::Rollout.new(rollout)
+flipper = Flipper.new(adapter)
+
+if flipper[:stats].enabled?
+  puts "Enabled!"
+else
+  puts "Disabled!"
+end
+
+rollout.deactivate(:stats)
+
+if flipper[:stats].enabled?
+  puts "Enabled!"
+else
+  puts "Disabled!"
+end

--- a/examples/rollout/import.rb
+++ b/examples/rollout/import.rb
@@ -1,0 +1,41 @@
+require 'pathname'
+require 'logger'
+
+root_path = Pathname(__FILE__).dirname.join('..').expand_path
+lib_path  = root_path.join('lib')
+$:.unshift(lib_path)
+
+require 'redis'
+require 'rollout'
+require 'flipper'
+require 'flipper/adapters/redis'
+require 'flipper/adapters/rollout'
+
+# setup redis, rollout and rollout flipper
+redis = Redis.new
+rollout = Rollout.new(redis)
+rollout_adapter = Flipper::Adapters::Rollout.new(rollout)
+rollout_flipper = Flipper.new(rollout_adapter)
+
+# setup flipper default instance
+Flipper.configure do |config|
+  config.default do
+    Flipper.new(Flipper::Adapters::Redis.new(redis))
+  end
+end
+
+# flush redis so we have clean state for script
+redis.flushdb
+
+# activate some rollout stuff to show that importing works
+rollout.activate(:stats)
+rollout.activate_user(:search, Struct.new(:id).new(1))
+rollout.activate_group(:admin, :admins)
+
+# import rollout into redis flipper
+Flipper.import(rollout_flipper)
+
+# demonstrate that the rollout enablements made it into flipper
+p Flipper[:stats].boolean_value # true
+p Flipper[:search].actors_value # #<Set: {"1"}>
+p Flipper[:admin].groups_value # #<Set: {"admins"}>

--- a/lib/flipper/adapters/rollout.rb
+++ b/lib/flipper/adapters/rollout.rb
@@ -1,3 +1,5 @@
+require "flipper/errors"
+
 module Flipper
   module Adapters
     class Rollout

--- a/lib/flipper/adapters/rollout.rb
+++ b/lib/flipper/adapters/rollout.rb
@@ -28,33 +28,32 @@ module Flipper
       #
       # Returns a Hash of Flipper::Gate#key => value.
       def get(feature)
-        if rollout_feature = @rollout.get(feature.key)
-          boolean = nil
-          groups = Set.new(rollout_feature.groups)
-          actors = Set.new(rollout_feature.users)
+        rollout_feature = @rollout.get(feature.key)
+        return default_config if rollout_feature.nil?
 
-          percentage_of_actors = case rollout_feature.percentage
-          when 100
-            boolean = true
-            groups = Set.new
-            actors = Set.new
-            nil
-          when 0
-            nil
-          else
-            rollout_feature.percentage
-          end
+        boolean = nil
+        groups = Set.new(rollout_feature.groups)
+        actors = Set.new(rollout_feature.users)
 
-          {
-            boolean: boolean,
-            groups: groups,
-            actors: actors,
-            percentage_of_actors: percentage_of_actors,
-            percentage_of_time: nil,
-          }
-        else
-          default_config
-        end
+        percentage_of_actors = case rollout_feature.percentage
+                               when 100
+                                 boolean = true
+                                 groups = Set.new
+                                 actors = Set.new
+                                 nil
+                               when 0
+                                 nil
+                               else
+                                 rollout_feature.percentage
+                               end
+
+        {
+          boolean: boolean,
+          groups: groups,
+          actors: actors,
+          percentage_of_actors: percentage_of_actors,
+          percentage_of_time: nil,
+        }
       end
 
       def get_multi(_features)

--- a/lib/flipper/adapters/rollout.rb
+++ b/lib/flipper/adapters/rollout.rb
@@ -29,12 +29,27 @@ module Flipper
       # Returns a Hash of Flipper::Gate#key => value.
       def get(feature)
         if rollout_feature = @rollout.get(feature.key)
-          percentage = rollout_feature.percentage.zero? ? nil : rollout_feature.percentage
+          boolean = nil
+          groups = Set.new(rollout_feature.groups)
+          actors = Set.new(rollout_feature.users)
+
+          percentage_of_actors = case rollout_feature.percentage
+          when 100
+            boolean = true
+            groups = Set.new
+            actors = Set.new
+            nil
+          when 0
+            nil
+          else
+            rollout_feature.percentage
+          end
+
           {
-            boolean: nil,
-            groups: Set.new(rollout_feature.groups),
-            actors: Set.new(rollout_feature.users),
-            percentage_of_actors: percentage,
+            boolean: boolean,
+            groups: groups,
+            actors: actors,
+            percentage_of_actors: percentage_of_actors,
             percentage_of_time: nil,
           }
         else

--- a/lib/flipper/adapters/rollout.rb
+++ b/lib/flipper/adapters/rollout.rb
@@ -3,6 +3,8 @@ require "flipper/errors"
 module Flipper
   module Adapters
     class Rollout
+      include Adapter
+
       class AdapterMethodNotSupportedError < Error
         def initialize(message = 'unsupported method called for import adapter')
           super(message)
@@ -26,15 +28,18 @@ module Flipper
       #
       # Returns a Hash of Flipper::Gate#key => value.
       def get(feature)
-        feature = @rollout.get(feature.key)
-        percentage = feature.percentage.zero? ? nil : feature.percentage
-        {
-          boolean: nil,
-          groups: Set.new(feature.groups),
-          actors: Set.new(feature.users),
-          percentage_of_actors: percentage,
-          percentage_of_time: nil,
-        }
+        if rollout_feature = @rollout.get(feature.key)
+          percentage = rollout_feature.percentage.zero? ? nil : rollout_feature.percentage
+          {
+            boolean: nil,
+            groups: Set.new(rollout_feature.groups),
+            actors: Set.new(rollout_feature.users),
+            percentage_of_actors: percentage,
+            percentage_of_time: nil,
+          }
+        else
+          default_config
+        end
       end
 
       def get_multi(_features)

--- a/spec/flipper/adapters/rollout_spec.rb
+++ b/spec/flipper/adapters/rollout_spec.rb
@@ -40,14 +40,29 @@ RSpec.describe Flipper::Adapters::Rollout do
       expect(source_adapter.get(feature)).to eq(expected)
     end
 
-    it 'works for fully activated' do
+    it 'returns fully flipper enabled for fully rollout activated' do
       rollout.activate(:chat)
       feature = source_flipper[:chat]
       expected = {
-        boolean: nil,
+        boolean: true,
         groups: Set.new,
         actors: Set.new,
-        percentage_of_actors: 100.0,
+        percentage_of_actors: nil,
+        percentage_of_time: nil,
+      }
+      expect(source_adapter.get(feature)).to eq(expected)
+    end
+
+    it 'returns fully flipper enabled for fully rollout activated with user/group' do
+      rollout.activate_user(:chat, Struct.new(:id).new(1))
+      rollout.activate_group(:chat, :admins)
+      rollout.activate(:chat)
+      feature = source_flipper[:chat]
+      expected = {
+        boolean: true,
+        groups: Set.new,
+        actors: Set.new,
+        percentage_of_actors: nil,
         percentage_of_time: nil,
       }
       expect(source_adapter.get(feature)).to eq(expected)

--- a/spec/flipper/adapters/rollout_spec.rb
+++ b/spec/flipper/adapters/rollout_spec.rb
@@ -29,15 +29,33 @@ RSpec.describe Flipper::Adapters::Rollout do
       rollout.activate_user(:chat, Struct.new(:id).new(1))
       rollout.activate_percentage(:chat, 20)
       rollout.activate_group(:chat, :admins)
-      feature = Struct.new(:key).new(:chat)
+      feature = source_flipper[:chat]
       expected = {
-        actors: Set.new(["1"]),
         boolean: nil,
         groups: Set.new([:admins]),
+        actors: Set.new(["1"]),
         percentage_of_actors: 20.0,
         percentage_of_time: nil,
       }
       expect(source_adapter.get(feature)).to eq(expected)
+    end
+
+    it 'works for fully activated' do
+      rollout.activate(:chat)
+      feature = source_flipper[:chat]
+      expected = {
+        boolean: nil,
+        groups: Set.new,
+        actors: Set.new,
+        percentage_of_actors: 100.0,
+        percentage_of_time: nil,
+      }
+      expect(source_adapter.get(feature)).to eq(expected)
+    end
+
+    it 'returns default hash of gate data for feature not existing in rollout' do
+      feature = source_flipper[:chat]
+      expect(source_adapter.get(feature)).to eq(source_adapter.default_config)
     end
   end
 


### PR DESCRIPTION
* Adds require for flipper/errors since `AdapterMethodNotSupportedError` inherits from Flipper::Error defined in that file.
* Ensures rollout works fine for features that do not exist. In some basic scripts I was playing with this was causing problems.
* Makes rollout percentage 100 equal to flipper fully enabled. Rollout doesn't clear other gate values (users/groups) when fully enabled and uses percentage == 100 as fully enabled instead of a different key (like boolean: false in flipper). Flipper.enabled?(:foo) returns false for 100% of actors enabled because no actor was passed, but rollout returns true (as it has no other way to denote 100% of actors enabled vs enabled regardless of actor). Making rollout 100% == flipper fully enabled means that rollout.active?(:chat) and flipper.enabled?(:chat) are equivalent, which feels right.
* Adds a basic and import example.
* Updates docs to match import example.