### PR TITLE
Moneta adapter each feature as key

### DIFF
--- a/flipper-moneta.gemspec
+++ b/flipper-moneta.gemspec
@@ -20,5 +20,5 @@ Gem::Specification.new do |gem|
   gem.version       = Flipper::VERSION
 
   gem.add_dependency 'flipper', "~> #{Flipper::VERSION}"
-  gem.add_dependency 'moneta', '>= 0.7.19'
+  gem.add_dependency 'moneta', '>= 0.7.0', '<= 1.0.0'
 end

--- a/flipper-moneta.gemspec
+++ b/flipper-moneta.gemspec
@@ -1,0 +1,24 @@
+# -*- encoding: utf-8 -*-
+require File.expand_path('../lib/flipper/version', __FILE__)
+
+flipper_moneta_files = lambda do |file|
+  file =~ /moneta/
+end
+
+Gem::Specification.new do |gem|
+  gem.authors       = ['John Nunemaker']
+  gem.email         = ['nunemaker@gmail.com']
+  gem.summary       = 'Moneta adapter for Flipper'
+  gem.description   = 'Moneta adapter for Flipper'
+  gem.license       = 'MIT'
+  gem.homepage      = 'https://github.com/jnunemaker/flipper'
+
+  gem.files         = `git ls-files`.split("\n").select(&flipper_moneta_files) + ['lib/flipper/version.rb']
+  gem.test_files    = `git ls-files -- {test,spec,features}/*`.split("\n").select(&flipper_moneta_files)
+  gem.name          = 'flipper-moneta'
+  gem.require_paths = ['lib']
+  gem.version       = Flipper::VERSION
+
+  gem.add_dependency 'flipper', "~> #{Flipper::VERSION}"
+  gem.add_dependency 'moneta', '>= 0.7.19'
+end

--- a/lib/flipper/adapters/moneta.rb
+++ b/lib/flipper/adapters/moneta.rb
@@ -31,7 +31,7 @@ module Flipper
       # all the values for the feature.
       def remove(feature)
         moneta[FEATURES_KEY] = features.delete(feature.key.to_s)
-        moneta[key(feature.key)] = default_config
+        moneta.delete(key(feature.key))
         true
       end
 
@@ -46,24 +46,6 @@ module Flipper
       # Returns a Hash of Flipper::Gate#key => value.
       def get(feature)
         default_config.merge(moneta[key(feature.key)].to_h)
-      end
-
-      # Public
-      def get_multi(features)
-        result = {}
-        features.each do |feature|
-          result[feature.key] = get(feature)
-        end
-        result
-      end
-
-      # Public
-      def get_all
-        result = {}
-        moneta[FEATURES_KEY].each do |feature_key|
-          result[feature_key] = get(Feature.new(feature_key, self))
-        end
-        result
       end
 
       # Public: Enables a gate for a given thing.
@@ -97,7 +79,7 @@ module Flipper
       def disable(feature, gate, thing)
         case gate.data_type
         when :boolean
-          moneta[key(feature.key)] = default_config
+          clear(feature)
         when :integer
           result = get(feature)
           result[gate.key] = thing.value.to_s

--- a/lib/flipper/adapters/moneta.rb
+++ b/lib/flipper/adapters/moneta.rb
@@ -1,12 +1,11 @@
 require 'moneta'
-require 'pry'
 
 module Flipper
   module Adapters
     class Moneta
       include ::Flipper::Adapter
 
-      FEATURES_KEY = :features
+      FEATURES_KEY = :flipper_features
 
       # Public: The name of the adapter.
       attr_reader :name
@@ -17,97 +16,108 @@ module Flipper
         @name = :moneta
       end
 
+      # Public:  The set of known features
       def features
-        moneta[:features] || Set.new
+        moneta[FEATURES_KEY] || Set.new
       end
 
       # Public: Adds a feature to the set of known features.
       def add(feature)
-        moneta[:features] = moneta[:features] || Set.new
-        moneta[:features] = moneta[:features] << feature.key.to_s
+        moneta[FEATURES_KEY] = (moneta[FEATURES_KEY] || Set.new) << feature.key.to_s
         true
       end
 
       # Public: Removes a feature from the set of known features and clears
       # all the values for the feature.
       def remove(feature)
-        moneta[:features] = moneta[:features] || Set.new
-        features = moneta[:features]
+        features = moneta[FEATURES_KEY] || Set.new
         features.delete(feature.key.to_s)
-        moneta[:features] = features
-        moneta[feature.key] = default_config
+        moneta[FEATURES_KEY] = features
+        moneta[key(feature.key)] = default_config
         true
       end
 
       # Public: Clears all the gate values for a feature.
       def clear(feature)
-        moneta[feature.key] = default_config
+        moneta[key(feature.key)] = default_config
         true
       end
 
-      # Public
+      # Public: Gets the values for all gates for a given feature.
+      #
+      # Returns a Hash of Flipper::Gate#key => value.
       def get(feature)
-        moneta[feature.key] || default_config
-      end
-
-      def get_multi(features)
-        h = {}
-        features.each do |feature|
-          h[feature.key] = default_config.merge(moneta[feature.key].to_h)
-        end
-        h
-      end
-
-      def get_all
-        h = {}
-        moneta[:features].each do |feature_key|
-          h[feature_key] = default_config.merge(moneta[feature_key].to_h)
-        end
-        h
+        moneta[key(feature.key)] || default_config
       end
 
       # Public
+      def get_multi(features)
+        result = {}
+        features.each do |feature|
+          result[feature.key] = default_config.merge(moneta[key(feature.key)].to_h)
+        end
+        result
+      end
+
+      # Public
+      def get_all
+        result = {}
+        moneta[FEATURES_KEY].each do |feature_key|
+          result[feature_key] = default_config.merge(moneta[key(feature_key)].to_h)
+        end
+        result
+      end
+
+      # Public: Enables a gate for a given thing.
+      #
+      # feature - The Flipper::Feature for the gate.
+      # gate - The Flipper::Gate to disable.
+      # thing - The Flipper::Type being enabled for the gate.
+      #
+      # Returns true.
       def enable(feature, gate, thing)
         case gate.data_type
         when :boolean, :integer
-          the_feature = moneta[feature.key] || {}
-          the_feature[gate.key] = thing.value.to_s
-          moneta[feature.key] = the_feature
+          result = moneta[key(feature.key)] || {}
+          result[gate.key] = thing.value.to_s
+          moneta[key(feature.key)] = result
         when :set
-          the_feature = moneta[feature.key] || {}
-          if the_feature[gate.key]
-            the_feature[gate.key] << thing.value.to_s
-            moneta[feature.key] = the_feature
-          else
-            the_feature[gate.key] = Set.new
-            the_feature[gate.key] << thing.value.to_s
-            moneta[feature.key] = the_feature
-          end
+          result = moneta[key(feature.key)] || {}
+          result[gate.key] ||= Set.new
+          result[gate.key] << thing.value.to_s
+          moneta[key(feature.key)] = result
         end
         true
       end
 
-      # Public
+      # Public: Disables a gate for a given thing.
+      #
+      # feature - The Flipper::Feature for the gate.
+      # gate - The Flipper::Gate to disable.
+      # thing - The Flipper::Type being disabled for the gate.
+      #
+      # Returns true.
       def disable(feature, gate, thing)
-        #binding.pry if thing.value.to_s == 0.to_s
         case gate.data_type
         when :boolean
-          moneta[feature.key] = default_config
+          moneta[key(feature.key)] = default_config
         when :integer
-          the_feature = moneta[feature.key] || default_config
-          the_feature[gate.key] = thing.value.to_s
-          moneta[feature.key] = the_feature
+          result = moneta[key(feature.key)] || {}
+          result[gate.key] = thing.value.to_s
+          moneta[key(feature.key)] = result
         when :set
-          the_feature = moneta[feature.key]
-          if the_feature[gate.key]
-            the_feature[gate.key] = the_feature[gate.key].delete(thing.value.to_s)
-          end
-          moneta[feature.key] = the_feature
+          result = moneta[key(feature.key)]
+          result[gate.key] = result[gate.key].delete(thing.value.to_s) if result[gate.key]
+          moneta[key(feature.key)] = result
         end
         true
       end
 
       private
+
+      def key(feature_key)
+        "#{FEATURES_KEY}/#{feature_key}"
+      end
 
       attr_reader :moneta
     end

--- a/lib/flipper/adapters/moneta.rb
+++ b/lib/flipper/adapters/moneta.rb
@@ -1,0 +1,177 @@
+module Flipper
+  module Adapters
+    class Moneta
+      include ::Flipper::Adapter
+
+      FeaturesKey = :features
+
+      # Public: The name of the adapter.
+      attr_reader :name
+
+      # Public
+      def initialize(moneta)
+        @moneta = moneta
+        @name = :moneta
+      end
+
+      def features
+        read_feature_keys
+      end
+
+      # Public: Adds a feature to the set of known features.
+      def add(feature)
+        @moneta[FeaturesKey.to_s] ||= Set.new
+        @moneta[FeaturesKey.to_s] = @moneta[FeaturesKey.to_s].add(feature.key)
+        true
+      end
+
+      # Public: Removes a feature from the set of known features and clears
+      # all the values for the feature.
+      def remove(feature)
+        @moneta[FeaturesKey.to_s] ||= Set.new
+        @moneta[FeaturesKey.to_s] = @moneta[FeaturesKey.to_s].delete(feature.key)
+        clear(feature)
+        true
+      end
+
+      # Public: Clears all the gate values for a feature.
+      def clear(feature)
+        feature.gates.each do |gate|
+          delete key(feature, gate)
+        end
+        true
+      end
+
+      # Public
+      def get(feature)
+        read_feature(feature)
+      end
+
+      def get_multi(features)
+        read_many_features(features)
+      end
+
+      def get_all
+        features = read_feature_keys.map do |key|
+          Flipper::Feature.new(key, self)
+        end
+
+        read_many_features(features)
+      end
+
+      # Public
+      def enable(feature, gate, thing)
+        case gate.data_type
+        when :boolean, :integer
+          write key(feature, gate), thing.value.to_s
+        when :set
+          set_add key(feature, gate), thing.value.to_s
+        else
+          raise "#{gate} is not supported by this adapter yet"
+        end
+
+        true
+      end
+
+      # Public
+      def disable(feature, gate, thing)
+        case gate.data_type
+        when :boolean
+          clear(feature)
+        when :integer
+          write key(feature, gate), thing.value.to_s
+        when :set
+          set_delete key(feature, gate), thing.value.to_s
+        else
+          raise "#{gate} is not supported by this adapter yet"
+        end
+
+        true
+      end
+
+      # Public
+      def inspect
+        attributes = [
+          'name=:memory',
+          "source=#{@moneta.inspect}",
+        ]
+        "#<#{self.class.name}:#{object_id} #{attributes.join(', ')}>"
+      end
+
+      private
+
+      def read_feature_keys
+        set_members(FeaturesKey)
+      end
+
+      # Private
+      def key(feature, gate)
+        "feature/#{feature.key}/#{gate.key}"
+      end
+
+      def read_many_features(features)
+        result = {}
+        features.each do |feature|
+          result[feature.key] = read_feature(feature)
+        end
+        result
+      end
+
+      def read_feature(feature)
+        result = {}
+
+        feature.gates.each do |gate|
+          result[gate.key] =
+            case gate.data_type
+            when :boolean, :integer
+              read key(feature, gate)
+            when :set
+              set_members key(feature, gate)
+            else
+              raise "#{gate} is not supported by this adapter yet"
+            end
+        end
+
+        result
+      end
+
+      # Private
+      def read(key)
+        @moneta[key.to_s]
+      end
+
+      # Private
+      def write(key, value)
+        @moneta[key.to_s] = value.to_s
+      end
+
+      # Private
+      def delete(key)
+        @moneta.delete(key.to_s)
+      end
+
+      # Private
+      def set_add(key, value)
+        ensure_set_initialized(key)
+        @moneta[key.to_s] = @moneta[key.to_s].add(value.to_s)
+      end
+
+      # Private
+      def set_delete(key, value)
+        ensure_set_initialized(key)
+        @moneta[key.to_s] = @moneta[key.to_s].delete(value.to_s)
+      end
+
+      # Private
+      def set_members(key)
+        ensure_set_initialized(key)
+        @moneta[key.to_s]
+      end
+
+      # Private
+      def ensure_set_initialized(key)
+        @moneta[key.to_s] ||= Set.new
+      end
+    end
+  end
+end

--- a/spec/flipper/adapters/moneta_spec.rb
+++ b/spec/flipper/adapters/moneta_spec.rb
@@ -1,10 +1,9 @@
 require 'helper'
-require 'moneta'
 require 'flipper/adapters/moneta'
 require 'flipper/spec/shared_adapter_specs'
 
 RSpec.describe Flipper::Adapters::Moneta do
-  let(:moneta) {  Moneta.new(:Memory) }
+  let(:moneta) { Moneta.new(:Memory) }
   subject { described_class.new(moneta) }
 
   it_should_behave_like 'a flipper adapter'

--- a/spec/flipper/adapters/moneta_spec.rb
+++ b/spec/flipper/adapters/moneta_spec.rb
@@ -1,0 +1,11 @@
+require 'helper'
+require 'moneta'
+require 'flipper/adapters/moneta'
+require 'flipper/spec/shared_adapter_specs'
+
+RSpec.describe Flipper::Adapters::Moneta do
+  let(:moneta) {  Moneta.new(:Memory) }
+  subject { described_class.new(moneta) }
+
+  it_should_behave_like 'a flipper adapter'
+end


### PR DESCRIPTION
Adds Moneta adapter #307 

This is an improved PR over #330, where we're now optimizing for reads. Moneta has a Logging middleware that I used with a [simple script to log database accesses](https://gist.github.com/AlexWheeler/0a6562f3805db6c00e7931993a664017) and below are the results:

#330  (previous PR)
```
############### 3x enable(:feature) #####################

Moneta load("features") -> nil
Moneta store("features", #<Set: {"feature"}>) -> #<Set: {"feature"}>
Moneta load("feature/feature/actors") -> nil
Moneta store("feature/feature/actors", #<Set: {"1"}>) -> #<Set: {"1"}>
Moneta load("features") -> #<Set: {"feature"}>
Moneta store("features", #<Set: {"feature"}>) -> #<Set: {"feature"}>
Moneta load("feature/feature/actors") -> #<Set: {"1"}>
Moneta store("feature/feature/actors", #<Set: {"1", "2"}>) -> #<Set: {"1", "2"}>
Moneta load("features") -> #<Set: {"feature"}>
Moneta store("features", #<Set: {"feature"}>) -> #<Set: {"feature"}>
Moneta load("feature/feature/actors") -> #<Set: {"1", "2"}>
Moneta store("feature/feature/actors", #<Set: {"1", "2", "3"}>) -> #<Set: {"1", "2", "3"}>

############### feature.inspect #####################

Moneta load("feature/feature/boolean") -> nil
Moneta load("feature/feature/groups") -> nil
Moneta load("feature/feature/actors") -> #<Set: {"1", "2", "3"}>
Moneta load("feature/feature/percentage_of_...) -> nil
Moneta load("feature/feature/percentage_of_...) -> nil
Moneta load("feature/feature/boolean") -> nil
Moneta load("feature/feature/groups") -> nil
Moneta load("feature/feature/actors") -> #<Set: {"1", "2", "3"}>
Moneta load("feature/feature/percentage_of_...) -> nil
Moneta load("feature/feature/percentage_of_...) -> nil

############### feature.clear #######################

Moneta delete("feature/feature/boolean") -> nil
Moneta delete("feature/feature/groups") -> nil
Moneta delete("feature/feature/actors") -> #<Set: {"1", "2", "3"}>
Moneta delete("feature/feature/percentage_of_...) -> nil
Moneta delete("feature/feature/percentage_of_...) -> nil
```

This PR
```
############### 3x enable(:feature) #####################

Moneta load(:flipper_features) -> nil
Moneta store(:flipper_features, #<Set: {"feature"}>) -> #<Set: {"feature"}>
Moneta load("flipper_features/feature") -> nil
Moneta store("flipper_features/feature", {:boolean=>nil, :groups=>#<Set:...) -> {:boolean=>nil, :groups=>#<Set:...
Moneta load(:flipper_features) -> #<Set: {"feature"}>
Moneta store(:flipper_features, #<Set: {"feature"}>) -> #<Set: {"feature"}>
Moneta load("flipper_features/feature") -> {:boolean=>nil, :groups=>#<Set:...
Moneta store("flipper_features/feature", {:boolean=>nil, :groups=>#<Set:...) -> {:boolean=>nil, :groups=>#<Set:...
Moneta load(:flipper_features) -> #<Set: {"feature"}>
Moneta store(:flipper_features, #<Set: {"feature"}>) -> #<Set: {"feature"}>
Moneta load("flipper_features/feature") -> {:boolean=>nil, :groups=>#<Set:...
Moneta store("flipper_features/feature", {:boolean=>nil, :groups=>#<Set:...) -> {:boolean=>nil, :groups=>#<Set:...

############### feature.inspect #####################

Moneta load("flipper_features/feature") -> {:boolean=>nil, :groups=>#<Set:...
Moneta load("flipper_features/feature") -> {:boolean=>nil, :groups=>#<Set:...

############### feature.clear #######################

Moneta store("flipper_features/feature", {:boolean=>nil, :groups=>#<Set:...) -> {:boolean=>nil, :groups=>#<Set:...
```
*As you can see reads are much more performant!*

* keys are namespaced under `flipper_features`
`flipper[:name].enable` would store a `flipper_features/name` key in moneta to avoid a collision


would be cool to get some feedback on a few thoughts:

1. To store a value I'm using the `[]=(key, value)` method. The docs state that keys stored this way will never expire, however I set an expiration on the store and set a key this way with the Memory adapter and it did expire. I need to do a bit more reading...

2. there's a similar method to `[]=` called `create(key, value)` which creates an entry atomically.  Not all stores support it, but we could check if a store does support it and favor that over `[]=`.
```
if moneta.supports?(:create)
  moneta.create(key, value)
else
  moneta[key] = value
end
```
Was hoping it would just fallback to using `[]=`, but it looks like it [will raise an error if not supported](https://github.com/minad/moneta/blob/master/lib/moneta/mixins.rb#L240)

3. There's another method for adding keys `#store(key, value, options = {})`, which accepts options, one being `expires:` If users are using moneta as a cache they might want to set expiration on writes:
```
moneta.store(key, value, expires: 200)
```
So we could optionally accept options in the Moneta initializer and pass these onto the write methods, however it also seems that a moneta user can set an expiration on the store when they initialize their moneta instance so I believe it makes sense to just let them do that and not worry about passing options
