### PR TITLE
Add data-toggle in squirrel state (flipper-ui) 💅

### DIFF
--- a/lib/flipper/ui/views/features.erb
+++ b/lib/flipper/ui/views/features.erb
@@ -34,7 +34,7 @@
         <% @features.each do |feature| %>
           <tr class="d-flex">
             <td class="col-1">
-              <span class="octicon octicon-squirrel <%= feature.color_class %>"></span>
+              <span class="octicon octicon-squirrel <%= feature.color_class %>" data-toggle="tooltip" title=<%= feature.state.to_s.capitalize %>></span>
             </td>
             <td class="col">
               <a href="<%= "#{script_name}/features/#{feature.key}" %>">


### PR DESCRIPTION
**Motivation**
At the first time I saw the features in the Flipper-ui, I was a little confused about the colors of the squirrel, and when my partner saw it, he tried to click on the squirrel. So I had a simple ideia to put a data-toggle with the feature state name.

**Solution**
It looks like this:
![Screenshot from 2019-10-22 01-16-39](https://user-images.githubusercontent.com/26775468/67259768-f7f2ae00-f46d-11e9-8fd1-22306db707a3.png)
![Screenshot from 2019-10-22 01-16-42](https://user-images.githubusercontent.com/26775468/67259794-19539a00-f46e-11e9-8479-168a32ab046a.png)
![Screenshot from 2019-10-22 01-16-46](https://user-images.githubusercontent.com/26775468/67259812-2d979700-f46e-11e9-877a-cb5608cbb1bb.png)
