### PR TITLE
Unescapes feature_name in FeatureNameFromRoute

### DIFF
--- a/lib/flipper/api/action.rb
+++ b/lib/flipper/api/action.rb
@@ -10,7 +10,7 @@ module Flipper
         def feature_name
           @feature_name ||= begin
             match = request.path_info.match(self.class.route_regex)
-            match ? match[:feature_name] : nil
+            match ? Rack::Utils.unescape(match[:feature_name]) : nil
           end
         end
         private :feature_name

--- a/lib/flipper/ui/action.rb
+++ b/lib/flipper/ui/action.rb
@@ -10,7 +10,7 @@ module Flipper
         def feature_name
           @feature_name ||= begin
             match = request.path_info.match(self.class.route_regex)
-            match ? match[:feature_name] : nil
+            match ? Rack::Utils.unescape(match[:feature_name]) : nil
           end
         end
         private :feature_name


### PR DESCRIPTION
* Before we supported slashes we [unescaped the feature name](https://github.com/jnunemaker/flipper/pull/362/files#diff-57d52309df29e6c236372b6f6c88fabeL36), but the
change to get feature_name using  `FeatureNameFromRoute` is not
unescaping feature names. 

This causes 2 issues:

1.  The redirect when creating the feature displays the feature name unescaped
2.  When you go to enable a gate for the feature the feature_key is the unescaped value

Reproduce:
* Flipper, Flipper UI, Flipper ActiveRecord - (all 0.16.0)
* Rails 4.2.4
* browsers: ChromeVersion 69.0.3497.100 and SafariVersion 11.1

1.  Navigate to `features/new` and create `my_team:cool_feature`.  This will redirect you to feature page:
<img width="582" alt="create-feature-redirect" src="https://user-images.githubusercontent.com/3260042/46217522-0ddb8100-c2f7-11e8-9578-f4079974f705.png">

2.  Confirm database feature record looks correct
<img width="1195" alt="feature-key" src="https://user-images.githubusercontent.com/3260042/46217536-19c74300-c2f7-11e8-8458-fd28beaf31b0.png">

3.  Enable the boolean gate for this feature by clicking "Enable"

4. Confirm it is enabled for the wrong feature_key
<img width="1192" alt="gate-feature-key" src="https://user-images.githubusercontent.com/3260042/46217558-2a77b900-c2f7-11e8-89b6-3c5227f9eef1.png">

Note: All is good if you link to the feature from the /features view
