### PR TITLE
Add changelog url to flipper.gemspec metadata

### DIFF
--- a/flipper-active_record.gemspec
+++ b/flipper-active_record.gemspec
@@ -1,5 +1,6 @@
 # -*- encoding: utf-8 -*-
 require File.expand_path('../lib/flipper/version', __FILE__)
+require File.expand_path('../lib/flipper/metadata', __FILE__)
 
 flipper_active_record_files = lambda do |file|
   file =~ /active_record/
@@ -22,6 +23,7 @@ Gem::Specification.new do |gem|
   gem.name          = 'flipper-active_record'
   gem.require_paths = ['lib']
   gem.version       = Flipper::VERSION
+  gem.metadata      = Flipper::METADATA
 
   gem.add_dependency 'flipper', "~> #{Flipper::VERSION}"
   gem.add_dependency 'activerecord', '>= 3.2', '< 6'

--- a/flipper-active_support_cache_store.gemspec
+++ b/flipper-active_support_cache_store.gemspec
@@ -1,5 +1,6 @@
 # -*- encoding: utf-8 -*-
 require File.expand_path('../lib/flipper/version', __FILE__)
+require File.expand_path('../lib/flipper/metadata', __FILE__)
 
 flipper_active_support_cache_store_files = lambda do |file|
   file =~ /active_support_cache_store/
@@ -18,6 +19,7 @@ Gem::Specification.new do |gem|
   gem.name          = 'flipper-active_support_cache_store'
   gem.require_paths = ['lib']
   gem.version       = Flipper::VERSION
+  gem.metadata      = Flipper::METADATA
 
   gem.add_dependency 'flipper', "~> #{Flipper::VERSION}"
   gem.add_dependency 'activesupport', '>= 3.2', '< 6'

--- a/flipper-api.gemspec
+++ b/flipper-api.gemspec
@@ -1,5 +1,6 @@
 # -*- encoding: utf-8 -*-
 require File.expand_path('../lib/flipper/version', __FILE__)
+require File.expand_path('../lib/flipper/metadata', __FILE__)
 
 flipper_api_files = lambda do |file|
   file =~ %r{(flipper)[\/-]api}
@@ -17,6 +18,7 @@ Gem::Specification.new do |gem|
   gem.name          = 'flipper-api'
   gem.require_paths = ['lib']
   gem.version       = Flipper::VERSION
+  gem.metadata      = Flipper::METADATA
 
   gem.add_dependency 'rack', '>= 1.4', '< 3'
   gem.add_dependency 'flipper', "~> #{Flipper::VERSION}"

--- a/flipper-cloud.gemspec
+++ b/flipper-cloud.gemspec
@@ -1,5 +1,6 @@
 # -*- encoding: utf-8 -*-
 require File.expand_path('../lib/flipper/version', __FILE__)
+require File.expand_path('../lib/flipper/metadata', __FILE__)
 
 flipper_cloud_files = lambda do |file|
   file =~ /cloud/
@@ -21,6 +22,7 @@ Gem::Specification.new do |gem|
   gem.name          = 'flipper-cloud'
   gem.require_paths = ['lib']
   gem.version       = Flipper::VERSION
+  gem.metadata      = Flipper::METADATA
 
   gem.add_dependency 'flipper', "~> #{Flipper::VERSION}"
 end

--- a/flipper-dalli.gemspec
+++ b/flipper-dalli.gemspec
@@ -1,5 +1,6 @@
 # -*- encoding: utf-8 -*-
 require File.expand_path('../lib/flipper/version', __FILE__)
+require File.expand_path('../lib/flipper/metadata', __FILE__)
 
 flipper_dalli_files = lambda do |file|
   file =~ /dalli/
@@ -18,6 +19,7 @@ Gem::Specification.new do |gem|
   gem.name          = 'flipper-dalli'
   gem.require_paths = ['lib']
   gem.version       = Flipper::VERSION
+  gem.metadata      = Flipper::METADATA
 
   gem.add_dependency 'flipper', "~> #{Flipper::VERSION}"
   gem.add_dependency 'dalli', '>= 2.0', '< 3'

--- a/flipper-mongo.gemspec
+++ b/flipper-mongo.gemspec
@@ -1,5 +1,6 @@
 # -*- encoding: utf-8 -*-
 require File.expand_path('../lib/flipper/version', __FILE__)
+require File.expand_path('../lib/flipper/metadata', __FILE__)
 
 flipper_mongo_files = lambda do |file|
   file =~ /mongo/
@@ -18,6 +19,7 @@ Gem::Specification.new do |gem|
   gem.name          = 'flipper-mongo'
   gem.require_paths = ['lib']
   gem.version       = Flipper::VERSION
+  gem.metadata      = Flipper::METADATA
 
   gem.add_dependency 'flipper', "~> #{Flipper::VERSION}"
   gem.add_dependency 'mongo', '~> 2.0'

--- a/flipper-redis.gemspec
+++ b/flipper-redis.gemspec
@@ -1,5 +1,6 @@
 # -*- encoding: utf-8 -*-
 require File.expand_path('../lib/flipper/version', __FILE__)
+require File.expand_path('../lib/flipper/metadata', __FILE__)
 
 flipper_redis_files = lambda do |file|
   file =~ /redis/
@@ -18,6 +19,7 @@ Gem::Specification.new do |gem|
   gem.name          = 'flipper-redis'
   gem.require_paths = ['lib']
   gem.version       = Flipper::VERSION
+  gem.metadata      = Flipper::METADATA
 
   gem.add_dependency 'flipper', "~> #{Flipper::VERSION}"
   gem.add_dependency 'redis', '>= 2.2', '< 4.1.0'

--- a/flipper-rollout.gemspec
+++ b/flipper-rollout.gemspec
@@ -1,5 +1,6 @@
 # -*- encoding: utf-8 -*-
 require File.expand_path('../lib/flipper/version', __FILE__)
+require File.expand_path('../lib/flipper/metadata', __FILE__)
 
 flipper_rollout_files = lambda do |file|
   file =~ /rollout/
@@ -18,6 +19,7 @@ Gem::Specification.new do |gem|
   gem.name          = 'flipper-rollout'
   gem.require_paths = ['lib']
   gem.version       = Flipper::VERSION
+  gem.metadata      = Flipper::METADATA
 
   gem.add_dependency 'flipper', "~> #{Flipper::VERSION}"
   gem.add_dependency 'redis', '>= 2.2', '< 4.1.0'

--- a/flipper-sequel.gemspec
+++ b/flipper-sequel.gemspec
@@ -1,5 +1,6 @@
 # -*- encoding: utf-8 -*-
 require File.expand_path('../lib/flipper/version', __FILE__)
+require File.expand_path('../lib/flipper/metadata', __FILE__)
 
 flipper_sequel_files = ->(file) { file =~ /sequel/ }
 
@@ -19,6 +20,7 @@ Gem::Specification.new do |gem|
   gem.name          = 'flipper-sequel'
   gem.require_paths = ['lib']
   gem.version       = Flipper::VERSION
+  gem.metadata      = Flipper::METADATA
 
   gem.add_dependency 'flipper', "~> #{Flipper::VERSION}"
   gem.add_dependency 'sequel', '>= 4.0.0', '< 5'

--- a/flipper-ui.gemspec
+++ b/flipper-ui.gemspec
@@ -1,5 +1,6 @@
 # -*- encoding: utf-8 -*-
 require File.expand_path('../lib/flipper/version', __FILE__)
+require File.expand_path('../lib/flipper/metadata', __FILE__)
 
 flipper_ui_files = lambda do |file|
   file =~ %r{(docs|examples|flipper)[\/-]ui}
@@ -18,6 +19,7 @@ Gem::Specification.new do |gem|
   gem.name          = 'flipper-ui'
   gem.require_paths = ['lib']
   gem.version       = Flipper::VERSION
+  gem.metadata      = Flipper::METADATA
 
   gem.add_dependency 'rack', '>= 1.4', '< 3'
   gem.add_dependency 'rack-protection', '>= 1.5.3', '< 2.1.0'

--- a/flipper.gemspec
+++ b/flipper.gemspec
@@ -1,5 +1,6 @@
 # -*- encoding: utf-8 -*-
 require File.expand_path('../lib/flipper/version', __FILE__)
+require File.expand_path('../lib/flipper/metadata', __FILE__)
 
 plugin_files = []
 plugin_test_files = []
@@ -34,4 +35,5 @@ Gem::Specification.new do |gem|
   gem.name          = 'flipper'
   gem.require_paths = ['lib']
   gem.version       = Flipper::VERSION
+  gem.metadata      = Flipper::METADATA
 end

--- a/lib/flipper/metadata.rb
+++ b/lib/flipper/metadata.rb
@@ -1,0 +1,5 @@
+module Flipper
+  METADATA = {
+    'changelog_uri' => 'https://github.com/jnunemaker/flipper/blob/master/Changelog.md',
+  }.freeze
+end


### PR DESCRIPTION
* gemspecs accept metadata for displaying links on RubyGems. This adds
a link to the changelog so RubyGems users can easily link to flipper's
changelog.

*would appear in links section*
<img width="204" alt="screen shot 2018-06-02 at 8 42 42 am" src="https://user-images.githubusercontent.com/3260042/40874785-aeee493c-6641-11e8-9bda-d52bf12e5853.png">

We could add a reference to this in say `module Flipper` (similar to `Flipper::VERSION`) and then add this to every adapter's .gemspec too. what do ya think?