### PR TITLE
Improve the ActiveRecord adapter loading

### DIFF
--- a/lib/flipper-active_record.rb
+++ b/lib/flipper-active_record.rb
@@ -1,5 +1,6 @@
 require 'active_support/lazy_load_hooks'
+require 'flipper/adapters/active_record'
 
 ActiveSupport.on_load(:active_record) do
-  require 'flipper/adapters/active_record'
+  require 'flipper/adapters/active_record/models'
 end

--- a/lib/flipper/adapters/active_record.rb
+++ b/lib/flipper/adapters/active_record.rb
@@ -1,6 +1,5 @@
 require 'set'
 require 'flipper'
-require 'active_record'
 
 module Flipper
   module Adapters

--- a/lib/flipper/adapters/active_record.rb
+++ b/lib/flipper/adapters/active_record.rb
@@ -6,24 +6,6 @@ module Flipper
     class ActiveRecord
       include ::Flipper::Adapter
 
-      # Private: Do not use outside of this adapter.
-      class Feature < ::ActiveRecord::Base
-        self.table_name = [
-          ::ActiveRecord::Base.table_name_prefix,
-          "flipper_features",
-          ::ActiveRecord::Base.table_name_suffix,
-        ].join
-      end
-
-      # Private: Do not use outside of this adapter.
-      class Gate < ::ActiveRecord::Base
-        self.table_name = [
-          ::ActiveRecord::Base.table_name_prefix,
-          "flipper_gates",
-          ::ActiveRecord::Base.table_name_suffix,
-        ].join
-      end
-
       # Public: The name of the adapter.
       attr_reader :name
 

--- a/lib/flipper/adapters/active_record/models.rb
+++ b/lib/flipper/adapters/active_record/models.rb
@@ -1,0 +1,23 @@
+module Flipper
+  module Adapters
+    class ActiveRecord
+      # Private: Do not use outside of this adapter.
+      class Feature < ::ActiveRecord::Base
+        self.table_name = [
+          ::ActiveRecord::Base.table_name_prefix,
+          "flipper_features",
+          ::ActiveRecord::Base.table_name_suffix,
+        ].join
+      end
+
+      # Private: Do not use outside of this adapter.
+      class Gate < ::ActiveRecord::Base
+        self.table_name = [
+          ::ActiveRecord::Base.table_name_prefix,
+          "flipper_gates",
+          ::ActiveRecord::Base.table_name_suffix,
+        ].join
+      end
+    end
+  end
+end

--- a/spec/flipper/adapters/active_record_spec.rb
+++ b/spec/flipper/adapters/active_record_spec.rb
@@ -1,5 +1,6 @@
 require 'helper'
-require 'flipper/adapters/active_record'
+require 'active_record'
+require 'flipper-active_record'
 require 'flipper/spec/shared_adapter_specs'
 
 # Turn off migration logging for specs

--- a/test/adapters/active_record_test.rb
+++ b/test/adapters/active_record_test.rb
@@ -1,5 +1,6 @@
 require 'test_helper'
-require 'flipper/adapters/active_record'
+require 'active_record'
+require 'flipper-active_record'
 
 # Turn off migration logging for specs
 ActiveRecord::Migration.verbose = false


### PR DESCRIPTION
This PR fixes #445 by making the following changes:

- Removes the unnecessary require of 'active_record' on the adapter code file.
- Lazily loads the adapter models only, instead of the whole adapter code.