### PR TITLE
Move Flipper::UI configuration options to Flipper::UI::Configuration

### DIFF
--- a/lib/flipper/errors.rb
+++ b/lib/flipper/errors.rb
@@ -29,4 +29,12 @@ module Flipper
       super(message || default)
     end
   end
+
+  # Raised when accessing a configuration property that has been deprecated
+  class ConfigurationDeprecated < Flipper::Error
+    def initialize(message = nil)
+      default = "The configuration property has been deprecated"
+      super(message || default)
+    end
+  end
 end

--- a/lib/flipper/ui.rb
+++ b/lib/flipper/ui.rb
@@ -17,26 +17,25 @@ require 'flipper/ui/configuration'
 module Flipper
   module UI
     class << self
-      # Public: If you set this, the UI will always have a first breadcrumb that
-      # says "App" which points to this href. The href can be a path (ie: "/")
-      # or full url ("https://app.example.com/").
-      attr_accessor :application_breadcrumb_href
+      # These three configuration options have been moved to Flipper::UI::Configuration
+      deprecated_configuration_options = %w(application_breadcrumb_href
+                                            feature_creation_enabled
+                                            feature_removal_enabled)
+      deprecated_configuration_options.each do |attribute_name|
+        send(:define_method, "#{attribute_name}=".to_sym) do
+          raise ConfigurationDeprecated, "The UI configuration for #{attribute_name} has " \
+            "deprecated. This configuration option has moved to Flipper::UI::Configuration"
+        end
 
-      # Public: Is feature creation allowed from the UI? Defaults to true. If
-      # set to false, users of the UI cannot create features. All feature
-      # creation will need to be done through the configured flipper instance.
-      attr_accessor :feature_creation_enabled
-
-      # Public: Is feature deletion allowed from the UI? Defaults to true. If
-      # set to false, users won't be able to delete features from the UI.
-      attr_accessor :feature_removal_enabled
+        send(:define_method, attribute_name.to_sym) do
+          raise ConfigurationDeprecated, "The UI configuration for #{attribute_name} has " \
+            "deprecated. This configuration option has moved to Flipper::UI::Configuration"
+        end
+      end
 
       # Public: Set attributes on this instance to customize UI text
       attr_reader :configuration
     end
-
-    self.feature_creation_enabled = true
-    self.feature_removal_enabled = true
 
     def self.root
       @root ||= Pathname(__FILE__).dirname.expand_path.join('ui')

--- a/lib/flipper/ui/action.rb
+++ b/lib/flipper/ui/action.rb
@@ -65,8 +65,8 @@ module Flipper
         @code = 200
         @headers = { 'Content-Type' => 'text/plain' }
         @breadcrumbs =
-          if Flipper::UI.application_breadcrumb_href
-            [Breadcrumb.new('App', Flipper::UI.application_breadcrumb_href)]
+          if Flipper::UI.configuration.application_breadcrumb_href
+            [Breadcrumb.new('App', Flipper::UI.configuration.application_breadcrumb_href)]
           else
             []
           end

--- a/lib/flipper/ui/actions/add_feature.rb
+++ b/lib/flipper/ui/actions/add_feature.rb
@@ -8,7 +8,7 @@ module Flipper
         route %r{features/new/?\Z}
 
         def get
-          unless Flipper::UI.feature_creation_enabled
+          unless Flipper::UI.configuration.feature_creation_enabled
             status 403
 
             breadcrumb 'Home', '/'

--- a/lib/flipper/ui/actions/feature.rb
+++ b/lib/flipper/ui/actions/feature.rb
@@ -21,7 +21,7 @@ module Flipper
         end
 
         def delete
-          unless Flipper::UI.feature_removal_enabled
+          unless Flipper::UI.configuration.feature_removal_enabled
             status 403
 
             breadcrumb 'Home', '/'

--- a/lib/flipper/ui/actions/features.rb
+++ b/lib/flipper/ui/actions/features.rb
@@ -23,7 +23,7 @@ module Flipper
         end
 
         def post
-          unless Flipper::UI.feature_creation_enabled
+          unless Flipper::UI.configuration.feature_creation_enabled
             status 403
 
             breadcrumb 'Home', '/'

--- a/lib/flipper/ui/configuration.rb
+++ b/lib/flipper/ui/configuration.rb
@@ -12,6 +12,20 @@ module Flipper
       attr_accessor :banner_text,
                     :banner_class
 
+      # Public: If you set this, the UI will always have a first breadcrumb that
+      # says "App" which points to this href. The href can be a path (ie: "/")
+      # or full url ("https://app.example.com/").
+      attr_accessor :application_breadcrumb_href
+
+      # Public: Is feature creation allowed from the UI? Defaults to true. If
+      # set to false, users of the UI cannot create features. All feature
+      # creation will need to be done through the configured flipper instance.
+      attr_accessor :feature_creation_enabled
+
+      # Public: Is feature deletion allowed from the UI? Defaults to true. If
+      # set to false, users won't be able to delete features from the UI.
+      attr_accessor :feature_removal_enabled
+
       VALID_BANNER_CLASS_VALUES = %w(
         danger
         dark
@@ -31,6 +45,8 @@ module Flipper
         @delete = Option.new("Danger Zone", "Deleting a feature removes it from the list of features and disables it for everyone.") # rubocop:disable Metrics/LineLength
         @banner_text = nil
         @banner_class = 'danger'
+        @feature_creation_enabled = true
+        @feature_removal_enabled = true
       end
 
       def banner_class=(value)

--- a/lib/flipper/ui/views/feature.erb
+++ b/lib/flipper/ui/views/feature.erb
@@ -229,7 +229,7 @@
     </div>
   </div>
 
-  <% if Flipper::UI.feature_removal_enabled %>
+  <% if Flipper::UI.configuration.feature_removal_enabled %>
   <div class="row">
     <div class="col">
       <div class="card border-danger">

--- a/lib/flipper/ui/views/feature_creation_disabled.erb
+++ b/lib/flipper/ui/views/feature_creation_disabled.erb
@@ -1,3 +1,3 @@
 <div class="alert alert-danger">
-  Feature creation is disabled. To enable, you'll need to set <code>Flipper::UI.feature_creation_enabled = true</code> wherever flipper is running from.
+  Feature creation is disabled. To enable, you'll need to set <code>Flipper::UI.configuration.feature_creation_enabled = true</code> wherever flipper is running from.
 </div>

--- a/lib/flipper/ui/views/feature_removal_disabled.erb
+++ b/lib/flipper/ui/views/feature_removal_disabled.erb
@@ -1,3 +1,3 @@
 <div class="alert alert-danger">
-  Feature removal from the UI is disabled. To enable, you'll need to set <code>Flipper::UI.feature_removal_enabled = true</code> wherever flipper is running from.
+  Feature removal from the UI is disabled. To enable, you'll need to set <code>Flipper::UI.configuration.feature_removal_enabled = true</code> wherever flipper is running from.
 </div>

--- a/lib/flipper/ui/views/layout.erb
+++ b/lib/flipper/ui/views/layout.erb
@@ -35,7 +35,7 @@
             </li>
           <% end %>
           <li class="ml-auto">
-            <%- if Flipper::UI.feature_creation_enabled -%>
+            <%- if Flipper::UI.configuration.feature_creation_enabled -%>
               <a class="btn btn-sm btn-light" href="<%= script_name %>/features/new">Add Feature</a>
             <%- end -%>
           </li>

--- a/spec/flipper/ui/actions/add_feature_spec.rb
+++ b/spec/flipper/ui/actions/add_feature_spec.rb
@@ -3,13 +3,13 @@ require 'helper'
 RSpec.describe Flipper::UI::Actions::AddFeature do
   describe 'GET /features/new with feature_creation_enabled set to true' do
     before do
-      @original_feature_creation_enabled = Flipper::UI.feature_creation_enabled
-      Flipper::UI.feature_creation_enabled = true
+      @original_feature_creation_enabled = Flipper::UI.configuration.feature_creation_enabled
+      Flipper::UI.configuration.feature_creation_enabled = true
       get '/features/new'
     end
 
     after do
-      Flipper::UI.feature_creation_enabled = @original_feature_creation_enabled
+      Flipper::UI.configuration.feature_creation_enabled = @original_feature_creation_enabled
     end
 
     it 'responds with success' do
@@ -24,13 +24,13 @@ RSpec.describe Flipper::UI::Actions::AddFeature do
 
   describe 'GET /features/new with feature_creation_enabled set to false' do
     before do
-      @original_feature_creation_enabled = Flipper::UI.feature_creation_enabled
-      Flipper::UI.feature_creation_enabled = false
+      @original_feature_creation_enabled = Flipper::UI.configuration.feature_creation_enabled
+      Flipper::UI.configuration.feature_creation_enabled = false
       get '/features/new'
     end
 
     after do
-      Flipper::UI.feature_creation_enabled = @original_feature_creation_enabled
+      Flipper::UI.configuration.feature_creation_enabled = @original_feature_creation_enabled
     end
 
     it 'returns 403' do

--- a/spec/flipper/ui/actions/feature_spec.rb
+++ b/spec/flipper/ui/actions/feature_spec.rb
@@ -32,11 +32,11 @@ RSpec.describe Flipper::UI::Actions::Feature do
     context 'when feature_removal_enabled is set to false' do
       around do |example|
         begin
-          @original_feature_removal_enabled = Flipper::UI.feature_removal_enabled
-          Flipper::UI.feature_removal_enabled = false
+          @original_feature_removal_enabled = Flipper::UI.configuration.feature_removal_enabled
+          Flipper::UI.configuration.feature_removal_enabled = false
           example.run
         ensure
-          Flipper::UI.feature_removal_enabled = @original_feature_removal_enabled
+          Flipper::UI.configuration.feature_removal_enabled = @original_feature_removal_enabled
         end
       end
 

--- a/spec/flipper/ui/actions/features_spec.rb
+++ b/spec/flipper/ui/actions/features_spec.rb
@@ -33,15 +33,15 @@ RSpec.describe Flipper::UI::Actions::Features do
     let(:feature_name) { 'notifications_next' }
 
     before do
-      @original_feature_creation_enabled = Flipper::UI.feature_creation_enabled
-      Flipper::UI.feature_creation_enabled = feature_creation_enabled
+      @original_feature_creation_enabled = Flipper::UI.configuration.feature_creation_enabled
+      Flipper::UI.configuration.feature_creation_enabled = feature_creation_enabled
       post '/features',
            { 'value' => feature_name, 'authenticity_token' => token },
            'rack.session' => session
     end
 
     after do
-      Flipper::UI.feature_creation_enabled = @original_feature_creation_enabled
+      Flipper::UI.configuration.feature_creation_enabled = @original_feature_creation_enabled
     end
 
     context 'feature_creation_enabled set to true' do

--- a/spec/flipper/ui/configuration_spec.rb
+++ b/spec/flipper/ui/configuration_spec.rb
@@ -69,4 +69,37 @@ RSpec.describe Flipper::UI::Configuration do
         .to raise_error(Flipper::InvalidConfigurationValue)
     end
   end
+
+  describe "#application_breadcrumb_href" do
+    it "has default value" do
+      expect(configuration.application_breadcrumb_href).to eq(nil)
+    end
+
+    it "can be updated" do
+      configuration.application_breadcrumb_href = 'http://www.myapp.com'
+      expect(configuration.application_breadcrumb_href).to eq('http://www.myapp.com')
+    end
+  end
+
+  describe "#feature_creation_enabled" do
+    it "has default value" do
+      expect(configuration.feature_creation_enabled).to eq(true)
+    end
+
+    it "can be updated" do
+      configuration.feature_creation_enabled = false
+      expect(configuration.feature_creation_enabled).to eq(false)
+    end
+  end
+
+  describe "#feature_removal_enabled" do
+    it "has default value" do
+      expect(configuration.feature_removal_enabled).to eq(true)
+    end
+
+    it "can be updated" do
+      configuration.feature_removal_enabled = false
+      expect(configuration.feature_removal_enabled).to eq(false)
+    end
+  end
 end

--- a/spec/flipper/ui_spec.rb
+++ b/spec/flipper/ui_spec.rb
@@ -11,6 +11,7 @@ RSpec.describe Flipper::UI do
   let(:session) do
     { :csrf => token, 'csrf' => token, '_csrf_token' => token }
   end
+  let(:configuration) { described_class.configuration }
 
   describe 'Initializing middleware with flipper instance' do
     let(:app) { build_app(flipper) }
@@ -59,91 +60,24 @@ RSpec.describe Flipper::UI do
     expect(last_response.headers['Location']).to eq('/features/refactor-images')
   end
 
-  it 'does not have an application_breadcrumb_href by default' do
-    expect(described_class.application_breadcrumb_href).to be(nil)
-  end
-
-  context 'with application_breadcrumb_href not set' do
-    before do
-      @original_application_breadcrumb_href = described_class.application_breadcrumb_href
-      described_class.application_breadcrumb_href = nil
-    end
-
-    after do
-      described_class.application_breadcrumb_href = @original_application_breadcrumb_href
-    end
-
-    it 'does not add App breadcrumb' do
-      get '/features'
-      expect(last_response.body).not_to include('<a href="/myapp">App</a>')
+  describe "application_breadcrumb_href" do
+    it "raises an exception since it is deprecated" do
+      expect { described_class.application_breadcrumb_href }
+        .to raise_error(Flipper::ConfigurationDeprecated)
     end
   end
 
-  context 'with application_breadcrumb_href set' do
-    before do
-      @original_application_breadcrumb_href = described_class.application_breadcrumb_href
-      described_class.application_breadcrumb_href = '/myapp'
-    end
-
-    after do
-      described_class.application_breadcrumb_href = @original_application_breadcrumb_href
-    end
-
-    it 'does add App breadcrumb' do
-      get '/features'
-      expect(last_response.body).to include('<a href="/myapp">App</a>')
+  describe "feature_creation_enabled" do
+    it "raises an exception since it is deprecated" do
+      expect { described_class.feature_creation_enabled }
+        .to raise_error(Flipper::ConfigurationDeprecated)
     end
   end
 
-  context 'with application_breadcrumb_href set to full url' do
-    before do
-      @original_application_breadcrumb_href = described_class.application_breadcrumb_href
-      described_class.application_breadcrumb_href = 'https://myapp.com/'
-    end
-
-    after do
-      described_class.application_breadcrumb_href = @original_application_breadcrumb_href
-    end
-
-    it 'does add App breadcrumb' do
-      get '/features'
-      expect(last_response.body).to include('<a href="https://myapp.com/">App</a>')
-    end
-  end
-
-  it 'sets feature_creation_enabled to true by default' do
-    expect(described_class.feature_creation_enabled).to be(true)
-  end
-
-  context 'with feature_creation_enabled set to true' do
-    before do
-      @original_feature_creation_enabled = described_class.feature_creation_enabled
-      described_class.feature_creation_enabled = true
-    end
-
-    it 'has the add_feature button' do
-      get '/features'
-      expect(last_response.body).to include('Add Feature')
-    end
-
-    after do
-      described_class.feature_creation_enabled = @original_feature_creation_enabled
-    end
-  end
-
-  context 'with feature_creation_enabled set to false' do
-    before do
-      @original_feature_creation_enabled = described_class.feature_creation_enabled
-      described_class.feature_creation_enabled = false
-    end
-
-    it 'does not have the add_feature button' do
-      get '/features'
-      expect(last_response.body).not_to include('Add Feature')
-    end
-
-    after do
-      described_class.feature_creation_enabled = @original_feature_creation_enabled
+  describe "feature_removal_enabled" do
+    it "raises an exception since it is deprecated" do
+      expect { described_class.feature_removal_enabled }
+        .to raise_error(Flipper::ConfigurationDeprecated)
     end
   end
 
@@ -174,6 +108,136 @@ RSpec.describe Flipper::UI do
         it 'includes banner' do
           get '/features'
           expect(last_response.body).to include('Production Environment')
+        end
+      end
+    end
+
+    describe "application_breadcrumb_href" do
+      it 'does not have an application_breadcrumb_href by default' do
+        expect(configuration.application_breadcrumb_href).to be(nil)
+      end
+
+      context 'with application_breadcrumb_href not set' do
+        before do
+          @original_application_breadcrumb_href = configuration.application_breadcrumb_href
+          configuration.application_breadcrumb_href = nil
+        end
+
+        after do
+          configuration.application_breadcrumb_href = @original_application_breadcrumb_href
+        end
+
+        it 'does not add App breadcrumb' do
+          get '/features'
+          expect(last_response.body).not_to include('<a href="/myapp">App</a>')
+        end
+      end
+
+      context 'with application_breadcrumb_href set' do
+        before do
+          @original_application_breadcrumb_href = configuration.application_breadcrumb_href
+          configuration.application_breadcrumb_href = '/myapp'
+        end
+
+        after do
+          configuration.application_breadcrumb_href = @original_application_breadcrumb_href
+        end
+
+        it 'does add App breadcrumb' do
+          get '/features'
+          expect(last_response.body).to include('<a href="/myapp">App</a>')
+        end
+      end
+
+      context 'with application_breadcrumb_href set to full url' do
+        before do
+          @original_application_breadcrumb_href = configuration.application_breadcrumb_href
+          configuration.application_breadcrumb_href = 'https://myapp.com/'
+        end
+
+        after do
+          configuration.application_breadcrumb_href = @original_application_breadcrumb_href
+        end
+
+        it 'does add App breadcrumb' do
+          get '/features'
+          expect(last_response.body).to include('<a href="https://myapp.com/">App</a>')
+        end
+      end
+    end
+
+    describe "feature_creation_enabled" do
+      it 'sets feature_creation_enabled to true by default' do
+        expect(configuration.feature_creation_enabled).to be(true)
+      end
+
+      context 'with feature_creation_enabled set to true' do
+        before do
+          @original_feature_creation_enabled = configuration.feature_creation_enabled
+          configuration.feature_creation_enabled = true
+        end
+
+        it 'has the add_feature button' do
+          get '/features'
+          expect(last_response.body).to include('Add Feature')
+        end
+
+        after do
+          configuration.feature_creation_enabled = @original_feature_creation_enabled
+        end
+      end
+
+      context 'with feature_creation_enabled set to false' do
+        before do
+          @original_feature_creation_enabled = configuration.feature_creation_enabled
+          configuration.feature_creation_enabled = false
+        end
+
+        it 'does not have the add_feature button' do
+          get '/features'
+          expect(last_response.body).not_to include('Add Feature')
+        end
+
+        after do
+          configuration.feature_creation_enabled = @original_feature_creation_enabled
+        end
+      end
+    end
+
+    describe "feature_removal_enabled" do
+      it 'sets feature_removal_enabled to true by default' do
+        expect(configuration.feature_removal_enabled).to be(true)
+      end
+
+      context 'with feature_removal_enabled set to true' do
+        before do
+          @original_feature_removal_enabled = configuration.feature_removal_enabled
+          configuration.feature_removal_enabled = true
+        end
+
+        it 'has the add_feature button' do
+          get '/features/test'
+          expect(last_response.body).to include('Delete')
+        end
+
+        after do
+          configuration.feature_removal_enabled = @original_feature_removal_enabled
+        end
+      end
+
+      context 'with feature_removal_enabled set to false' do
+        before do
+          @original_feature_removal_enabled = configuration.feature_removal_enabled
+          configuration.feature_removal_enabled = false
+        end
+
+        it 'does not have the add_feature button' do
+          get '/features/test'
+          expect(last_response.body).not_to include('Delete')
+        end
+
+        after do
+          configuration.feature_removal_enabled = @original_feature_removal_enabled
         end
       end
     end


### PR DESCRIPTION
Resolves: https://github.com/jnunemaker/flipper/issues/326

Alex had the idea of linking to the docs to let the user know how to update the configuration, but I wasn't really sure what that would look like. I just mentioned in the exception that the configuration options moved to `Flipper::UI::Configure` which might be enough?

## Purpose
Now that Flipper::UI::Configuration exists, some configuration options on Flipper::UI should be moved over.

## Notable Changes
- Moved attribute_breadcrumb_href, feature_creation_enabled, and feature_removal_enabled from Flipper::UI to Flipper::UI::Configuration
- Deprecate the values on Flipper::UI by raising an exception