### PR TITLE
remove Taylor Swift joke

### DIFF
--- a/lib/flipper/ui/views/features.erb
+++ b/lib/flipper/ui/views/features.erb
@@ -3,11 +3,8 @@
     <span class="mega-octicon octicon-plus"></span>
     <span class="mega-octicon octicon-list-unordered"></span>
     <span class="mega-octicon octicon-zap"></span>
-    <h4>But I've got a blank space baby...</h4>
-    <p>And I'll flip your features.</p>
-    <div class="embed-responsive embed-responsive-16by9">
-      <iframe class="embed-responsive-item" width="560" height="315" src="https://www.youtube.com/embed/e-ORhEE9VVg" frameborder="0" allowfullscreen></iframe>
-    </div>
+    <h4>There are no features defined</h4>
+    <p>Click on "Add Feature" to start flippin'.</p>
   </div>
 <% else %>
   <div class="card">


### PR DESCRIPTION
Empty features page features an embedded Taylor Swift reference as a joke.

Don't mean to bother, but it grew old fast.