### PR TITLE
📝 Update docs for mounting Flipper::UI

### DIFF
--- a/docs/ui/README.md
+++ b/docs/ui/README.md
@@ -96,7 +96,7 @@ end
 # config/routes.rb
 
 constraints CanAccessFlipperUI do
-  mount Flipper::UI.app(flipper) => '/flipper'
+  mount Flipper::UI.app(Flipper) => '/flipper'
 end
 ```
 


### PR DESCRIPTION
You need to target `Flipper` here as in the example no instance has been assigned to the `flipper` variable.

Just a small change that I ran into when referencing the examples here and trying to load a file. 