### PR TITLE
Require ActiveSupport.on_load in flipper-active_record

### DIFF
--- a/lib/flipper-active_record.rb
+++ b/lib/flipper-active_record.rb
@@ -1,3 +1,5 @@
+require 'activesupport/lazy_load_hooks'
+
 ActiveSupport.on_load(:active_record) do
   require 'flipper/adapters/active_record'
 end


### PR DESCRIPTION
Fixes #431