### PR TITLE
Fix typo in lib/flipper-active_record.rb

### DIFF
--- a/lib/flipper-active_record.rb
+++ b/lib/flipper-active_record.rb
@@ -1,4 +1,4 @@
-require 'activesupport/lazy_load_hooks'
+require 'active_support/lazy_load_hooks'
 
 ActiveSupport.on_load(:active_record) do
   require 'flipper/adapters/active_record'


### PR DESCRIPTION
Per @mike101 in #432:

> I'm not sure if it's just me, but this change seems to have broken Rails for me using Rails 6 and the latest version of this gem with this PR included. I get an error now where bundler is trying to load the gem, and I get an error that it can't find activesupport/lazy_load_hooks.

I typo'd my PR, and forgot the underscore in `active_record`.  I don't know how the tests passed, but they did.  I have manually verified this fix, and would encourage reviewers to do the same.