### PR TITLE
::ActiveRecord::RecordNotUnique > ActiveRecord::RecordNotUnique

### DIFF
--- a/lib/flipper/adapters/active_record.rb
+++ b/lib/flipper/adapters/active_record.rb
@@ -59,7 +59,7 @@ module Flipper
           unless @feature_class.where(key: feature.key).first
             begin
               @feature_class.create! { |f| f.key = feature.key }
-            rescue ActiveRecord::RecordNotUnique
+            rescue ::ActiveRecord::RecordNotUnique
             end
           end
         end


### PR DESCRIPTION
While in my particular case I'm confused as to why this error even happened, considering the `unless @feature_class.where(key: feature.key).first` check, but, nonetheless, there a typo in which exception to `rescue`... FIXED!