### PR TITLE
Include thing_value in payload of Instrumented#enable and #disable

### DIFF
--- a/lib/flipper/adapters/instrumented.rb
+++ b/lib/flipper/adapters/instrumented.rb
@@ -124,6 +124,7 @@ module Flipper
           adapter_name: @adapter.name,
           feature_name: feature.name,
           gate_name: gate.name,
+          thing_value: thing.value,
         }
 
         @instrumenter.instrument(InstrumentationName, payload) do |payload|
@@ -138,6 +139,7 @@ module Flipper
           adapter_name: @adapter.name,
           feature_name: feature.name,
           gate_name: gate.name,
+          thing_value: thing.value,
         }
 
         @instrumenter.instrument(InstrumentationName, payload) do |payload|

--- a/spec/flipper/adapters/instrumented_spec.rb
+++ b/spec/flipper/adapters/instrumented_spec.rb
@@ -73,6 +73,7 @@ RSpec.describe Flipper::Adapters::Instrumented do
       expect(event.payload[:adapter_name]).to eq(:memory)
       expect(event.payload[:feature_name]).to eq(:stats)
       expect(event.payload[:gate_name]).to eq(:percentage_of_actors)
+      expect(event.payload[:thing_value]).to eq(22)
       expect(event.payload[:result]).to be(result)
     end
   end
@@ -88,6 +89,7 @@ RSpec.describe Flipper::Adapters::Instrumented do
       expect(event.payload[:adapter_name]).to eq(:memory)
       expect(event.payload[:feature_name]).to eq(:stats)
       expect(event.payload[:gate_name]).to eq(:percentage_of_actors)
+      expect(event.payload[:thing_value]).to eq(22)
       expect(event.payload[:result]).to be(result)
     end
   end


### PR DESCRIPTION
When subscribing to notifications it can be useful to know the value of the gate being enabled/disabled. For example, that way you could set up notifications and output the name of the group or the percentage being changed.

This adds a new `thing_value` attribute to the payload of `Instrumented#enable` and `Instrumented#disable`.

Thanks for the great gem!