### PR TITLE
Allow to customize Rack::Protection middleware list

### DIFF
--- a/lib/flipper/ui.rb
+++ b/lib/flipper/ui.rb
@@ -41,15 +41,15 @@ module Flipper
 
     def self.app(flipper = nil, options = {})
       env_key = options.fetch(:env_key, 'flipper')
+      rack_protection_options = options.fetch(:rack_protection, use: :authenticity_token)
       app = ->() { [200, { 'Content-Type' => 'text/html' }, ['']] }
       builder = Rack::Builder.new
       yield builder if block_given?
-      builder.use Rack::Protection
-      builder.use Rack::Protection::AuthenticityToken
+      builder.use Rack::Protection, rack_protection_options
       builder.use Rack::MethodOverride
       builder.use Flipper::Middleware::SetupEnv, flipper, env_key: env_key
       builder.use Flipper::Middleware::Memoizer, env_key: env_key
-      builder.use Middleware, env_key: env_key
+      builder.use Flipper::UI::Middleware, env_key: env_key
       builder.run app
       klass = self
       builder.define_singleton_method(:inspect) { klass.inspect } # pretty rake routes output


### PR DESCRIPTION
This PR allows to customize `Rack::Protection` middleware list.

Currently we are forced to use `Rack::Protection` defaults, when we may want to use or skip some of them: https://github.com/sinatra/sinatra/blob/master/rack-protection/lib/rack/protection.rb#L23-L51.