### PR TITLE
Avoid errors on import when there are no features

### DIFF
--- a/lib/flipper/adapters/redis_cache.rb
+++ b/lib/flipper/adapters/redis_cache.rb
@@ -146,6 +146,9 @@ module Flipper
 
       def multi_cache_get(keys)
         cache_keys = keys.map { |key| key_for(key) }
+
+        return [] if cache_keys.none?
+
         @cache.mget(cache_keys).map do |value|
           value ? Marshal.load(value) : nil
         end

--- a/spec/flipper/adapters/redis_cache_spec.rb
+++ b/spec/flipper/adapters/redis_cache_spec.rb
@@ -94,6 +94,18 @@ RSpec.describe Flipper::Adapters::RedisCache do
       5.times { adapter.get_all }
       expect(memory_adapter.count(:get_all)).to eq(1)
     end
+
+    context 'when there are no features' do
+      before do
+        stats.remove
+        search.remove
+      end
+
+      it 'does not raise an error' do
+        adapter.get_all
+        expect { adapter.get_all }.not_to raise_error
+      end
+    end
   end
 
   describe '#name' do


### PR DESCRIPTION
I've noticed running flipper locally that if you try the following:

```ruby
client = Redis.new(url: redis_url)

old_adapter = Flipper::Adapters::Redis.new(client)

ar_adapter = Flipper::Adapters::ActiveRecord.new
adapter = Flipper::Adapters::RedisCache.new(ar_adapter, client, 3_600)

adapter.import(old_adapter)
```
you get the following error:
```ruby
/usr/local/bundle/gems/redis-4.1.3/lib/redis/client.rb:126:in `call': ERR wrong number of arguments for 'mget' command (Redis::CommandError)
        from /usr/local/bundle/gems/redis-4.1.3/lib/redis.rb:930:in `block in mget'
        from /usr/local/bundle/gems/redis-4.1.3/lib/redis.rb:52:in `block in synchronize'
        from /usr/local/lib/ruby/2.5.0/monitor.rb:226:in `mon_synchronize'
        from /usr/local/bundle/gems/redis-4.1.3/lib/redis.rb:52:in `synchronize'
        from /usr/local/bundle/gems/redis-4.1.3/lib/redis.rb:929:in `mget'
        from /usr/local/bundle/gems/flipper-redis-0.17.1/lib/flipper/adapters/redis_cache.rb:149:in `multi_cache_get'
        from /usr/local/bundle/gems/flipper-redis-0.17.1/lib/flipper/adapters/redis_cache.rb:114:in `read_many_features'
        from /usr/local/bundle/gems/flipper-redis-0.17.1/lib/flipper/adapters/redis_cache.rb:84:in `get_all'
        from /usr/local/bundle/gems/flipper-0.17.1/lib/flipper/adapters/sync/synchronizer.rb:33:in `sync'
        from /usr/local/bundle/gems/flipper-0.17.1/lib/flipper/adapters/sync/synchronizer.rb:27:in `block in call'
        from /usr/local/bundle/gems/flipper-0.17.1/lib/flipper/instrumenters/noop.rb:5:in `instrument'
        from /usr/local/bundle/gems/flipper-0.17.1/lib/flipper/adapters/sync/synchronizer.rb:27:in `call'
        from /usr/local/bundle/gems/flipper-0.17.1/lib/flipper/adapter.rb:48:in `import'
```

This happens when you try to import and there are no features. Redis doesn't seem to like
`@cache.mget(cache_keys)` when `cache_keys` is `[]`.

Apologies if the PR is a bit clunky, I rather submitted a PR that shows the error than opening an issue. I don't mind changes or having this merged with a new PR.I am not sure why in the test it was needed to call `adapter.get_all` twice, but calling it once did not raise an error.

Side note: The test setup with docker following `docs/DockerCompose.md` did not work for me, I had to go through some hops to be able to run just my test locally. I think having it up to date would help other people submit more PRs. 👏 for this gem anyway, it's awesome 🙂 