### PR TITLE
Feature timestamps

### DIFF
--- a/lib/flipper/adapters/redis.rb
+++ b/lib/flipper/adapters/redis.rb
@@ -74,9 +74,9 @@ module Flipper
       def enable(feature, gate, thing)
         case gate.data_type
         when :boolean, :integer
-          @client.hset feature.key, gate.key, thing.value.to_s
+          @client.hmset feature.key, 'time', feature.timestamp, gate.key, thing.value.to_s
         when :set
-          @client.hset feature.key, to_field(gate, thing), 1
+          @client.hmset feature.key, 'time', feature.timestamp, to_field(gate, thing), 1
         else
           unsupported_data_type gate.data_type
         end
@@ -139,6 +139,8 @@ module Flipper
       def result_for_feature(feature, doc)
         result = {}
         fields = doc.keys
+        result[:time] = doc['time']
+        feature.set_timestamp(result[:time])
 
         feature.gates.each do |gate|
           result[gate.key] =

--- a/lib/flipper/adapters/redis.rb
+++ b/lib/flipper/adapters/redis.rb
@@ -44,6 +44,7 @@ module Flipper
       # Public: Clears the gate values for a feature.
       def clear(feature)
         @client.del feature.key
+        @client.hset feature.key, 'time', feature.timestamp
         true
       end
 
@@ -94,9 +95,11 @@ module Flipper
       def disable(feature, gate, thing)
         case gate.data_type
         when :boolean
-          @client.del feature.key
+          @client.hset feature.key, 'time', feature.timestamp
+          @client.hdel feature.key, gate.key
+          @client.hdel feature.key, thing.value.to_s
         when :integer
-          @client.hset feature.key, gate.key, thing.value.to_s
+          @client.hmset feature.key, 'time', feature.timestamp, gate.key, thing.value.to_s
         when :set
           @client.hdel feature.key, to_field(gate, thing)
         else

--- a/lib/flipper/feature.rb
+++ b/lib/flipper/feature.rb
@@ -343,6 +343,10 @@ module Flipper
       @timestamp = time
     end
 
+    def get_timestamp
+      @timestamp
+    end
+
     # Public: update timestamp attribute to be current time
     def update_timestamp
       @timestamp = Time.now

--- a/lib/flipper/feature.rb
+++ b/lib/flipper/feature.rb
@@ -37,7 +37,6 @@ module Flipper
       @key = name.to_s
       @instrumenter = options.fetch(:instrumenter, Instrumenters::Noop)
       @adapter = adapter
-      @timestamp = Time.now
     end
 
     # Public: Enable this feature for something.
@@ -336,6 +335,11 @@ module Flipper
     # Public: Identifier to be used in the url (a rails-ism).
     def to_param
       to_s
+    end
+
+    # Public: set the timestamp
+    def set_timestamp(time)
+      @timestamp = time
     end
 
     # Public: update timestamp attribute to be current time

--- a/lib/flipper/feature.rb
+++ b/lib/flipper/feature.rb
@@ -5,6 +5,7 @@ require 'flipper/feature_check_context'
 require 'flipper/gate_values'
 
 module Flipper
+  # rubocop:disable Metrics/ClassLength
   class Feature
     # Private: The name of feature instrumentation events.
     InstrumentationName = "feature_operation.#{InstrumentationNamespace}".freeze

--- a/lib/flipper/ui/decorators/feature.rb
+++ b/lib/flipper/ui/decorators/feature.rb
@@ -44,6 +44,11 @@ module Flipper
           enabled_gates.map { |gate| Util.titleize(gate.key) }.sort.join(', ')
         end
 
+        def pretty_timestamp
+          return "" if timestamp.nil?
+          timestamp[0..15]
+        end
+
         StateSortMap = {
           on: 1,
           conditional: 2,
@@ -62,6 +67,8 @@ module Flipper
         def time_compare(other)
           if timestamp && other.timestamp
             timestamp <=> other.timestamp
+          elsif !(timestamp || other.timestamp)
+            self <=> other
           else
             timestamp ? 1 : -1
           end

--- a/lib/flipper/ui/decorators/feature.rb
+++ b/lib/flipper/ui/decorators/feature.rb
@@ -60,7 +60,11 @@ module Flipper
 
         # Public: method used to sort by timestamp (nil timestamps are first)
         def time_compare(other)
-          timestamp && other.timestamp ? timestamp <=> other.timestamp : timestamp ? 1 : -1
+          if timestamp && other.timestamp
+            timestamp <=> other.timestamp
+          else
+            timestamp ? 1 : -1
+          end
         end
       end
     end

--- a/lib/flipper/ui/decorators/feature.rb
+++ b/lib/flipper/ui/decorators/feature.rb
@@ -57,6 +57,11 @@ module Flipper
             StateSortMap[state] <=> StateSortMap[other.state]
           end
         end
+
+        # Public: method used to sort by timestamp (nil timestamps are first)
+        def time_compare(other)
+          timestamp && other.timestamp ? timestamp <=> other.timestamp : timestamp ? 1 : -1
+        end
       end
     end
   end

--- a/lib/flipper/ui/views/features.erb
+++ b/lib/flipper/ui/views/features.erb
@@ -28,10 +28,13 @@
           </th>
           <th class="col">Feature</th>
           <th class="col">Enabled Gates</th>
+          <% if flipper.adapter.adapter.name.eql? :redis %>
+            <th class="col">Gate Timestamp</th>
+          <% end %>
         </tr>
       </thead>
       <tbody>
-        <% if true %>
+        <% if false %>
           <% @features.sort { |a,b| a.time_compare(b) }.each do |feature| %>
             <tr class="d-flex">
               <td class="col-1">
@@ -43,6 +46,9 @@
               </td>
               <td class="col">
                 <%= feature.pretty_enabled_gate_names %>
+              </td>
+              <td class="col">
+                <%= feature.pretty_timestamp %>
               </td>
             </tr>
             <% end %>
@@ -59,6 +65,11 @@
               <td class="col">
                 <%= feature.pretty_enabled_gate_names %>
               </td>
+              <% if flipper.adapter.adapter.name.eql? :redis %>
+                <td class="col">
+                  <%= feature.pretty_timestamp %>
+                </td>
+              <% end %>
             </tr>
           <% end %>
         <% end %>

--- a/lib/flipper/ui/views/features.erb
+++ b/lib/flipper/ui/views/features.erb
@@ -32,7 +32,7 @@
       </thead>
       <tbody>
         <% if true %>
-          <% @features.sort { |a,b| a.timestamp && b.timestamp ? a.timestamp <=> b.timestamp : a ? 1 : -1 }.each do |feature| %>
+          <% @features.sort { |a,b| a.time_compare(b) }.each do |feature| %>
             <tr class="d-flex">
               <td class="col-1">
                 <span class="octicon octicon-squirrel <%= feature.color_class %>"></span>

--- a/lib/flipper/ui/views/features.erb
+++ b/lib/flipper/ui/views/features.erb
@@ -31,19 +31,36 @@
         </tr>
       </thead>
       <tbody>
-        <% @features.each do |feature| %>
-          <tr class="d-flex">
-            <td class="col-1">
-              <span class="octicon octicon-squirrel <%= feature.color_class %>"></span>
-            </td>
-            <td class="col">
-              <a href="<%= "#{script_name}/features/#{feature.key}" %>">
-                <%= feature.key %></a>
-            </td>
-            <td class="col">
-              <%= feature.pretty_enabled_gate_names %>
-            </td>
-          </tr>
+        <% if true %>
+          <% @features.sort { |a,b| a.timestamp && b.timestamp ? a.timestamp <=> b.timestamp : a ? 1 : -1 }.each do |feature| %>
+            <tr class="d-flex">
+              <td class="col-1">
+                <span class="octicon octicon-squirrel <%= feature.color_class %>"></span>
+              </td>
+              <td class="col">
+                <a href="<%= "#{script_name}/features/#{feature.key}" %>">
+                  <%= feature.key %></a>
+              </td>
+              <td class="col">
+                <%= feature.pretty_enabled_gate_names %>
+              </td>
+            </tr>
+            <% end %>
+        <% else %>
+          <% @features.each do |feature| %>
+            <tr class="d-flex">
+              <td class="col-1">
+                <span class="octicon octicon-squirrel <%= feature.color_class %>"></span>
+              </td>
+              <td class="col">
+                <a href="<%= "#{script_name}/features/#{feature.key}" %>">
+                  <%= feature.key %></a>
+              </td>
+              <td class="col">
+                <%= feature.pretty_enabled_gate_names %>
+              </td>
+            </tr>
+          <% end %>
         <% end %>
       </tbody>
     </table>


### PR DESCRIPTION
I have added a timestamp attribute to Feature.rb. The idea is to have timestamps that can be evaluated in the UI so that it will be obvious which features have gone stale (should be permanently added or removed from the codebase). A common issue with the feature toggle design pattern is that the codebase becomes riddled with flags and they grow difficult to track, so this aims to mitigate that pain.

Current Status:
- Timestamps are currently only compatible with the Redis adapter ( others or I could add PR's for other adapters )
- Timestamps are updated on each change to  a gate (not upon polling enabled?/disabled?)
- Timestamps are displayed in the UI in a third column if the adapter being used is a Redis adapter. I am hoping add toggles for showing timestamps and sorting by timestamp but I am having some trouble since I don't have much frontend experience.