### PR TITLE
Cloud Sync

### DIFF
--- a/lib/flipper/adapters/sync.rb
+++ b/lib/flipper/adapters/sync.rb
@@ -12,6 +12,9 @@ module Flipper
       # Public: The name of the adapter.
       attr_reader :name
 
+      # Public: The synchronizer that will keep the local and remote in sync.
+      attr_reader :synchronizer
+
       # Public: Build a new sync instance.
       #
       # local - The local flipper adapter that should serve reads.

--- a/lib/flipper/adapters/sync/interval_synchronizer.rb
+++ b/lib/flipper/adapters/sync/interval_synchronizer.rb
@@ -12,6 +12,10 @@ module Flipper
           Process.clock_gettime(Process::CLOCK_MONOTONIC, :millisecond)
         end
 
+        # Public: The number of milliseconds between invocations of the
+        # wrapped synchronizer.
+        attr_reader :interval
+
         # Public: Initializes a new interval synchronizer.
         #
         # synchronizer - The Synchronizer to call when the interval has passed.

--- a/lib/flipper/cloud/configuration.rb
+++ b/lib/flipper/cloud/configuration.rb
@@ -1,4 +1,6 @@
 require "flipper/adapters/http"
+require "flipper/adapters/memory"
+require "flipper/adapters/sync"
 require "flipper/instrumenters/noop"
 
 module Flipper
@@ -36,11 +38,21 @@ module Flipper
       #  configuration.instrumenter = ActiveSupport::Notifications
       attr_accessor :instrumenter
 
+      # Public: Local adapter that all reads should go to in order to ensure
+      # latency is low and resiliency is high. This adapter is automatically
+      # kept in sync with cloud.
+      #
+      #  # for example, to use active record you could do:
+      #  configuration = Flipper::Cloud::Configuration.new
+      #  configuration.local_adapter = Flipper::Adapters::ActiveRecord.new
+      attr_accessor :local_adapter
+
       def initialize(options = {})
         @token = options.fetch(:token)
         @instrumenter = options.fetch(:instrumenter, Instrumenters::Noop)
         @read_timeout = options.fetch(:read_timeout, 5)
         @open_timeout = options.fetch(:open_timeout, 5)
+        @local_adapter = options.fetch(:local_adapter) { Adapters::Memory.new }
         @debug_output = options[:debug_output]
         @adapter_block = ->(adapter) { adapter }
 
@@ -48,7 +60,7 @@ module Flipper
       end
 
       # Public: Read or customize the http adapter. Calling without a block will
-      # perform a read. Calling with a block yields the http_adapter
+      # perform a read. Calling with a block yields the cloud adapter
       # for customization.
       #
       #   # for example, to instrument the http calls, you can wrap the http
@@ -62,23 +74,30 @@ module Flipper
         if block_given?
           @adapter_block = block
         else
-          @adapter_block.call(http_adapter)
+          @adapter_block.call sync_adapter
         end
       end
 
-      # Public: Set url and uri for the http adapter.
+      # Public: Set url for the http adapter.
       attr_writer :url
 
       private
 
+      def sync_adapter
+        Flipper::Adapters::Sync.new(local_adapter, http_adapter, instrumenter: instrumenter)
+      end
+
       def http_adapter
-        Flipper::Adapters::Http.new(url: @url,
-                                    read_timeout: @read_timeout,
-                                    open_timeout: @open_timeout,
-                                    debug_output: @debug_output,
-                                    headers: {
-                                      "Feature-Flipper-Token" => @token,
-                                    })
+        http_options = {
+          url: @url,
+          read_timeout: @read_timeout,
+          open_timeout: @open_timeout,
+          debug_output: @debug_output,
+          headers: {
+            "Feature-Flipper-Token" => @token,
+          },
+        }
+        Flipper::Adapters::Http.new(http_options)
       end
     end
   end

--- a/spec/flipper/cloud/configuration_spec.rb
+++ b/spec/flipper/cloud/configuration_spec.rb
@@ -34,11 +34,17 @@ RSpec.describe Flipper::Cloud::Configuration do
   end
 
   it "defaults adapter block" do
+    # The initial sync of http to local invokes this web request.
+    stub_request(:get, /featureflipper\.com/).to_return(status: 200, body: "{}")
+
     instance = described_class.new(required_options)
-    expect(instance.adapter).to be_instance_of(Flipper::Adapters::Http)
+    expect(instance.adapter).to be_instance_of(Flipper::Adapters::Sync)
   end
 
   it "can override adapter block" do
+    # The initial sync of http to local invokes this web request.
+    stub_request(:get, /featureflipper\.com/).to_return(status: 200, body: "{}")
+
     instance = described_class.new(required_options)
     instance.adapter do |adapter|
       Flipper::Adapters::Instrumented.new(adapter)

--- a/spec/flipper/cloud/configuration_spec.rb
+++ b/spec/flipper/cloud/configuration_spec.rb
@@ -28,6 +28,19 @@ RSpec.describe Flipper::Cloud::Configuration do
     expect(instance.open_timeout).to eq(5)
   end
 
+  it "can set sync_interval" do
+    instance = described_class.new(required_options.merge(sync_interval: 1_000))
+    expect(instance.sync_interval).to eq(1_000)
+  end
+
+  it "passes sync_interval into sync adapter" do
+    # The initial sync of http to local invokes this web request.
+    stub_request(:get, /featureflipper\.com/).to_return(status: 200, body: "{}")
+
+    instance = described_class.new(required_options.merge(sync_interval: 1_000))
+    expect(instance.adapter.synchronizer.interval).to be(1_000)
+  end
+
   it "can set debug_output" do
     instance = described_class.new(required_options.merge(debug_output: STDOUT))
     expect(instance.debug_output).to eq(STDOUT)

--- a/spec/flipper/cloud_spec.rb
+++ b/spec/flipper/cloud_spec.rb
@@ -4,13 +4,18 @@ require 'flipper/adapters/instrumented'
 require 'flipper/instrumenters/memory'
 
 RSpec.describe Flipper::Cloud do
+  before do
+    stub_request(:get, /featureflipper\.com/).to_return(status: 200, body: "{}")
+  end
+
   context "initialize with token" do
     let(:token) { 'asdf' }
 
     before do
       @instance = described_class.new(token)
       memoized_adapter = @instance.adapter
-      @http_adapter = memoized_adapter.adapter
+      sync_adapter = memoized_adapter.adapter
+      @http_adapter = sync_adapter.instance_variable_get('@remote')
       @http_client = @http_adapter.instance_variable_get('@client')
     end
 
@@ -41,9 +46,12 @@ RSpec.describe Flipper::Cloud do
 
   context 'initialize with token and options' do
     before do
+      stub_request(:get, /fakeflipper\.com/).to_return(status: 200, body: "{}")
+
       @instance = described_class.new('asdf', url: 'https://www.fakeflipper.com/sadpanda')
       memoized_adapter = @instance.adapter
-      @http_adapter = memoized_adapter.adapter
+      sync_adapter = memoized_adapter.adapter
+      @http_adapter = sync_adapter.instance_variable_get('@remote')
       @http_client = @http_adapter.instance_variable_get('@client')
     end
 

--- a/spec/flipper/cloud_spec.rb
+++ b/spec/flipper/cloud_spec.rb
@@ -1,6 +1,7 @@
 require 'helper'
 require 'flipper/cloud'
 require 'flipper/adapters/instrumented'
+require 'flipper/instrumenters/memory'
 
 RSpec.describe Flipper::Cloud do
   context "initialize with token" do
@@ -55,7 +56,7 @@ RSpec.describe Flipper::Cloud do
   end
 
   it 'can set instrumenter' do
-    instrumenter = Object.new
+    instrumenter = Flipper::Instrumenters::Memory.new
     instance = described_class.new('asdf', instrumenter: instrumenter)
     expect(instance.instrumenter).to be(instrumenter)
   end


### PR DESCRIPTION
This uses the sync adapter for cloud. It allows people to set a local adapter to keep in sync with remote. The default is in memory which is similar to using the active support in memory caching that we were recommending for cloud. The primary difference is that this is resilient to cloud being unavailable because exceptions are rescued and the local is persisted across restarts (assuming you are using active record, redis, mongo, or whatever instead of the default memory adapter). It also persists longer because the in memory cache expires, but this does not.