### PR TITLE
Target correct bootstrap breakpoints in Flipper::UI feature view

### DIFF
--- a/lib/flipper/ui/views/feature.erb
+++ b/lib/flipper/ui/views/feature.erb
@@ -35,7 +35,7 @@
     </div>
   </div>
   <div class="row">
-    <div class="col-md mb-4 mb-md-0">
+    <div class="col-md mb-4 mb-lg-0">
       <div class="card">
         <h4 class="card-header"><%= Flipper::UI.configuration.percentage_of_actors.title %></h4>
         <div class="card-body">

--- a/lib/flipper/ui/views/feature.erb
+++ b/lib/flipper/ui/views/feature.erb
@@ -128,7 +128,7 @@
                 <form action="<%= script_name %>/features/<%= @feature.key %>/groups" method="post" class="form-inline">
                   <%== csrf_input_tag %>
                   <input type="hidden" name="operation" value="enable">
-                  <select name="value" class="form-control form-control-sm mr-sm-2 mb-2 mb-md-0">
+                  <select name="value" class="form-control form-control-sm mr-sm-2 mb-2 mb-sm-0">
                     <option value="">Select a group...</option>
                     <% @feature.disabled_groups.each do |group| %>
                       <option value="<%= group.name %>"><%= group.name %></option>
@@ -186,7 +186,7 @@
               <form action="<%= script_name %>/features/<%= @feature.key %>/actors" method="post" class="form-inline">
                 <%== csrf_input_tag %>
                 <input type="hidden" name="operation" value="enable">
-                <input type="text" name="value" placeholder="ie: User:6" class="form-control form-control-sm mr-sm-2 mb-2 mb-md-0">
+                <input type="text" name="value" placeholder="ie: User:6" class="form-control form-control-sm mr-sm-2 mb-2 mb-sm-0">
                 <input type="submit" value="Add Actor" class="btn btn-light btn-sm">
               </form>
             </div>


### PR DESCRIPTION
It seems that in the `feature` view of `Flipper::UI`, a couple of the bootstrap responsive utility classes are off-by-one on the breakpoints they target. Changing `md` to `sm` in two places and `md` to `lg` in one place seems to fix the issues without introducing unwanted side effects (from what I can tell.

Before:
![image](https://user-images.githubusercontent.com/1863540/51654726-19aa1d80-1f4e-11e9-83ad-e0aa1f3f91f3.png)

After:
![image](https://user-images.githubusercontent.com/1863540/51654753-2f1f4780-1f4e-11e9-9015-0bc0adf9f14f.png)


Before:
![image](https://user-images.githubusercontent.com/1863540/51654858-ad7be980-1f4e-11e9-870f-be5f11b8d1e7.png)

After:
![image](https://user-images.githubusercontent.com/1863540/51654904-ec11a400-1f4e-11e9-8e3a-0f04ee0151c3.png)
