### PR TITLE
Re-order gates for improved performance (in some cases)

### DIFF
--- a/lib/flipper/feature.rb
+++ b/lib/flipper/feature.rb
@@ -335,10 +335,10 @@ module Flipper
     def gates
       @gates ||= [
         Gates::Boolean.new,
-        Gates::Group.new,
         Gates::Actor.new,
         Gates::PercentageOfActors.new,
         Gates::PercentageOfTime.new,
+        Gates::Group.new,
       ]
     end
 

--- a/spec/flipper/api/v1/actions/feature_spec.rb
+++ b/spec/flipper/api/v1/actions/feature_spec.rb
@@ -23,11 +23,6 @@ RSpec.describe Flipper::Api::V1::Actions::Feature do
               'value' => 'true',
             },
             {
-              'key' => 'groups',
-              'name' => 'group',
-              'value' => [],
-            },
-            {
               'key' => 'actors',
               'name' => 'actor',
               'value' => [],
@@ -41,6 +36,11 @@ RSpec.describe Flipper::Api::V1::Actions::Feature do
               'key' => 'percentage_of_time',
               'name' => 'percentage_of_time',
               'value' => nil,
+            },
+            {
+              'key' => 'groups',
+              'name' => 'group',
+              'value' => [],
             },
           ],
         }
@@ -67,11 +67,6 @@ RSpec.describe Flipper::Api::V1::Actions::Feature do
               'value' => nil,
             },
             {
-              'key' => 'groups',
-              'name' => 'group',
-              'value' => [],
-            },
-            {
               'key' => 'actors',
               'name' => 'actor',
               'value' => [],
@@ -85,6 +80,11 @@ RSpec.describe Flipper::Api::V1::Actions::Feature do
               'key' => 'percentage_of_time',
               'name' => 'percentage_of_time',
               'value' => nil,
+            },
+            {
+              'key' => 'groups',
+              'name' => 'group',
+              'value' => [],
             },
           ],
         }
@@ -127,11 +127,6 @@ RSpec.describe Flipper::Api::V1::Actions::Feature do
               'value' => 'true',
             },
             {
-              'key' => 'groups',
-              'name' => 'group',
-              'value' => [],
-            },
-            {
               'key' => 'actors',
               'name' => 'actor',
               'value' => [],
@@ -145,6 +140,11 @@ RSpec.describe Flipper::Api::V1::Actions::Feature do
               'key' => 'percentage_of_time',
               'name' => 'percentage_of_time',
               'value' => nil,
+            },
+            {
+              'key' => 'groups',
+              'name' => 'group',
+              'value' => [],
             },
           ],
         }

--- a/spec/flipper/api/v1/actions/features_spec.rb
+++ b/spec/flipper/api/v1/actions/features_spec.rb
@@ -26,11 +26,6 @@ RSpec.describe Flipper::Api::V1::Actions::Features do
                   'value' => 'true',
                 },
                 {
-                  'key' => 'groups',
-                  'name' => 'group',
-                  'value' => [],
-                },
-                {
                   'key' => 'actors',
                   'name' => 'actor',
                   'value' => ['10'],
@@ -44,6 +39,11 @@ RSpec.describe Flipper::Api::V1::Actions::Features do
                   'key' => 'percentage_of_time',
                   'name' => 'percentage_of_time',
                   'value' => nil,
+                },
+                {
+                  'key' => 'groups',
+                  'name' => 'group',
+                  'value' => [],
                 },
               ],
             },
@@ -121,11 +121,6 @@ RSpec.describe Flipper::Api::V1::Actions::Features do
               'value' => nil,
             },
             {
-              'key' => 'groups',
-              'name' => 'group',
-              'value' => [],
-            },
-            {
               'key' => 'actors',
               'name' => 'actor',
               'value' => [],
@@ -139,6 +134,11 @@ RSpec.describe Flipper::Api::V1::Actions::Features do
               'key' => 'percentage_of_time',
               'name' => 'percentage_of_time',
               'value' => nil,
+            },
+            {
+              'key' => 'groups',
+              'name' => 'group',
+              'value' => [],
             },
           ],
         }


### PR DESCRIPTION
Groups are likely the least performant gate since the others just do equality and inclusion checks. Groups could do other network calls or what not, so let's just re-order them to have groups gate last.

xref https://github.com/jnunemaker/flipper/issues/369