### PR TITLE
Add spec testing require of flipper-active_record.rb

### DIFF
--- a/spec/flipper/adapters/active_record_requires_spec.rb
+++ b/spec/flipper/adapters/active_record_requires_spec.rb
@@ -1,0 +1,5 @@
+# This nominally-empty spec ensures that the file "flipper-active_record.rb" can be
+# required without error, and guards against regressions of the kind fixed in
+# https://github.com/jnunemaker/flipper/pull/437.
+
+require "flipper-active_record.rb"


### PR DESCRIPTION
This will guard against regressions like that fixed in #437.

I manually validated that this spec generates an error prior to the fix in #437, and runs successfully after.