### PR TITLE
Remove version constraint for Sequel gem

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -10,6 +10,7 @@ AllCops:
     - 'examples/**/*'
     - 'tmp/**/*'
     - 'bin/**/*'
+    - 'vendor/bundle/**/*'
   TargetRubyVersion: 2.0
   # DefaultFormatter: fuubar
 Style/Alias:

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,8 +5,9 @@ rvm:
   - 2.3
   - 2.4
   - 2.5
-bundler_args: --without guard
-before_script: gem install bundler
+before_install:
+  - gem install bundler -v 1.17.3 --no-rdoc --no-ri --without guard
+  - bundle _1.17.3_ install
 script: bundle exec rubocop -D && bundle exec rake
 services:
   - redis-server

--- a/flipper-sequel.gemspec
+++ b/flipper-sequel.gemspec
@@ -23,5 +23,5 @@ Gem::Specification.new do |gem|
   gem.metadata      = Flipper::METADATA
 
   gem.add_dependency 'flipper', "~> #{Flipper::VERSION}"
-  gem.add_dependency 'sequel', '>= 4.0.0', '< 5'
+  gem.add_dependency 'sequel', '>= 4.0.0'
 end


### PR DESCRIPTION
I want to use this gem, but we are heavy-users of Sequel, and limiting the version to < 5 will block us...
I removed it, and apparently nothing (rspec and rubocop) broke.