### PR TITLE
[UI Configuration] Allow for feature icon to be configured to another octicon

### DIFF
--- a/lib/flipper/ui/configuration.rb
+++ b/lib/flipper/ui/configuration.rb
@@ -10,7 +10,8 @@ module Flipper
                   :percentage_of_time
 
       attr_accessor :banner_text,
-                    :banner_class
+                    :banner_class,
+                    :feature_icon
 
       # Public: If you set this, the UI will always have a first breadcrumb that
       # says "App" which points to this href. The href can be a path (ie: "/")
@@ -45,6 +46,7 @@ module Flipper
         @delete = Option.new("Danger Zone", "Deleting a feature removes it from the list of features and disables it for everyone.") # rubocop:disable Metrics/LineLength
         @banner_text = nil
         @banner_class = 'danger'
+        @feature_icon = 'squirrel'
         @feature_creation_enabled = true
         @feature_removal_enabled = true
       end

--- a/lib/flipper/ui/views/feature.erb
+++ b/lib/flipper/ui/views/feature.erb
@@ -9,7 +9,7 @@
     <div class="col">
       <div class="card">
         <h4 class="card-header">
-          <span class="octicon octicon-squirrel <%= @feature.color_class %>"></span>
+          <span class="octicon octicon-<%= Flipper::UI.configuration.feature_icon %> <%= @feature.color_class %>"></span>
           <%= @feature.key %>
         </h4>
         <div class="card-body">
@@ -144,7 +144,7 @@
           <div class="card-body bg-light">
             <div class="text-center">
               <span class="mega-octicon octicon-organization text-muted"></span>
-              <span class="mega-octicon octicon-squirrel text-muted"></span>
+              <span class="mega-octicon octicon-<%= Flipper::UI.configuration.feature_icon %> text-muted"></span>
               <span class="mega-octicon octicon-zap text-muted"></span>
               <h4>No Enabled Groups</h4>
               <p><%= Flipper::UI.configuration.groups.description %></p>
@@ -196,7 +196,7 @@
           <div class="card-body bg-light">
             <div class="text-center">
               <span class="mega-octicon octicon-person text-muted"></span>
-              <span class="mega-octicon octicon-squirrel text-muted"></span>
+              <span class="mega-octicon octicon-<%= Flipper::UI.configuration.feature_icon %> text-muted"></span>
               <span class="mega-octicon octicon-zap text-muted"></span>
               <h4>No Enabled Actors</h4>
               <p><%= Flipper::UI.configuration.actors.description %></p>

--- a/lib/flipper/ui/views/features.erb
+++ b/lib/flipper/ui/views/features.erb
@@ -16,7 +16,7 @@
       <thead>
         <tr class="d-flex">
           <th class="col-1">
-            <span class="octicon octicon-squirrel"></span>
+            <span class="octicon octicon-<%= Flipper::UI.configuration.feature_icon %>"></span>
           </th>
           <th class="col">Feature</th>
           <th class="col">Enabled Gates</th>
@@ -26,7 +26,7 @@
         <% @features.each do |feature| %>
           <tr class="d-flex">
             <td class="col-1">
-              <span class="octicon octicon-squirrel <%= feature.color_class %>"></span>
+              <span class="octicon octicon-<%= Flipper::UI.configuration.feature_icon %> <%= feature.color_class %>"></span>
             </td>
             <td class="col">
               <a href="<%= "#{script_name}/features/#{feature.key}" %>">


### PR DESCRIPTION
This PR adds a configuration option in `Flipper::UI::Configuration` called `feature_icon` to allow for use of any of the other [ocitcons](https://octicons.github.com/), and defaults it to the good ol' classic squirrel.