### PR TITLE
Upgrade to Rails 6.0.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,7 +14,7 @@ services:
   - mongodb
   - memcached
 env:
-  - RAILS_VERSION=6.0.0.rc1 SQLITE3_VERSION=1.4.1
+  - RAILS_VERSION=6.0.0 SQLITE3_VERSION=1.4.1
   - RAILS_VERSION=5.2.3
   - RAILS_VERSION=5.1.4
   - RAILS_VERSION=5.0.0
@@ -30,10 +30,10 @@ matrix:
     - rvm: 2.1
       env: RAILS_VERSION=5.2.3
     - rvm: 2.1
-      env: RAILS_VERSION=6.0.0.rc1 SQLITE3_VERSION=1.4.1
+      env: RAILS_VERSION=6.0.0 SQLITE3_VERSION=1.4.1
     - rvm: 2.2
-      env: RAILS_VERSION=6.0.0.rc1 SQLITE3_VERSION=1.4.1
+      env: RAILS_VERSION=6.0.0 SQLITE3_VERSION=1.4.1
     - rvm: 2.3
-      env: RAILS_VERSION=6.0.0.rc1 SQLITE3_VERSION=1.4.1
+      env: RAILS_VERSION=6.0.0 SQLITE3_VERSION=1.4.1
     - rvm: 2.4
-      env: RAILS_VERSION=6.0.0.rc1 SQLITE3_VERSION=1.4.1
+      env: RAILS_VERSION=6.0.0 SQLITE3_VERSION=1.4.1

--- a/script/test
+++ b/script/test
@@ -32,7 +32,7 @@ export RAILS_VERSION=5.2.3
 script/bootstrap || bundle update
 bundle exec rake
 
-export RAILS_VERSION=6.0.0.rc1
+export RAILS_VERSION=6.0.0
 export SQLITE3_VERSION=1.4.1
 script/bootstrap || bundle update
 bundle exec rake


### PR DESCRIPTION
It is possible to release a new version of `flipper-active_record` with the loosened version constraint that will allow it to work in rails 6.0 applications?

* https://weblog.rubyonrails.org/2019/8/15/Rails-6-0-final-release/