### PR TITLE
Switch to flippercloud.io for cloud domain

### DIFF
--- a/lib/flipper/cloud/configuration.rb
+++ b/lib/flipper/cloud/configuration.rb
@@ -7,9 +7,9 @@ module Flipper
   module Cloud
     class Configuration
       # The default url should be the one, the only, the website.
-      DEFAULT_URL = "https://www.featureflipper.com/adapter".freeze
+      DEFAULT_URL = "https://www.flippercloud.io/adapter".freeze
 
-      # Public: The token corresponding to an environment on featureflipper.com.
+      # Public: The token corresponding to an environment on flippercloud.io.
       attr_accessor :token
 
       # Public: The url for http adapter (default: Flipper::Cloud::DEFAULT_URL).

--- a/spec/flipper/cloud/configuration_spec.rb
+++ b/spec/flipper/cloud/configuration_spec.rb
@@ -35,7 +35,7 @@ RSpec.describe Flipper::Cloud::Configuration do
 
   it "passes sync_interval into sync adapter" do
     # The initial sync of http to local invokes this web request.
-    stub_request(:get, /featureflipper\.com/).to_return(status: 200, body: "{}")
+    stub_request(:get, /flippercloud\.io/).to_return(status: 200, body: "{}")
 
     instance = described_class.new(required_options.merge(sync_interval: 1))
     expect(instance.adapter.synchronizer.interval).to be(1)
@@ -48,7 +48,7 @@ RSpec.describe Flipper::Cloud::Configuration do
 
   it "defaults adapter block" do
     # The initial sync of http to local invokes this web request.
-    stub_request(:get, /featureflipper\.com/).to_return(status: 200, body: "{}")
+    stub_request(:get, /flippercloud\.io/).to_return(status: 200, body: "{}")
 
     instance = described_class.new(required_options)
     expect(instance.adapter).to be_instance_of(Flipper::Adapters::Sync)
@@ -56,7 +56,7 @@ RSpec.describe Flipper::Cloud::Configuration do
 
   it "can override adapter block" do
     # The initial sync of http to local invokes this web request.
-    stub_request(:get, /featureflipper\.com/).to_return(status: 200, body: "{}")
+    stub_request(:get, /flippercloud\.io/).to_return(status: 200, body: "{}")
 
     instance = described_class.new(required_options)
     instance.adapter do |adapter|

--- a/spec/flipper/cloud_spec.rb
+++ b/spec/flipper/cloud_spec.rb
@@ -5,7 +5,7 @@ require 'flipper/instrumenters/memory'
 
 RSpec.describe Flipper::Cloud do
   before do
-    stub_request(:get, /featureflipper\.com/).to_return(status: 200, body: "{}")
+    stub_request(:get, /flippercloud\.io/).to_return(status: 200, body: "{}")
   end
 
   context "initialize with token" do
@@ -30,7 +30,7 @@ RSpec.describe Flipper::Cloud do
     it 'sets up correct url' do
       uri = @http_client.instance_variable_get('@uri')
       expect(uri.scheme).to eq('https')
-      expect(uri.host).to eq('www.featureflipper.com')
+      expect(uri.host).to eq('www.flippercloud.io')
       expect(uri.path).to eq('/adapter')
     end
 


### PR DESCRIPTION
No biggie. I got tired of talking about Flipper Cloud and linking to featureflipper.com so I went for the io. Now they match.