### PR TITLE
Fixed XSS in feature UI

### DIFF
--- a/lib/flipper/ui/views/feature.erb
+++ b/lib/flipper/ui/views/feature.erb
@@ -239,7 +239,7 @@
             <%= Flipper::UI.configuration.delete.description %>
           </p>
 
-          <form action="<%= script_name %>/features/<%= @feature.key %>" method="post" onsubmit="return confirm('Are you sure you want to remove <%= @feature.key %> from the list of features and disable it for everyone?')">
+          <form action="<%= script_name %>/features/<%= @feature.key %>" method="post" onsubmit="return confirm('Are you sure you want to remove <%= j @feature.key %> from the list of features and disable it for everyone?')">
             <%== csrf_input_tag %>
             <input type="hidden" name="_method" value="DELETE">
             <button type="submit" name="action" value="Delete" class="btn btn-danger" data-toggle="tooltip" title="Remove feature from list of features and disable it." data-placement="right">Delete</button>


### PR DESCRIPTION
There is a reflected XSS in the Flipper UI. It could be used by attackers to execute code if an user opens a malicious link and clicks on the delete feature button. The following PoC has been tested in the lastest version of Flipper: http://127.0.0.1:3000/flipper/features/ef'%2balert("XSS")%2b'

![xss](https://user-images.githubusercontent.com/25706428/62638263-5adbab00-b93d-11e9-8a71-2f56ba1f4d07.png)


Single quotes should be escaped to fix the issue.
