### PR TITLE
Change sync_interval to seconds

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -1,3 +1,7 @@
+## master
+
+* Changed sync_interval to be seconds instead of milliseconds.
+
 ## 0.13.0
 
 ### Additions/Changes

--- a/examples/cloud/local_adapter.rb
+++ b/examples/cloud/local_adapter.rb
@@ -22,7 +22,7 @@ Flipper.configure do |config|
     Flipper::Cloud.new(token) do |cloud|
       cloud.debug_output = STDOUT
       cloud.local_adapter = Flipper::Adapters::Redis.new(redis)
-      cloud.sync_interval = 10_000
+      cloud.sync_interval = 10
     end
   end
 end

--- a/lib/flipper/adapters/sync.rb
+++ b/lib/flipper/adapters/sync.rb
@@ -20,8 +20,8 @@ module Flipper
       # local - The local flipper adapter that should serve reads.
       # remote - The remote flipper adpater that should serve writes and update
       #          the local on an interval.
-      # interval - The number of milliseconds between syncs from remote to
-      #            local. Default value is set in IntervalSynchronizer.
+      # interval - The Float or Integer number of seconds between syncs from
+      # remote to local. Default value is set in IntervalSynchronizer.
       def initialize(local, remote, options = {})
         @name = :sync
         @local = local

--- a/lib/flipper/adapters/sync/interval_synchronizer.rb
+++ b/lib/flipper/adapters/sync/interval_synchronizer.rb
@@ -12,8 +12,8 @@ module Flipper
           Process.clock_gettime(Process::CLOCK_MONOTONIC, :millisecond)
         end
 
-        # Public: The number of milliseconds between invocations of the
-        # wrapped synchronizer.
+        # Public: The Float or Integer number of seconds between invocations of
+        # the wrapped synchronizer.
         attr_reader :interval
 
         # Public: Initializes a new interval synchronizer.

--- a/lib/flipper/adapters/sync/interval_synchronizer.rb
+++ b/lib/flipper/adapters/sync/interval_synchronizer.rb
@@ -2,10 +2,10 @@ module Flipper
   module Adapters
     class Sync
       # Internal: Wraps a Synchronizer instance and only invokes it every
-      # N milliseconds.
+      # N seconds.
       class IntervalSynchronizer
-        # Private: Number of milliseconds between syncs (default: 10 seconds).
-        DEFAULT_INTERVAL_MS = 10_000
+        # Private: Number of seconds between syncs (default: 10).
+        DEFAULT_INTERVAL = 10
 
         # Private
         def self.now_ms
@@ -23,7 +23,7 @@ module Flipper
         #            the wrapped synchronizer.
         def initialize(synchronizer, interval: nil)
           @synchronizer = synchronizer
-          @interval = interval || DEFAULT_INTERVAL_MS
+          @interval = interval || DEFAULT_INTERVAL
           # TODO: add jitter to this so all processes booting at the same time
           # don't phone home at the same time.
           @last_sync_at = 0
@@ -41,7 +41,7 @@ module Flipper
         private
 
         def time_to_sync?
-          (now_ms - @last_sync_at) >= @interval
+          ((now_ms - @last_sync_at) / 1_000.0) >= @interval
         end
 
         def now_ms

--- a/lib/flipper/cloud/configuration.rb
+++ b/lib/flipper/cloud/configuration.rb
@@ -47,8 +47,8 @@ module Flipper
       #  configuration.local_adapter = Flipper::Adapters::ActiveRecord.new
       attr_accessor :local_adapter
 
-      # Public: Number of milliseconds between attempts to bring the local in
-      # sync with cloud (default: 10_000 aka 10 seconds).
+      # Public: The Integer or Float number of seconds between attempts to bring
+      # the local in sync with cloud (default: 10).
       attr_accessor :sync_interval
 
       def initialize(options = {})
@@ -56,7 +56,7 @@ module Flipper
         @instrumenter = options.fetch(:instrumenter, Instrumenters::Noop)
         @read_timeout = options.fetch(:read_timeout, 5)
         @open_timeout = options.fetch(:open_timeout, 5)
-        @sync_interval = options.fetch(:sync_interval, 10_000)
+        @sync_interval = options.fetch(:sync_interval, 10)
         @local_adapter = options.fetch(:local_adapter) { Adapters::Memory.new }
         @debug_output = options[:debug_output]
         @adapter_block = ->(adapter) { adapter }

--- a/spec/flipper/adapters/sync/interval_synchronizer_spec.rb
+++ b/spec/flipper/adapters/sync/interval_synchronizer_spec.rb
@@ -14,20 +14,20 @@ RSpec.describe Flipper::Adapters::Sync::IntervalSynchronizer do
     expect(events.size).to be(1)
   end
 
-  it "only invokes wrapped synchronizer every interval milliseconds" do
+  it "only invokes wrapped synchronizer every interval seconds" do
     now = described_class.now_ms
     subject.call
     events.clear
 
     # move time to one millisecond less than last sync + interval
     1.upto(interval) do |i|
-      allow(described_class).to receive(:now_ms).and_return(now + i - 1)
+      allow(described_class).to receive(:now_ms).and_return(now + (i * 1_000) - 1)
       subject.call
     end
     expect(events.size).to be(0)
 
-    # move time to last sync + interval
-    allow(described_class).to receive(:now_ms).and_return(now + interval)
+    # move time to last sync + interval in milliseconds
+    allow(described_class).to receive(:now_ms).and_return(now + (interval * 1_000))
     subject.call
     expect(events.size).to be(1)
   end

--- a/spec/flipper/cloud/configuration_spec.rb
+++ b/spec/flipper/cloud/configuration_spec.rb
@@ -29,16 +29,16 @@ RSpec.describe Flipper::Cloud::Configuration do
   end
 
   it "can set sync_interval" do
-    instance = described_class.new(required_options.merge(sync_interval: 1_000))
-    expect(instance.sync_interval).to eq(1_000)
+    instance = described_class.new(required_options.merge(sync_interval: 1))
+    expect(instance.sync_interval).to eq(1)
   end
 
   it "passes sync_interval into sync adapter" do
     # The initial sync of http to local invokes this web request.
     stub_request(:get, /featureflipper\.com/).to_return(status: 200, body: "{}")
 
-    instance = described_class.new(required_options.merge(sync_interval: 1_000))
-    expect(instance.adapter.synchronizer.interval).to be(1_000)
+    instance = described_class.new(required_options.merge(sync_interval: 1))
+    expect(instance.adapter.synchronizer.interval).to be(1)
   end
 
   it "can set debug_output" do


### PR DESCRIPTION
No reason we can't use floats to represent milliseconds (e.g. 0.1 for 100ms). Smaller numbers are easier to deal with and every other number is seconds so having one in milliseconds is confusing.