### PR TITLE
Reveal real boolean value for feature in UI

### DIFF
--- a/lib/flipper/ui/views/feature.erb
+++ b/lib/flipper/ui/views/feature.erb
@@ -14,7 +14,7 @@
         </h4>
         <div class="card-body">
           <p>
-            <% if @feature.on? %>
+            <% if @feature.boolean_value %>
               The feature is enabled for <strong>everyone</strong>. Disable this feature with one click.
             <% else %>
               Enable or disable this feature for <strong>everyone</strong> with one click.
@@ -24,7 +24,7 @@
           <form action="<%= script_name %>/features/<%= @feature.key %>/boolean" method="post">
             <%== csrf_input_tag %>
 
-            <% unless @feature.on? %>
+            <% unless @feature.boolean_value %>
               <button type="submit" name="action" value="Enable" class="btn btn-danger" data-toggle="tooltip" title="Enable for everyone">Enable</button>
             <% end %>
 


### PR DESCRIPTION
Before this change, enabling a feature for 100% of actors or time would hide the "Enable" action for the Boolean Gate. After this change, the boolean gate actions can be used independently of the current value of the other gates.

A feature being enabled for 100% actors is not necessarily the same as enabling it for "everyone", depending on how you configure your actors. In a typical scenario, users are actors. Enabling a feature for 100% actors would enable it for 100% *logged in* users. But `Flipper.enabled?(:my_feature)` would return false for logged out users.