### PR TITLE
Remove multi on the Redis adapter for removing a feature

### DIFF
--- a/lib/flipper/adapters/redis.rb
+++ b/lib/flipper/adapters/redis.rb
@@ -34,10 +34,8 @@ module Flipper
 
       # Public: Removes a feature from the set of known features.
       def remove(feature)
-        @client.multi do
-          @client.srem FeaturesKey, feature.key
-          @client.del feature.key
-        end
+        @client.srem FeaturesKey, feature.key
+        @client.del feature.key
         true
       end
 


### PR DESCRIPTION
multi fails on a cluster set.

Fix #451

See https://github.com/jnunemaker/flipper/issues/450#issuecomment-561702603