### PR TITLE
Replace Erubis with Erubi (2)

### DIFF
--- a/flipper-ui.gemspec
+++ b/flipper-ui.gemspec
@@ -24,5 +24,5 @@ Gem::Specification.new do |gem|
   gem.add_dependency 'rack', '>= 1.4', '< 3'
   gem.add_dependency 'rack-protection', '>= 1.5.3', '< 2.1.0'
   gem.add_dependency 'flipper', "~> #{Flipper::VERSION}"
-  gem.add_dependency 'erubis', '~> 2.7.0'
+  gem.add_dependency 'erubi', '>= 1.0.0'
 end

--- a/lib/flipper/ui/action.rb
+++ b/lib/flipper/ui/action.rb
@@ -1,6 +1,6 @@
 require 'forwardable'
 require 'flipper/ui/error'
-require 'flipper/ui/eruby'
+require 'erubi'
 require 'json'
 
 module Flipper
@@ -208,9 +208,9 @@ module Flipper
 
         raise "Template does not exist: #{path}" unless path.exist?
 
-        contents = path.read
-        compiled = Eruby.new(contents)
-        compiled.result proc {}.binding
+        # rubocop:disable Lint/Eval
+        eval(Erubi::Engine.new(path.read, escape: true).src)
+        # rubocop:enable Lint/Eval
       end
 
       # Internal: The path the app is mounted at.


### PR DESCRIPTION
Following up on https://github.com/jnunemaker/flipper/pull/397.

- [x] Merge master
- [x] Tell rubocop using `eval` is ok here
- [x] Configure Erubi to escape `<%=`

This should make `flipper-ui` Rails 5.2 compatible.