### PR TITLE
Bump redis dep for flipper-rollout

### DIFF
--- a/flipper-rollout.gemspec
+++ b/flipper-rollout.gemspec
@@ -22,6 +22,6 @@ Gem::Specification.new do |gem|
   gem.metadata      = Flipper::METADATA
 
   gem.add_dependency 'flipper', "~> #{Flipper::VERSION}"
-  gem.add_dependency 'redis', '>= 2.2', '< 4.1.0'
+  gem.add_dependency 'redis', '>= 2.2', '< 5'
   gem.add_dependency 'rollout', "~> 2.0"
 end


### PR DESCRIPTION
This also bumps the redis dependency for flipper-rollout so it can be used with the latest redis.