### PR TITLE
Sync Fix

### DIFF
--- a/lib/flipper/adapter.rb
+++ b/lib/flipper/adapter.rb
@@ -43,7 +43,7 @@ module Flipper
     #
     # Returns result of Synchronizer#call.
     def import(source_adapter)
-      Adapters::Sync::Synchronizer.new(self, source_adapter).call
+      Adapters::Sync::Synchronizer.new(self, source_adapter, raise: true).call
     end
 
     # Public: Default config for a feature's gate values.

--- a/lib/flipper/adapter.rb
+++ b/lib/flipper/adapter.rb
@@ -1,3 +1,5 @@
+require "flipper/adapters/sync/synchronizer"
+
 module Flipper
   # Adding a module include so we have some hooks for stuff down the road
   module Adapter
@@ -37,55 +39,16 @@ module Flipper
       result
     end
 
-    # Public: Wipe features and gate values and then import features and gate
-    # values from provided adapter.
+    # Public: Ensure that adapter is in sync with source adapter provided.
     #
-    # Returns nothing.
+    # Returns result of Synchronizer#call.
     def import(source_adapter)
-      wipe
-      copy_features_and_gates(source_adapter)
-      nil
+      Adapters::Sync::Synchronizer.new(self, source_adapter).call
     end
 
     # Public: Default config for a feature's gate values.
     def default_config
       self.class.default_config
-    end
-
-    private
-
-    # Private: Copy source adapter features and gate values into self.
-    def copy_features_and_gates(source_adapter)
-      source_adapter.features.each do |key|
-        source_feature = Flipper::Feature.new(key, source_adapter)
-        destination_feature = Flipper::Feature.new(key, self)
-
-        case source_feature.state
-        when :on
-          destination_feature.enable
-        when :conditional
-          source_feature.groups_value.each do |value|
-            destination_feature.enable_group(value)
-          end
-
-          source_feature.actors_value.each do |value|
-            destination_feature.enable_actor(Flipper::Actor.new(value))
-          end
-
-          destination_feature.enable_percentage_of_actors(source_feature.percentage_of_actors_value)
-          destination_feature.enable_percentage_of_time(source_feature.percentage_of_time_value)
-        when :off
-          destination_feature.add
-        end
-      end
-    end
-
-    # Private: Completely wipe adapter features and gate values.
-    def wipe
-      features.each do |key|
-        feature = Flipper::Feature.new(key, self)
-        remove(feature)
-      end
     end
   end
 end

--- a/lib/flipper/adapters/rollout.rb
+++ b/lib/flipper/adapters/rollout.rb
@@ -56,14 +56,6 @@ module Flipper
         }
       end
 
-      def get_multi(_features)
-        raise AdapterMethodNotSupportedError
-      end
-
-      def get_all
-        raise AdapterMethodNotSupportedError
-      end
-
       def add(_feature)
         raise AdapterMethodNotSupportedError
       end

--- a/lib/flipper/adapters/sync.rb
+++ b/lib/flipper/adapters/sync.rb
@@ -27,8 +27,10 @@ module Flipper
         @local = local
         @remote = remote
         @synchronizer = options.fetch(:synchronizer) do
+          sync_options = {
+            raise: false,
+          }
           instrumenter = options[:instrumenter]
-          sync_options = {}
           sync_options[:instrumenter] = instrumenter if instrumenter
           synchronizer = Synchronizer.new(@local, @remote, sync_options)
           IntervalSynchronizer.new(synchronizer, interval: options[:interval])

--- a/lib/flipper/adapters/sync/feature_synchronizer.rb
+++ b/lib/flipper/adapters/sync/feature_synchronizer.rb
@@ -39,6 +39,7 @@ module Flipper
             return if local_boolean_enabled?
             @feature.enable
           else
+            @feature.disable if local_boolean_enabled?
             sync_actors
             sync_groups
             sync_percentage_of_actors

--- a/lib/flipper/adapters/sync/synchronizer.rb
+++ b/lib/flipper/adapters/sync/synchronizer.rb
@@ -20,6 +20,7 @@ module Flipper
           @local = local
           @remote = remote
           @instrumenter = options.fetch(:instrumenter, Instrumenters::Noop)
+          @raise = options.fetch(:raise, true)
         end
 
         # Public: Forces a sync.
@@ -53,6 +54,7 @@ module Flipper
           nil
         rescue => exception
           @instrumenter.instrument("synchronizer_exception.flipper", exception: exception)
+          raise if @raise
         end
       end
     end

--- a/lib/flipper/adapters/sync/synchronizer.rb
+++ b/lib/flipper/adapters/sync/synchronizer.rb
@@ -36,9 +36,15 @@ module Flipper
             FeatureSynchronizer.new(feature, local_gate_values, remote_gate_values).call
           end
 
-          # Add features that are missing
+          # Add features that are missing in local and present in remote.
           features_to_add = remote_get_all.keys - local_get_all.keys
           features_to_add.each { |key| Feature.new(key, @local).add }
+
+          # Remove features that are present in local and missing in remote.
+          features_to_remove = local_get_all.keys - remote_get_all.keys
+          features_to_remove.each { |key| Feature.new(key, @local).remove }
+
+          nil
         rescue => exception
           @instrumenter.instrument("synchronizer_exception.flipper", exception: exception)
         end

--- a/lib/flipper/adapters/sync/synchronizer.rb
+++ b/lib/flipper/adapters/sync/synchronizer.rb
@@ -6,15 +6,23 @@ require "flipper/adapters/sync/feature_synchronizer"
 module Flipper
   module Adapters
     class Sync
-      # Internal: Given a local and remote adapter, it can update the local to
+      # Public: Given a local and remote adapter, it can update the local to
       # match the remote doing only the necessary enable/disable operations.
       class Synchronizer
+        # Public: Initializes a new synchronizer.
+        #
+        # local - The Flipper adapter to get in sync with the remote.
+        # remote - The Flipper adapter that is source of truth that the local
+        #          adapter should be brought in line with.
+        # options - The Hash of options.
+        #           :instrumenter - The instrumenter used to instrument.
         def initialize(local, remote, options = {})
           @local = local
           @remote = remote
           @instrumenter = options.fetch(:instrumenter, Instrumenters::Noop)
         end
 
+        # Public: Forces a sync.
         def call
           @instrumenter.instrument("synchronizer_call.flipper") { sync }
         end
@@ -23,8 +31,6 @@ module Flipper
 
         def sync
           local_get_all = @local.get_all
-          # TODO: Move remote get all to background thread to minimize impact to
-          # whatever is happening in main thread.
           remote_get_all = @remote.get_all
 
           # Sync all the gate values.

--- a/lib/flipper/instrumenters/memory.rb
+++ b/lib/flipper/instrumenters/memory.rb
@@ -21,6 +21,18 @@ module Flipper
         @events << Event.new(name, payload, result)
         result
       end
+
+      def events_by_name(name)
+        @events.select { |event| event.name == name }
+      end
+
+      def event_by_name(name)
+        events_by_name(name).first
+      end
+
+      def reset
+        @events = []
+      end
     end
   end
 end

--- a/spec/flipper/adapters/rollout_spec.rb
+++ b/spec/flipper/adapters/rollout_spec.rb
@@ -126,16 +126,6 @@ RSpec.describe Flipper::Adapters::Rollout do
   end
 
   describe 'unsupported methods' do
-    it 'raises on get_multi' do
-      expect { source_adapter.get_multi([]) }
-        .to raise_error(Flipper::Adapters::Rollout::AdapterMethodNotSupportedError)
-    end
-
-    it 'raises on get_all' do
-      expect { source_adapter.get_all }
-        .to raise_error(Flipper::Adapters::Rollout::AdapterMethodNotSupportedError)
-    end
-
     it 'raises on add' do
       expect { source_adapter.add(:feature) }
         .to raise_error(Flipper::Adapters::Rollout::AdapterMethodNotSupportedError)

--- a/spec/flipper/adapters/sync/synchronizer_spec.rb
+++ b/spec/flipper/adapters/sync/synchronizer_spec.rb
@@ -39,17 +39,19 @@ RSpec.describe Flipper::Adapters::Sync::Synchronizer do
       expect(instrumenter.events_by_name("synchronizer_exception.flipper").size).to be(0)
     end
 
-    it 'can sync feature from one adapter to another' do
+    it 'syncs each remote feature to local' do
       remote_flipper.enable(:search)
+      remote_flipper.enable_percentage_of_time(:logging, 10)
 
       subject.call
       expect(instrumenter.events_by_name("synchronizer_exception.flipper").size).to be(0)
 
       expect(local_flipper[:search].boolean_value).to eq(true)
-      expect(local_flipper.features.map(&:key).sort).to eq(%w(search))
+      expect(local_flipper[:logging].percentage_of_time_value).to eq(10)
+      expect(local_flipper.features.map(&:key).sort).to eq(%w(logging search))
     end
 
-    it 'can sync features that have been added but their state is off' do
+    it 'adds features in remote that are not in local' do
       remote_flipper.add(:search)
 
       subject.call
@@ -58,85 +60,13 @@ RSpec.describe Flipper::Adapters::Sync::Synchronizer do
       expect(local_flipper.features.map(&:key)).to eq(["search"])
     end
 
-    it 'can sync multiple features' do
-      remote_flipper.enable(:yep)
-      remote_flipper.enable_group(:preview_features, :developers)
-      remote_flipper.enable_group(:preview_features, :marketers)
-      remote_flipper.enable_group(:preview_features, :company)
-      remote_flipper.enable_group(:preview_features, :early_access)
-      remote_flipper.enable_actor(:preview_features, Flipper::Actor.new('1'))
-      remote_flipper.enable_actor(:preview_features, Flipper::Actor.new('2'))
-      remote_flipper.enable_actor(:preview_features, Flipper::Actor.new('3'))
-      remote_flipper.enable_percentage_of_actors(:issues_next, 25)
-      remote_flipper.enable_percentage_of_time(:verbose_logging, 5)
-
-      subject.call
-      expect(instrumenter.events_by_name("synchronizer_exception.flipper").size).to be(0)
-
-      feature = local_flipper[:yep]
-      expect(feature.boolean_value).to be(true)
-      expect(feature.groups_value).to eq(Set[])
-      expect(feature.actors_value).to eq(Set[])
-      expect(feature.percentage_of_actors_value).to be(0)
-      expect(feature.percentage_of_time_value).to be(0)
-
-      feature = local_flipper[:preview_features]
-      expect(feature.boolean_value).to be(false)
-      expect(feature.actors_value).to eq(Set['1', '2', '3'])
-      expected_groups = Set['developers', 'marketers', 'company', 'early_access']
-      expect(feature.groups_value).to eq(expected_groups)
-      expect(feature.percentage_of_actors_value).to be(0)
-      expect(feature.percentage_of_time_value).to be(0)
-
-      feature = local_flipper[:issues_next]
-      expect(feature.boolean_value).to eq(false)
-      expect(feature.actors_value).to eq(Set.new)
-      expect(feature.groups_value).to eq(Set.new)
-      expect(feature.percentage_of_actors_value).to be(25)
-      expect(feature.percentage_of_time_value).to be(0)
-
-      feature = local_flipper[:verbose_logging]
-      expect(feature.boolean_value).to eq(false)
-      expect(feature.actors_value).to eq(Set.new)
-      expect(feature.groups_value).to eq(Set.new)
-      expect(feature.percentage_of_actors_value).to be(0)
-      expect(feature.percentage_of_time_value).to be(5)
-    end
-
-    it 'wipes existing enablements for adapter' do
-      local_flipper.enable(:stats)
-      local_flipper.enable_percentage_of_time(:verbose_logging, 5)
-      remote_flipper.enable_percentage_of_time(:stats, 5)
-      remote_flipper.enable_percentage_of_actors(:verbose_logging, 25)
-
-      subject.call
-      expect(instrumenter.events_by_name("synchronizer_exception.flipper").size).to be(0)
-
-      feature = local_flipper[:stats]
-      expect(feature.boolean_value).to be(false)
-      expect(feature.percentage_of_time_value).to be(5)
-
-      feature = local_flipper[:verbose_logging]
-      expect(feature.percentage_of_time_value).to be(0)
-      expect(feature.percentage_of_actors_value).to be(25)
-    end
-
-    it 'removes locally added features' do
+    it 'removes features in local that are not in remote' do
       local_flipper.add(:stats)
 
       subject.call
       expect(instrumenter.events_by_name("synchronizer_exception.flipper").size).to be(0)
 
       expect(local_flipper.features.map(&:key)).to eq([])
-    end
-
-    it 'disables locally enabled features' do
-      local_flipper.enable(:stats)
-
-      subject.call
-      expect(instrumenter.events_by_name("synchronizer_exception.flipper").size).to be(0)
-
-      expect(local_flipper[:stats]).to be_off
     end
   end
 end

--- a/spec/flipper/adapters/sync/synchronizer_spec.rb
+++ b/spec/flipper/adapters/sync/synchronizer_spec.rb
@@ -6,15 +6,17 @@ require "flipper/adapters/sync/synchronizer"
 RSpec.describe Flipper::Adapters::Sync::Synchronizer do
   let(:local) { Flipper::Adapters::Memory.new }
   let(:remote) { Flipper::Adapters::Memory.new }
+  let(:local_flipper) { Flipper.new(local) }
+  let(:remote_flipper) { Flipper.new(remote) }
   let(:instrumenter) { Flipper::Instrumenters::Memory.new }
 
   subject { described_class.new(local, remote, instrumenter: instrumenter) }
 
   it "instruments call" do
     subject.call
-    events = instrumenter.events.select do |event|
-      event.name == "synchronizer_call.flipper"
-    end
+    expect(instrumenter.events_by_name("synchronizer_exception.flipper").size).to be(0)
+
+    events = instrumenter.events_by_name("synchronizer_call.flipper")
     expect(events.size).to be(1)
   end
 
@@ -24,12 +26,117 @@ RSpec.describe Flipper::Adapters::Sync::Synchronizer do
 
     expect { subject.call }.not_to raise_error
 
-    events = instrumenter.events.select do |event|
-      event.name == "synchronizer_exception.flipper"
-    end
+    events = instrumenter.events_by_name("synchronizer_exception.flipper")
     expect(events.size).to be(1)
 
     event = events[0]
     expect(event.payload[:exception]).to eq(exception)
+  end
+
+  describe '#call' do
+    it 'returns nothing' do
+      expect(subject.call).to be(nil)
+      expect(instrumenter.events_by_name("synchronizer_exception.flipper").size).to be(0)
+    end
+
+    it 'can sync feature from one adapter to another' do
+      remote_flipper.enable(:search)
+
+      subject.call
+      expect(instrumenter.events_by_name("synchronizer_exception.flipper").size).to be(0)
+
+      expect(local_flipper[:search].boolean_value).to eq(true)
+      expect(local_flipper.features.map(&:key).sort).to eq(%w(search))
+    end
+
+    it 'can sync features that have been added but their state is off' do
+      remote_flipper.add(:search)
+
+      subject.call
+      expect(instrumenter.events_by_name("synchronizer_exception.flipper").size).to be(0)
+
+      expect(local_flipper.features.map(&:key)).to eq(["search"])
+    end
+
+    it 'can sync multiple features' do
+      remote_flipper.enable(:yep)
+      remote_flipper.enable_group(:preview_features, :developers)
+      remote_flipper.enable_group(:preview_features, :marketers)
+      remote_flipper.enable_group(:preview_features, :company)
+      remote_flipper.enable_group(:preview_features, :early_access)
+      remote_flipper.enable_actor(:preview_features, Flipper::Actor.new('1'))
+      remote_flipper.enable_actor(:preview_features, Flipper::Actor.new('2'))
+      remote_flipper.enable_actor(:preview_features, Flipper::Actor.new('3'))
+      remote_flipper.enable_percentage_of_actors(:issues_next, 25)
+      remote_flipper.enable_percentage_of_time(:verbose_logging, 5)
+
+      subject.call
+      expect(instrumenter.events_by_name("synchronizer_exception.flipper").size).to be(0)
+
+      feature = local_flipper[:yep]
+      expect(feature.boolean_value).to be(true)
+      expect(feature.groups_value).to eq(Set[])
+      expect(feature.actors_value).to eq(Set[])
+      expect(feature.percentage_of_actors_value).to be(0)
+      expect(feature.percentage_of_time_value).to be(0)
+
+      feature = local_flipper[:preview_features]
+      expect(feature.boolean_value).to be(false)
+      expect(feature.actors_value).to eq(Set['1', '2', '3'])
+      expected_groups = Set['developers', 'marketers', 'company', 'early_access']
+      expect(feature.groups_value).to eq(expected_groups)
+      expect(feature.percentage_of_actors_value).to be(0)
+      expect(feature.percentage_of_time_value).to be(0)
+
+      feature = local_flipper[:issues_next]
+      expect(feature.boolean_value).to eq(false)
+      expect(feature.actors_value).to eq(Set.new)
+      expect(feature.groups_value).to eq(Set.new)
+      expect(feature.percentage_of_actors_value).to be(25)
+      expect(feature.percentage_of_time_value).to be(0)
+
+      feature = local_flipper[:verbose_logging]
+      expect(feature.boolean_value).to eq(false)
+      expect(feature.actors_value).to eq(Set.new)
+      expect(feature.groups_value).to eq(Set.new)
+      expect(feature.percentage_of_actors_value).to be(0)
+      expect(feature.percentage_of_time_value).to be(5)
+    end
+
+    it 'wipes existing enablements for adapter' do
+      local_flipper.enable(:stats)
+      local_flipper.enable_percentage_of_time(:verbose_logging, 5)
+      remote_flipper.enable_percentage_of_time(:stats, 5)
+      remote_flipper.enable_percentage_of_actors(:verbose_logging, 25)
+
+      subject.call
+      expect(instrumenter.events_by_name("synchronizer_exception.flipper").size).to be(0)
+
+      feature = local_flipper[:stats]
+      expect(feature.boolean_value).to be(false)
+      expect(feature.percentage_of_time_value).to be(5)
+
+      feature = local_flipper[:verbose_logging]
+      expect(feature.percentage_of_time_value).to be(0)
+      expect(feature.percentage_of_actors_value).to be(25)
+    end
+
+    it 'removes locally added features' do
+      local_flipper.add(:stats)
+
+      subject.call
+      expect(instrumenter.events_by_name("synchronizer_exception.flipper").size).to be(0)
+
+      expect(local_flipper.features.map(&:key)).to eq([])
+    end
+
+    it 'disables locally enabled features' do
+      local_flipper.enable(:stats)
+
+      subject.call
+      expect(instrumenter.events_by_name("synchronizer_exception.flipper").size).to be(0)
+
+      expect(local_flipper[:stats]).to be_off
+    end
   end
 end

--- a/spec/flipper/adapters/sync_spec.rb
+++ b/spec/flipper/adapters/sync_spec.rb
@@ -194,4 +194,10 @@ RSpec.describe Flipper::Adapters::Sync do
     expect(subject).to receive(:sync)
     subject.get_all
   end
+
+  it 'does not raise sync exceptions' do
+    exception = StandardError.new
+    expect(remote_adapter).to receive(:get_all).and_raise(exception)
+    expect { subject.get_all }.not_to raise_error
+  end
 end


### PR DESCRIPTION
**Problem/Solution 1**: If a feature was enabled locally and remote it was disabled and then conditionally enabled (say for a single actor) the feature remained enabled locally. This PR ensures that the feature is disabled and then conditionally enabled since a feature cannot be fully enabled and conditionally enabled. 

**Problem/Solution 2**: Any features added to the local but not the remote were not removed after a sync. This PR makes sure they are removed so the features and gates are equivalent.

**Problem/Solution 3**: This also makes import use synchronizer since import and sync are the same. Previously, import would remove all features and then re-add what was needed. Now it only makes the changes that are necessary. It should make import faster as it only tweaks what it has to. It also makes import more idempotent in the event that it fails halfway through or whatever.