### PR TITLE
Allow shorthand block notation on group types

### DIFF
--- a/lib/flipper/types/group.rb
+++ b/lib/flipper/types/group.rb
@@ -14,7 +14,7 @@ module Flipper
 
         if block_given?
           @block = block
-          @single_argument = @block.arity == 1
+          @single_argument = @block.arity.abs == 1
         else
           @block = ->(_thing, _context) { false }
           @single_argument = false

--- a/spec/flipper/types/group_spec.rb
+++ b/spec/flipper/types/group_spec.rb
@@ -65,6 +65,28 @@ RSpec.describe Flipper::Types::Group do
       expect(group.match?(double('Actor'), fake_context)).to be_falsey
     end
 
+    it 'returns true for truthy shortand block results' do
+      actor = Class.new do
+        def admin?
+          true
+        end
+      end.new
+
+      group = described_class.new(:admin, &:admin?)
+      expect(group.match?(actor, fake_context)).to be_truthy
+    end
+
+    it 'returns false for falsy shortand block results' do
+      actor = Class.new do
+        def admin?
+          false
+        end
+      end.new
+
+      group = described_class.new(:admin, &:admin?)
+      expect(group.match?(actor, fake_context)).to be_falsey
+    end
+
     it 'can yield without context as block argument' do
       context = Flipper::FeatureCheckContext.new(
         feature_name: :my_feature,


### PR DESCRIPTION
@jnunemaker @supersam654 I went ahead and took a shot at fixing the the issue in #405. See if this makes sense.


## Description of changes
When a shorthand block was used when initializing a Group, an error would be thrown about not passing the correct number of arguments. That was due to the arity of the shortand being -1 instead of 1. By taking the absolute value of the arity, an arity of -1 will still correctly set the single_argument instance variable.