### PR TITLE
Update Redis dependency constraint to < 5

### DIFF
--- a/flipper-redis.gemspec
+++ b/flipper-redis.gemspec
@@ -22,5 +22,5 @@ Gem::Specification.new do |gem|
   gem.metadata      = Flipper::METADATA
 
   gem.add_dependency 'flipper', "~> #{Flipper::VERSION}"
-  gem.add_dependency 'redis', '>= 2.2', '< 4.1.0'
+  gem.add_dependency 'redis', '>= 2.2', '< 5'
 end


### PR DESCRIPTION
Redis gem v4.1 was recently released, so any app running it will
cause bundler to resolve to using an older version of `flipper-redis`.
We should consider relaxing the constraint to anything less than v5.

Addresses https://github.com/jnunemaker/flipper/issues/392