### PR TITLE
Guard Rubocop

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -27,6 +27,12 @@ Style/NumericLiterals:
 Style/StringLiterals:
   Enabled: false
 
+Style/GuardClause:
+  Enabled: false
+
+Style/IfUnlessModifier:
+  Enabled: false
+
 Metrics/LineLength:
   Max: 100
   Exclude:

--- a/Gemfile
+++ b/Gemfile
@@ -24,6 +24,7 @@ gem 'test-unit', '~> 3.0'
 
 group(:guard) do
   gem 'guard', '~> 2.12.5'
+  gem 'guard-rubocop', '~> 1.3.0'
   gem 'guard-rspec', '~> 4.5.0'
   gem 'guard-bundler', '~> 2.1.0'
   gem 'guard-coffeescript', '~> 2.0.1'

--- a/Guardfile
+++ b/Guardfile
@@ -35,3 +35,8 @@ sass_options = {
   output: 'lib/flipper/ui/public/css',
 }
 guard 'sass', sass_options
+
+guard :rubocop do
+  watch(/.+\.rb$/)
+  watch(%r{(?:.+/)?\.rubocop(?:_todo)?\.yml$}) { |m| File.dirname(m[0]) }
+end


### PR DESCRIPTION
If using guard, this makes it automatically show rubocop problems and fixes some for you. Makes it easier to keep formatting up to date.