### PR TITLE
Describe actor in Flipper.register

### DIFF
--- a/docs/Gates.md
+++ b/docs/Gates.md
@@ -139,7 +139,7 @@ Flipper.register(:admins) do |actor|
   actor.respond_to?(:admin?) && actor.admin?
 end
 ```
-- The above first registers a group called `admins` which essentially saves a [Proc](http://www.eriktrautman.com/posts/ruby-explained-blocks-procs-and-lambdas-aka-closures) to be called later.
+- The above first registers a group called `admins` which essentially saves a [Proc](http://www.eriktrautman.com/posts/ruby-explained-blocks-procs-and-lambdas-aka-closures) to be called later. The `actor` is an instance of the `Flipper::Types::Actor` that wraps the thing being checked against and `actor.thing` is the original object being checked. 
 
 ```
 flipper[:stats].enable flipper.group(:admins)


### PR DESCRIPTION
The documentation doesn't make it clear that the `actor`'s class when checking a group isn't the same as the the class of the actor used in the arguments. 

This change is a small documentation to help clear up that misconception.