### PR TITLE
Remove YouTube embed from default landing

### DIFF
--- a/lib/flipper/ui/views/features.erb
+++ b/lib/flipper/ui/views/features.erb
@@ -3,11 +3,8 @@
     <span class="mega-octicon octicon-plus"></span>
     <span class="mega-octicon octicon-list-unordered"></span>
     <span class="mega-octicon octicon-zap"></span>
-    <h4>But I've got a blank space baby...</h4>
-    <p>And I'll flip your features.</p>
-    <div class="embed-responsive embed-responsive-16by9">
-      <iframe class="embed-responsive-item" width="560" height="315" src="https://www.youtube.com/embed/e-ORhEE9VVg" frameborder="0" allowfullscreen></iframe>
-    </div>
+    <h4>No features created.</h4>
+    <p>Please add a feature to begin flipping.</p>
   </div>
 <% else %>
   <div class="card">


### PR DESCRIPTION
I find the default landing page frustratingly unprofessional. You can call me unfunny if you want, but I always need to ensure I add some features in every environment, lest I get strange looks and comments from my clients.

Am I the only one who thinks we should just keep this page simple and meme-free?

<img width="1140" alt="screen shot 2018-11-20 at 7 26 51 am" src="https://user-images.githubusercontent.com/925/48773711-2f713d00-ec96-11e8-8a7c-cb104424a89b.png">
