### PR TITLE
Allow feature names to end with "features" in UI

### DIFF
--- a/lib/flipper/ui/middleware.rb
+++ b/lib/flipper/ui/middleware.rb
@@ -16,7 +16,6 @@ module Flipper
         @action_collection = ActionCollection.new
 
         # UI
-        @action_collection.add UI::Actions::Features
         @action_collection.add UI::Actions::AddFeature
         @action_collection.add UI::Actions::Feature
         @action_collection.add UI::Actions::ActorsGate
@@ -25,6 +24,7 @@ module Flipper
         @action_collection.add UI::Actions::PercentageOfTimeGate
         @action_collection.add UI::Actions::PercentageOfActorsGate
         @action_collection.add UI::Actions::Gate
+        @action_collection.add UI::Actions::Features
 
         # Static Assets/Files
         @action_collection.add UI::Actions::File

--- a/spec/flipper/api/v1/actions/feature_spec.rb
+++ b/spec/flipper/api/v1/actions/feature_spec.rb
@@ -109,6 +109,50 @@ RSpec.describe Flipper::Api::V1::Actions::Feature do
         expect(json_response).to eq(expected)
       end
     end
+
+    context 'feature with name that ends in "features"' do
+      before do
+        flipper[:search_features].enable
+        get '/features/search_features'
+      end
+
+      it 'responds with correct attributes' do
+        response_body = {
+          'key' => 'search_features',
+          'state' => 'on',
+          'gates' => [
+            {
+              'key' => 'boolean',
+              'name' => 'boolean',
+              'value' => 'true',
+            },
+            {
+              'key' => 'groups',
+              'name' => 'group',
+              'value' => [],
+            },
+            {
+              'key' => 'actors',
+              'name' => 'actor',
+              'value' => [],
+            },
+            {
+              'key' => 'percentage_of_actors',
+              'name' => 'percentage_of_actors',
+              'value' => nil,
+            },
+            {
+              'key' => 'percentage_of_time',
+              'name' => 'percentage_of_time',
+              'value' => nil,
+            },
+          ],
+        }
+
+        expect(last_response.status).to eq(200)
+        expect(json_response).to eq(response_body)
+      end
+    end
   end
 
   describe 'delete' do

--- a/spec/flipper/ui/actions/feature_spec.rb
+++ b/spec/flipper/ui/actions/feature_spec.rb
@@ -87,4 +87,24 @@ RSpec.describe Flipper::UI::Actions::Feature do
       expect(last_response.body).to include('Percentage of Actors')
     end
   end
+
+  describe 'GET /features/:feature with _features in feature name' do
+    before do
+      get '/features/search_features'
+    end
+
+    it 'responds with success' do
+      expect(last_response.status).to be(200)
+    end
+
+    it 'renders template' do
+      expect(last_response.body).to include('search_features')
+      expect(last_response.body).to include('Enable')
+      expect(last_response.body).to include('Disable')
+      expect(last_response.body).to include('Actors')
+      expect(last_response.body).to include('Groups')
+      expect(last_response.body).to include('Percentage of Time')
+      expect(last_response.body).to include('Percentage of Actors')
+    end
+  end
 end


### PR DESCRIPTION
Because of the order of the action classes, the features index route was picked. I put it last so now the feature actions will get picked prior to the list.

Fixes #352 