### PR TITLE
Make it easier to decorate flipper

### DIFF
--- a/lib/flipper/ui/actions/boolean_gate.rb
+++ b/lib/flipper/ui/actions/boolean_gate.rb
@@ -10,13 +10,13 @@ module Flipper
         route %r{\A/features/(?<feature_name>.*)/boolean/?\Z}
 
         def post
-          feature = flipper[feature_name]
-          @feature = Decorators::Feature.new(feature)
+          feature = feature_name.to_sym
+          @feature = Decorators::Feature.new(flipper[feature])
 
           if params['action'] == 'Enable'
-            feature.enable
+            flipper.enable(feature)
           else
-            feature.disable
+            flipper.disable(feature)
           end
 
           redirect_to "/features/#{@feature.key}"


### PR DESCRIPTION
Hello!

This is obviously not complete: the change as proposed would have to be applied to the other files.

This came about because we were trying to decorate Flipper and log enabling and disabling of features -- so we wrote a simple delegator that wrapped Flipper, but that did not log changes made through the web interface. As you see below, we then went as far as creating a decorator for the internal "feature" object, but a user of Flipper shouldn't be decorating anything beyond the Flipper API.

```ruby
  module Flipper
    class Decorator < SimpleDelegator
      def initialize(adapter)
        @adapter = ::Flipper.new(adapter)
        super(@adapter)
      end

      # overridden to log when used in console
      def enable(name, *args)
        Rails.logger.info "ENABLE #{name} with #{args} from API"
        super(name, *args)
      end

      # overridden to log when used in console
      def disable(name, *args)
        Rails.logger.info "DISABLE #{name} with #{args} from API"
        super(name, *args)
      end

      def [](feature_name)
        feature = super(feature_name)
        Flipper::FeatureDecorator.new(feature)
      end
    end
  end
```

So, this is a suggestion for a change that would allow people to decorate Flipper more easily.