### PR TITLE
Remove require of rack body proxy

### DIFF
--- a/lib/flipper/middleware/memoizer.rb
+++ b/lib/flipper/middleware/memoizer.rb
@@ -1,5 +1,3 @@
-require 'rack/body_proxy'
-
 module Flipper
   module Middleware
     class Memoizer


### PR DESCRIPTION
This file is now required in the main flipper file. That makes it more convenient to use, but there are some projects that don't use rack. Having this require means that even though they don't use this, they need rack so the require won't fail. 

I see two choices. 

1. Make memoizer a separate gem with a rack dependency and a require.
2. Remove the require as this does which effectively only requires the dependency if you use this file. This makes it more like it was before when it was a separate require but avoids the separate require. If the code is executed in a request, rack is required for rack request and body proxy. If it is not used in a request it is not required. Should be fine.

fixes #373 