### PR TITLE
Add regression test for escaping feature names

### DIFF
--- a/spec/flipper/ui/action_spec.rb
+++ b/spec/flipper/ui/action_spec.rb
@@ -1,59 +1,78 @@
 require 'helper'
 
 RSpec.describe Flipper::UI::Action do
-  let(:action_subclass) do
-    Class.new(described_class) do
-      def noooope
-        raise 'should never run this'
-      end
+  describe 'request methods' do
+    let(:action_subclass) do
+      Class.new(described_class) do
+        def noooope
+          raise 'should never run this'
+        end
 
-      def get
-        [200, {}, 'get']
-      end
+        def get
+          [200, {}, 'get']
+        end
 
-      def post
-        [200, {}, 'post']
-      end
+        def post
+          [200, {}, 'post']
+        end
 
-      def put
-        [200, {}, 'put']
-      end
+        def put
+          [200, {}, 'put']
+        end
 
-      def delete
-        [200, {}, 'delete']
+        def delete
+          [200, {}, 'delete']
+        end
       end
+    end
+
+    it "won't run method that isn't whitelisted" do
+      fake_request = Struct.new(:request_method, :env, :session).new('NOOOOPE', {}, {})
+      action = action_subclass.new(flipper, fake_request)
+      expect do
+        action.run
+      end.to raise_error(Flipper::UI::RequestMethodNotSupported)
+    end
+
+    it 'will run get' do
+      fake_request = Struct.new(:request_method, :env, :session).new('GET', {}, {})
+      action = action_subclass.new(flipper, fake_request)
+      expect(action.run).to eq([200, {}, 'get'])
+    end
+
+    it 'will run post' do
+      fake_request = Struct.new(:request_method, :env, :session).new('POST', {}, {})
+      action = action_subclass.new(flipper, fake_request)
+      expect(action.run).to eq([200, {}, 'post'])
+    end
+
+    it 'will run put' do
+      fake_request = Struct.new(:request_method, :env, :session).new('PUT', {}, {})
+      action = action_subclass.new(flipper, fake_request)
+      expect(action.run).to eq([200, {}, 'put'])
     end
   end
 
-  it "won't run method that isn't whitelisted" do
-    fake_request = Struct.new(:request_method, :env, :session).new('NOOOOPE', {}, {})
-    action = action_subclass.new(flipper, fake_request)
-    expect do
-      action.run
-    end.to raise_error(Flipper::UI::RequestMethodNotSupported)
-  end
+  describe 'FeatureNameFromRoute' do
+    let(:action_subclass) do
+      Class.new(described_class) do |parent|
+        include parent::FeatureNameFromRoute
 
-  it 'will run get' do
-    fake_request = Struct.new(:request_method, :env, :session).new('GET', {}, {})
-    action = action_subclass.new(flipper, fake_request)
-    expect(action.run).to eq([200, {}, 'get'])
-  end
+        route %r{\A/features/(?<feature_name>.*)\Z}
 
-  it 'will run post' do
-    fake_request = Struct.new(:request_method, :env, :session).new('POST', {}, {})
-    action = action_subclass.new(flipper, fake_request)
-    expect(action.run).to eq([200, {}, 'post'])
-  end
+        def get
+          [200, { feature_name: feature_name }, 'get']
+        end
+      end
+    end
 
-  it 'will run put' do
-    fake_request = Struct.new(:request_method, :env, :session).new('PUT', {}, {})
-    action = action_subclass.new(flipper, fake_request)
-    expect(action.run).to eq([200, {}, 'put'])
-  end
-
-  it 'will run delete' do
-    fake_request = Struct.new(:request_method, :env, :session).new('DELETE', {}, {})
-    action = action_subclass.new(flipper, fake_request)
-    expect(action.run).to eq([200, {}, 'delete'])
+    it 'decodes feature_name' do
+      requested_feature_name = Rack::Utils.escape("team:side_pane")
+      fake_request = Struct
+                     .new(:request_method, :env, :session, :path_info)
+                     .new('GET', {}, {}, "/features/#{requested_feature_name}")
+      action = action_subclass.new(flipper, fake_request)
+      expect(action.run).to eq([200, { feature_name: "team:side_pane" }, 'get'])
+    end
   end
 end


### PR DESCRIPTION
@jnunemaker great idea about [adding a regression test](https://github.com/jnunemaker/flipper/pull/377) lemme know what ya think

* 7151715c6afd55b3b87b46aada152dff3fc13ea9 was merged which escapes
feature_names like we were doing before the change to support slashes
and adding the FeatureNameFromRoute module for pulling the feature name
out of the request.  This adds a regression spec to make sure this
continues to work in the future as changes are made.

* I decided to test this in a separate describe block since the current `action_subclass` is super simple and really easy to understand what its testing.  Since the `FeatureNameFromRoute` returns a request body with values and includes a module, etc I think its nice to separate the two.  Since `feature_name` is a private method I didn't really want to test it using `send` and instead decided to run the fake request via the public `run` method like the other specs have.  If you like this approach I'll add the same for `Api::Action` just lemme know.  Totally open to other suggestions to better test this too

* I decided to stub `path_info` instead of add the header `PATH_INFO` to `env` because that feels like messing with internals of the path_info method and we just care about the public method and not how its implemented under the hood