### PR TITLE
Clear Gate Values on Enable

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -33,7 +33,7 @@ Style/GuardClause:
 Style/IfUnlessModifier:
   Enabled: false
 
-Metrics/LineLength:
+Layout/LineLength:
   Max: 100
 
 Style/RegexpLiteral:
@@ -48,5 +48,5 @@ Style/TrailingCommaInHashLiteral:
 RSpec/InstanceVariable:
   Enabled: false
 
-Lint/HandleExceptions:
+Lint/SuppressedException:
   Enabled: false

--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -32,7 +32,7 @@ Gemspec/OrderedDependencies:
 # SupportedHashRocketStyles: key, separator, table
 # SupportedColonStyles: key, separator, table
 # SupportedLastArgumentHashStyles: always_inspect, always_ignore, ignore_implicit, ignore_explicit
-Layout/AlignHash:
+Layout/HashAlignment:
   Exclude:
     - 'lib/flipper/typecast.rb'
 
@@ -81,7 +81,7 @@ Layout/EmptyLinesAroundExceptionHandlingKeywords:
 # Cop supports --auto-correct.
 # Configuration parameters: EnforcedStyle.
 # SupportedStyles: squiggly, active_support, powerpack, unindent
-Layout/IndentHeredoc:
+Layout/HeredocIndentation:
   Exclude:
     - 'test/generators/flipper/active_record_generator_test.rb'
 
@@ -138,13 +138,13 @@ Lint/ShadowingOuterLocalVariable:
 
 # Offense count: 2
 # Cop supports --auto-correct.
-Lint/UnneededCopDisableDirective:
+Lint/RedundantCopDisableDirective:
   Exclude:
     - 'spec/flipper/adapter_spec.rb'
 
 # Offense count: 1
 # Cop supports --auto-correct.
-Lint/UnneededRequireStatement:
+Lint/RedundantRequireStatement:
   Exclude:
     - 'lib/flipper/registry.rb'
 
@@ -174,13 +174,13 @@ Metrics/BlockLength:
 # Offense count: 11
 # Configuration parameters: CountComments.
 Metrics/ClassLength:
-  Max: 150
+  Max: 160
 
 # Offense count: 20
 # Cop supports --auto-correct.
 # Configuration parameters: AutoCorrect, AllowHeredoc, AllowURI, URISchemes, IgnoreCopDirectives, IgnoredPatterns.
 # URISchemes: http, https
-Metrics/LineLength:
+Layout/LineLength:
   Max: 251
 
 # Offense count: 59

--- a/Changelog.md
+++ b/Changelog.md
@@ -4,6 +4,7 @@
 
 * Avoid errors on import when there are no features and shared specs/tests for get all with no features (https://github.com/jnunemaker/flipper/pull/441 and https://github.com/jnunemaker/flipper/pull/442)
 * ::ActiveRecord::RecordNotUnique > ActiveRecord::RecordNotUnique (https://github.com/jnunemaker/flipper/pull/444)
+* Clear gate values on enable (https://github.com/jnunemaker/flipper/pull/454)
 
 ## 0.17.1
 

--- a/flipper-active_record.gemspec
+++ b/flipper-active_record.gemspec
@@ -19,7 +19,7 @@ Gem::Specification.new do |gem|
     'lib/flipper/version.rb',
   ]
   gem.files         = `git ls-files`.split("\n").select(&flipper_active_record_files) + extra_files
-  gem.test_files    = `git ls-files -- {test,spec,features}/*`.split("\n").select(&flipper_active_record_files) # rubocop:disable Metrics/LineLength
+  gem.test_files    = `git ls-files -- {test,spec,features}/*`.split("\n").select(&flipper_active_record_files) # rubocop:disable Layout/LineLength
   gem.name          = 'flipper-active_record'
   gem.require_paths = ['lib']
   gem.version       = Flipper::VERSION

--- a/flipper-active_support_cache_store.gemspec
+++ b/flipper-active_support_cache_store.gemspec
@@ -14,8 +14,8 @@ Gem::Specification.new do |gem|
   gem.license       = 'MIT'
   gem.homepage      = 'https://github.com/jnunemaker/flipper'
 
-  gem.files         = `git ls-files`.split("\n").select(&flipper_active_support_cache_store_files) + ['lib/flipper/version.rb'] # rubocop:disable Metrics/LineLength
-  gem.test_files    = `git ls-files -- {test,spec,features}/*`.split("\n").select(&flipper_active_support_cache_store_files) # rubocop:disable Metrics/LineLength
+  gem.files         = `git ls-files`.split("\n").select(&flipper_active_support_cache_store_files) + ['lib/flipper/version.rb'] # rubocop:disable Layout/LineLength
+  gem.test_files    = `git ls-files -- {test,spec,features}/*`.split("\n").select(&flipper_active_support_cache_store_files) # rubocop:disable Layout/LineLength
   gem.name          = 'flipper-active_support_cache_store'
   gem.require_paths = ['lib']
   gem.version       = Flipper::VERSION

--- a/flipper-api.gemspec
+++ b/flipper-api.gemspec
@@ -13,8 +13,8 @@ Gem::Specification.new do |gem|
   gem.description   = 'Rack middleware that provides an API for the flipper gem.'
   gem.license       = 'MIT'
   gem.homepage      = 'https://github.com/jnunemaker/flipper'
-  gem.files         = `git ls-files`.split("\n").select(&flipper_api_files) + ['lib/flipper/version.rb'] # rubocop:disable Metrics/LineLength
-  gem.test_files    = `git ls-files -- {test,spec,features}/*`.split("\n").select(&flipper_api_files) # rubocop:disable Metrics/LineLength
+  gem.files         = `git ls-files`.split("\n").select(&flipper_api_files) + ['lib/flipper/version.rb'] # rubocop:disable Layout/LineLength
+  gem.test_files    = `git ls-files -- {test,spec,features}/*`.split("\n").select(&flipper_api_files) # rubocop:disable Layout/LineLength
   gem.name          = 'flipper-api'
   gem.require_paths = ['lib']
   gem.version       = Flipper::VERSION

--- a/flipper-cloud.gemspec
+++ b/flipper-cloud.gemspec
@@ -18,7 +18,7 @@ Gem::Specification.new do |gem|
     'lib/flipper/version.rb',
   ]
   gem.files         = `git ls-files`.split("\n").select(&flipper_cloud_files) + extra_files
-  gem.test_files    = `git ls-files -- {test,spec,features}/*`.split("\n").select(&flipper_cloud_files) # rubocop:disable Metrics/LineLength
+  gem.test_files    = `git ls-files -- {test,spec,features}/*`.split("\n").select(&flipper_cloud_files) # rubocop:disable Layout/LineLength
   gem.name          = 'flipper-cloud'
   gem.require_paths = ['lib']
   gem.version       = Flipper::VERSION

--- a/flipper-dalli.gemspec
+++ b/flipper-dalli.gemspec
@@ -14,8 +14,8 @@ Gem::Specification.new do |gem|
   gem.license       = 'MIT'
   gem.homepage      = 'https://github.com/jnunemaker/flipper'
 
-  gem.files         = `git ls-files`.split("\n").select(&flipper_dalli_files) + ['lib/flipper/version.rb'] # rubocop:disable Metrics/LineLength
-  gem.test_files    = `git ls-files -- {test,spec,features}/*`.split("\n").select(&flipper_dalli_files) # rubocop:disable Metrics/LineLength
+  gem.files         = `git ls-files`.split("\n").select(&flipper_dalli_files) + ['lib/flipper/version.rb'] # rubocop:disable Layout/LineLength
+  gem.test_files    = `git ls-files -- {test,spec,features}/*`.split("\n").select(&flipper_dalli_files) # rubocop:disable Layout/LineLength
   gem.name          = 'flipper-dalli'
   gem.require_paths = ['lib']
   gem.version       = Flipper::VERSION

--- a/flipper-moneta.gemspec
+++ b/flipper-moneta.gemspec
@@ -13,8 +13,8 @@ Gem::Specification.new do |gem|
   gem.license       = 'MIT'
   gem.homepage      = 'https://github.com/jnunemaker/flipper'
 
-  gem.files         = `git ls-files`.split("\n").select(&flipper_moneta_files) + ['lib/flipper/version.rb'] # rubocop:disable Metrics/LineLength
-  gem.test_files    = `git ls-files -- {test,spec,features}/*`.split("\n").select(&flipper_moneta_files) # rubocop:disable Metrics/LineLength
+  gem.files         = `git ls-files`.split("\n").select(&flipper_moneta_files) + ['lib/flipper/version.rb'] # rubocop:disable Layout/LineLength
+  gem.test_files    = `git ls-files -- {test,spec,features}/*`.split("\n").select(&flipper_moneta_files) # rubocop:disable Layout/LineLength
   gem.name          = 'flipper-moneta'
   gem.require_paths = ['lib']
   gem.version       = Flipper::VERSION

--- a/flipper-mongo.gemspec
+++ b/flipper-mongo.gemspec
@@ -14,8 +14,8 @@ Gem::Specification.new do |gem|
   gem.license       = 'MIT'
   gem.homepage      = 'https://github.com/jnunemaker/flipper'
 
-  gem.files         = `git ls-files`.split("\n").select(&flipper_mongo_files) + ['lib/flipper/version.rb'] # rubocop:disable Metrics/LineLength
-  gem.test_files    = `git ls-files -- {test,spec,features}/*`.split("\n").select(&flipper_mongo_files) # rubocop:disable Metrics/LineLength
+  gem.files         = `git ls-files`.split("\n").select(&flipper_mongo_files) + ['lib/flipper/version.rb'] # rubocop:disable Layout/LineLength
+  gem.test_files    = `git ls-files -- {test,spec,features}/*`.split("\n").select(&flipper_mongo_files) # rubocop:disable Layout/LineLength
   gem.name          = 'flipper-mongo'
   gem.require_paths = ['lib']
   gem.version       = Flipper::VERSION

--- a/flipper-redis.gemspec
+++ b/flipper-redis.gemspec
@@ -14,8 +14,8 @@ Gem::Specification.new do |gem|
   gem.license       = 'MIT'
   gem.homepage      = 'https://github.com/jnunemaker/flipper'
 
-  gem.files         = `git ls-files`.split("\n").select(&flipper_redis_files) + ['lib/flipper/version.rb'] # rubocop:disable Metrics/LineLength
-  gem.test_files    = `git ls-files -- {test,spec,features}/*`.split("\n").select(&flipper_redis_files) # rubocop:disable Metrics/LineLength
+  gem.files         = `git ls-files`.split("\n").select(&flipper_redis_files) + ['lib/flipper/version.rb'] # rubocop:disable Layout/LineLength
+  gem.test_files    = `git ls-files -- {test,spec,features}/*`.split("\n").select(&flipper_redis_files) # rubocop:disable Layout/LineLength
   gem.name          = 'flipper-redis'
   gem.require_paths = ['lib']
   gem.version       = Flipper::VERSION

--- a/flipper-rollout.gemspec
+++ b/flipper-rollout.gemspec
@@ -14,8 +14,8 @@ Gem::Specification.new do |gem|
   gem.license       = 'MIT'
   gem.homepage      = 'https://github.com/jnunemaker/flipper'
 
-  gem.files         = `git ls-files`.split("\n").select(&flipper_rollout_files) + ['lib/flipper/version.rb'] # rubocop:disable Metrics/LineLength
-  gem.test_files    = `git ls-files -- {test,spec,features}/*`.split("\n").select(&flipper_rollout_files) # rubocop:disable Metrics/LineLength
+  gem.files         = `git ls-files`.split("\n").select(&flipper_rollout_files) + ['lib/flipper/version.rb'] # rubocop:disable Layout/LineLength
+  gem.test_files    = `git ls-files -- {test,spec,features}/*`.split("\n").select(&flipper_rollout_files) # rubocop:disable Layout/LineLength
   gem.name          = 'flipper-rollout'
   gem.require_paths = ['lib']
   gem.version       = Flipper::VERSION

--- a/flipper-sequel.gemspec
+++ b/flipper-sequel.gemspec
@@ -16,7 +16,7 @@ Gem::Specification.new do |gem|
     'lib/flipper/version.rb',
   ]
   gem.files         = `git ls-files`.split("\n").select(&flipper_sequel_files) + extra_files
-  gem.test_files    = `git ls-files -- {test,spec,features}/*`.split("\n").select(&flipper_sequel_files) # rubocop:disable Metrics/LineLength
+  gem.test_files    = `git ls-files -- {test,spec,features}/*`.split("\n").select(&flipper_sequel_files) # rubocop:disable Layout/LineLength
   gem.name          = 'flipper-sequel'
   gem.require_paths = ['lib']
   gem.version       = Flipper::VERSION

--- a/flipper-ui.gemspec
+++ b/flipper-ui.gemspec
@@ -10,11 +10,11 @@ Gem::Specification.new do |gem|
   gem.authors       = ['John Nunemaker']
   gem.email         = ['nunemaker@gmail.com']
   gem.summary       = 'UI for the Flipper gem'
-  gem.description   = 'Rack middleware that provides a fully featured web interface for the flipper gem.' # rubocop:disable Metrics/LineLength
+  gem.description   = 'Rack middleware that provides a fully featured web interface for the flipper gem.' # rubocop:disable Layout/LineLength
   gem.license       = 'MIT'
   gem.homepage      = 'https://github.com/jnunemaker/flipper'
 
-  gem.files         = `git ls-files`.split("\n").select(&flipper_ui_files) + ['lib/flipper/version.rb'] # rubocop:disable Metrics/LineLength
+  gem.files         = `git ls-files`.split("\n").select(&flipper_ui_files) + ['lib/flipper/version.rb'] # rubocop:disable Layout/LineLength
   gem.test_files    = `git ls-files -- {test,spec,features}/*`.split("\n").select(&flipper_ui_files)
   gem.name          = 'flipper-ui'
   gem.require_paths = ['lib']

--- a/flipper.gemspec
+++ b/flipper.gemspec
@@ -25,7 +25,7 @@ Gem::Specification.new do |gem|
   gem.authors       = ['John Nunemaker']
   gem.email         = ['nunemaker@gmail.com']
   gem.summary       = 'Feature flipper for ANYTHING'
-  gem.description   = 'Feature flipper is the act of enabling/disabling features in your application, ideally without re-deploying or changing anything in your code base. Flipper makes this extremely easy to do with any backend you would like to use.' # rubocop:disable Metrics/LineLength
+  gem.description   = 'Feature flipper is the act of enabling/disabling features in your application, ideally without re-deploying or changing anything in your code base. Flipper makes this extremely easy to do with any backend you would like to use.' # rubocop:disable Layout/LineLength
   gem.homepage      = 'https://github.com/jnunemaker/flipper'
   gem.license       = 'MIT'
 

--- a/lib/flipper/adapters/active_record.rb
+++ b/lib/flipper/adapters/active_record.rb
@@ -125,7 +125,9 @@ module Flipper
       # Returns true.
       def enable(feature, gate, thing)
         case gate.data_type
-        when :boolean, :integer
+        when :boolean
+          set(feature, gate, thing, clear: true)
+        when :integer
           set(feature, gate, thing)
         when :set
           enable_multi(feature, gate, thing)
@@ -165,8 +167,10 @@ module Flipper
 
       private
 
-      def set(feature, gate, thing)
+      def set(feature, gate, thing, options = {})
+        clear_feature = options.fetch(:clear, false)
         @gate_class.transaction do
+          clear(feature) if clear_feature
           @gate_class.where(feature_key: feature.key, key: gate.key).destroy_all
           @gate_class.create! do |g|
             g.feature_key = feature.key

--- a/lib/flipper/adapters/memory.rb
+++ b/lib/flipper/adapters/memory.rb
@@ -65,7 +65,10 @@ module Flipper
       # Public
       def enable(feature, gate, thing)
         case gate.data_type
-        when :boolean, :integer
+        when :boolean
+          clear(feature)
+          write key(feature, gate), thing.value.to_s
+        when :integer
           write key(feature, gate), thing.value.to_s
         when :set
           set_add key(feature, gate), thing.value.to_s

--- a/lib/flipper/adapters/moneta.rb
+++ b/lib/flipper/adapters/moneta.rb
@@ -57,7 +57,12 @@ module Flipper
       # Returns true.
       def enable(feature, gate, thing)
         case gate.data_type
-        when :boolean, :integer
+        when :boolean
+          clear(feature)
+          result = get(feature)
+          result[gate.key] = thing.value.to_s
+          moneta[key(feature.key)] = result
+        when :integer
           result = get(feature)
           result[gate.key] = thing.value.to_s
           moneta[key(feature.key)] = result

--- a/lib/flipper/adapters/mongo.rb
+++ b/lib/flipper/adapters/mongo.rb
@@ -68,7 +68,12 @@ module Flipper
       # Returns true.
       def enable(feature, gate, thing)
         case gate.data_type
-        when :boolean, :integer
+        when :boolean
+          clear(feature)
+          update feature.key, '$set' => {
+            gate.key.to_s => thing.value.to_s,
+          }
+        when :integer
           update feature.key, '$set' => {
             gate.key.to_s => thing.value.to_s,
           }

--- a/lib/flipper/adapters/pstore.rb
+++ b/lib/flipper/adapters/pstore.rb
@@ -84,7 +84,10 @@ module Flipper
       def enable(feature, gate, thing)
         @store.transaction do
           case gate.data_type
-          when :boolean, :integer
+          when :boolean
+            clear_gates(feature)
+            write key(feature, gate), thing.value.to_s
+          when :integer
             write key(feature, gate), thing.value.to_s
           when :set
             set_add key(feature, gate), thing.value.to_s

--- a/lib/flipper/adapters/redis.rb
+++ b/lib/flipper/adapters/redis.rb
@@ -71,7 +71,10 @@ module Flipper
       # Returns true.
       def enable(feature, gate, thing)
         case gate.data_type
-        when :boolean, :integer
+        when :boolean
+          clear(feature)
+          @client.hset feature.key, gate.key, thing.value.to_s
+        when :integer
           @client.hset feature.key, gate.key, thing.value.to_s
         when :set
           @client.hset feature.key, to_field(gate, thing), 1

--- a/lib/flipper/adapters/sequel.rb
+++ b/lib/flipper/adapters/sequel.rb
@@ -120,7 +120,17 @@ module Flipper
       # Returns true.
       def enable(feature, gate, thing)
         case gate.data_type
-        when :boolean, :integer
+        when :boolean
+          @gate_class.db.transaction do
+            clear(feature)
+            args = {
+              feature_key: feature.key,
+              key: gate.key.to_s,
+            }
+            @gate_class.where(args).delete
+            @gate_class.create(gate_attrs(feature, gate, thing))
+          end
+        when :integer
           @gate_class.db.transaction do
             args = {
               feature_key: feature.key,

--- a/lib/flipper/middleware/memoizer.rb
+++ b/lib/flipper/middleware/memoizer.rb
@@ -23,7 +23,7 @@ module Flipper
       #
       def initialize(app, opts = {})
         if opts.is_a?(Flipper::DSL) || opts.is_a?(Proc)
-          raise 'Flipper::Middleware::Memoizer no longer initializes with a flipper instance or block. Read more at: https://git.io/vSo31.' # rubocop:disable LineLength
+          raise 'Flipper::Middleware::Memoizer no longer initializes with a flipper instance or block. Read more at: https://git.io/vSo31.' # rubocop:disable Layout/LineLength
         end
 
         @app = app

--- a/lib/flipper/spec/shared_adapter_specs.rb
+++ b/lib/flipper/spec/shared_adapter_specs.rb
@@ -294,4 +294,14 @@ RSpec.shared_examples_for 'a flipper adapter' do
     expect(subject.features).to eq(Set.new)
     expect(subject.get_all).to eq({})
   end
+
+  it 'clears other gate values on enable' do
+    actor = Flipper::Actor.new('Flipper::Actor;22')
+    subject.enable(feature, actors_gate, flipper.actors(25))
+    subject.enable(feature, time_gate, flipper.time(25))
+    subject.enable(feature, group_gate, flipper.group(:admins))
+    subject.enable(feature, actor_gate, flipper.actor(actor))
+    subject.enable(feature, boolean_gate, flipper.boolean(true))
+    expect(subject.get(feature)).to eq(subject.default_config.merge(boolean: "true"))
+  end
 end

--- a/lib/flipper/test/shared_adapter_test.rb
+++ b/lib/flipper/test/shared_adapter_test.rb
@@ -291,6 +291,16 @@ module Flipper
         assert_equal Set.new, @adapter.features
         assert_equal expected, @adapter.get_all
       end
+
+      def test_clears_other_gate_values_on_enable
+        actor = Flipper::Actor.new('Flipper::Actor;22')
+        assert_equal true, @adapter.enable(@feature, @actors_gate, @flipper.actors(25))
+        assert_equal true, @adapter.enable(@feature, @time_gate, @flipper.time(25))
+        assert_equal true, @adapter.enable(@feature, @group_gate, @flipper.group(:admins))
+        assert_equal true, @adapter.enable(@feature, @actor_gate, @flipper.actor(actor))
+        assert_equal true, @adapter.enable(@feature, @boolean_gate, @flipper.boolean(true))
+        assert_equal @adapter.default_config.merge(boolean: "true"), @adapter.get(@feature)
+      end
     end
   end
 end

--- a/lib/flipper/ui/configuration.rb
+++ b/lib/flipper/ui/configuration.rb
@@ -49,9 +49,9 @@ module Flipper
       def initialize
         @actors = Option.new("Actors", "Enable actors using the form above.")
         @groups = Option.new("Groups", "Enable groups using the form above.")
-        @percentage_of_actors = Option.new("Percentage of Actors", "Percentage of actors functions independently of percentage of time. If you enable 50% of Actors and 25% of Time then the feature will always be enabled for 50% of users and occasionally enabled 25% of the time for everyone.") # rubocop:disable Metrics/LineLength
-        @percentage_of_time = Option.new("Percentage of Time", "Percentage of actors functions independently of percentage of time. If you enable 50% of Actors and 25% of Time then the feature will always be enabled for 50% of users and occasionally enabled 25% of the time for everyone.") # rubocop:disable Metrics/LineLength
-        @delete = Option.new("Danger Zone", "Deleting a feature removes it from the list of features and disables it for everyone.") # rubocop:disable Metrics/LineLength
+        @percentage_of_actors = Option.new("Percentage of Actors", "Percentage of actors functions independently of percentage of time. If you enable 50% of Actors and 25% of Time then the feature will always be enabled for 50% of users and occasionally enabled 25% of the time for everyone.") # rubocop:disable Layout/LineLength
+        @percentage_of_time = Option.new("Percentage of Time", "Percentage of actors functions independently of percentage of time. If you enable 50% of Actors and 25% of Time then the feature will always be enabled for 50% of users and occasionally enabled 25% of the time for everyone.") # rubocop:disable Layout/LineLength
+        @delete = Option.new("Danger Zone", "Deleting a feature removes it from the list of features and disables it for everyone.") # rubocop:disable Layout/LineLength
         @banner_text = nil
         @banner_class = 'danger'
         @feature_creation_enabled = true

--- a/spec/flipper/ui/actions/actors_gate_spec.rb
+++ b/spec/flipper/ui/actions/actors_gate_spec.rb
@@ -73,23 +73,23 @@ RSpec.describe Flipper::UI::Actions::ActorsGate do
         context 'empty value' do
           let(:value) { '' }
 
-          # rubocop:disable Metrics/LineLength
+          # rubocop:disable Layout/LineLength
           it 'redirects back to feature' do
             expect(last_response.status).to be(302)
             expect(last_response.headers['Location']).to eq('/features/search/actors?error=%22%22+is+not+a+valid+actor+value.')
           end
-          # rubocop:enable Metrics/LineLength
+          # rubocop:enable Layout/LineLength
         end
 
         context 'nil value' do
           let(:value) { nil }
 
-          # rubocop:disable Metrics/LineLength
+          # rubocop:disable Layout/LineLength
           it 'redirects back to feature' do
             expect(last_response.status).to be(302)
             expect(last_response.headers['Location']).to eq('/features/search/actors?error=%22%22+is+not+a+valid+actor+value.')
           end
-          # rubocop:enable Metrics/LineLength
+          # rubocop:enable Layout/LineLength
         end
       end
     end

--- a/spec/flipper/ui/actions/features_spec.rb
+++ b/spec/flipper/ui/actions/features_spec.rb
@@ -111,12 +111,12 @@ RSpec.describe Flipper::UI::Actions::Features do
             expect(flipper.features.map(&:key)).to eq([])
           end
 
-          # rubocop:disable Metrics/LineLength
+          # rubocop:disable Layout/LineLength
           it 'redirects back to feature' do
             expect(last_response.status).to be(302)
             expect(last_response.headers['Location']).to eq('/features/new?error=%22%22+is+not+a+valid+feature+name.')
           end
-          # rubocop:enable Metrics/LineLength
+          # rubocop:enable Layout/LineLength
         end
 
         context 'nil feature name' do
@@ -126,12 +126,12 @@ RSpec.describe Flipper::UI::Actions::Features do
             expect(flipper.features.map(&:key)).to eq([])
           end
 
-          # rubocop:disable Metrics/LineLength
+          # rubocop:disable Layout/LineLength
           it 'redirects back to feature' do
             expect(last_response.status).to be(302)
             expect(last_response.headers['Location']).to eq('/features/new?error=%22%22+is+not+a+valid+feature+name.')
           end
-          # rubocop:enable Metrics/LineLength
+          # rubocop:enable Layout/LineLength
         end
       end
     end

--- a/spec/flipper/ui/actions/groups_gate_spec.rb
+++ b/spec/flipper/ui/actions/groups_gate_spec.rb
@@ -72,34 +72,34 @@ RSpec.describe Flipper::UI::Actions::GroupsGate do
         context 'unknown group name' do
           let(:group_name) { 'not_here' }
 
-          # rubocop:disable Metrics/LineLength
+          # rubocop:disable Layout/LineLength
           it 'redirects back to feature' do
             expect(last_response.status).to be(302)
             expect(last_response.headers['Location']).to eq('/features/search/groups?error=The+group+named+%22not_here%22+has+not+been+registered.')
           end
-          # rubocop:enable Metrics/LineLength
+          # rubocop:enable Layout/LineLength
         end
 
         context 'empty group name' do
           let(:group_name) { '' }
 
-          # rubocop:disable Metrics/LineLength
+          # rubocop:disable Layout/LineLength
           it 'redirects back to feature' do
             expect(last_response.status).to be(302)
             expect(last_response.headers['Location']).to eq('/features/search/groups?error=The+group+named+%22%22+has+not+been+registered.')
           end
-          # rubocop:enable Metrics/LineLength
+          # rubocop:enable Layout/LineLength
         end
 
         context 'nil group name' do
           let(:group_name) { nil }
 
-          # rubocop:disable Metrics/LineLength
+          # rubocop:disable Layout/LineLength
           it 'redirects back to feature' do
             expect(last_response.status).to be(302)
             expect(last_response.headers['Location']).to eq('/features/search/groups?error=The+group+named+%22%22+has+not+been+registered.')
           end
-          # rubocop:enable Metrics/LineLength
+          # rubocop:enable Layout/LineLength
         end
       end
     end

--- a/spec/flipper/ui/actions/percentage_of_actors_gate_spec.rb
+++ b/spec/flipper/ui/actions/percentage_of_actors_gate_spec.rb
@@ -41,12 +41,12 @@ RSpec.describe Flipper::UI::Actions::PercentageOfActorsGate do
         expect(flipper[:search].percentage_of_actors_value).to be(0)
       end
 
-      # rubocop:disable Metrics/LineLength
+      # rubocop:disable Layout/LineLength
       it 'redirects back to feature' do
         expect(last_response.status).to be(302)
         expect(last_response.headers['Location']).to eq('/features/search?error=Invalid+percentage+of+actors+value%3A+value+must+be+a+positive+number+less+than+or+equal+to+100%2C+but+was+555')
       end
-      # rubocop:enable Metrics/LineLength
+      # rubocop:enable Layout/LineLength
     end
   end
 end

--- a/spec/flipper/ui/actions/percentage_of_time_gate_spec.rb
+++ b/spec/flipper/ui/actions/percentage_of_time_gate_spec.rb
@@ -41,12 +41,12 @@ RSpec.describe Flipper::UI::Actions::PercentageOfTimeGate do
         expect(flipper[:search].percentage_of_time_value).to be(0)
       end
 
-      # rubocop:disable Metrics/LineLength
+      # rubocop:disable Layout/LineLength
       it 'redirects back to feature' do
         expect(last_response.status).to be(302)
         expect(last_response.headers['Location']).to eq('/features/search?error=Invalid+percentage+of+time+value%3A+value+must+be+a+positive+number+less+than+or+equal+to+100%2C+but+was+555')
       end
-      # rubocop:enable Metrics/LineLength
+      # rubocop:enable Layout/LineLength
     end
   end
 end

--- a/spec/flipper/ui/configuration_spec.rb
+++ b/spec/flipper/ui/configuration_spec.rb
@@ -25,21 +25,21 @@ RSpec.describe Flipper::UI::Configuration do
   describe "#percentage_of_actors" do
     it "has default text" do
       expect(configuration.percentage_of_actors.title).to eq("Percentage of Actors")
-      expect(configuration.percentage_of_actors.description).to eq("Percentage of actors functions independently of percentage of time. If you enable 50% of Actors and 25% of Time then the feature will always be enabled for 50% of users and occasionally enabled 25% of the time for everyone.") # rubocop:disable Metrics/LineLength
+      expect(configuration.percentage_of_actors.description).to eq("Percentage of actors functions independently of percentage of time. If you enable 50% of Actors and 25% of Time then the feature will always be enabled for 50% of users and occasionally enabled 25% of the time for everyone.") # rubocop:disable Layout/LineLength
     end
   end
 
   describe "#percentage_of_time" do
     it "has default text" do
       expect(configuration.percentage_of_time.title).to eq("Percentage of Time")
-      expect(configuration.percentage_of_time.description).to eq("Percentage of actors functions independently of percentage of time. If you enable 50% of Actors and 25% of Time then the feature will always be enabled for 50% of users and occasionally enabled 25% of the time for everyone.") # rubocop:disable Metrics/LineLength
+      expect(configuration.percentage_of_time.description).to eq("Percentage of actors functions independently of percentage of time. If you enable 50% of Actors and 25% of Time then the feature will always be enabled for 50% of users and occasionally enabled 25% of the time for everyone.") # rubocop:disable Layout/LineLength
     end
   end
 
   describe "#delete" do
     it "has default text" do
       expect(configuration.delete.title).to eq("Danger Zone")
-      expect(configuration.delete.description).to eq("Deleting a feature removes it from the list of features and disables it for everyone.") # rubocop:disable Metrics/LineLength
+      expect(configuration.delete.description).to eq("Deleting a feature removes it from the list of features and disables it for everyone.") # rubocop:disable Layout/LineLength
     end
   end
 

--- a/spec/helper.rb
+++ b/spec/helper.rb
@@ -17,7 +17,7 @@ require 'flipper'
 require 'flipper-ui'
 require 'flipper-api'
 
-Dir[FlipperRoot.join('spec/support/**/*.rb')].each { |f| require f }
+Dir[FlipperRoot.join('spec/support/**/*.rb')].sort.each { |f| require f }
 
 RSpec.configure do |config|
   config.before(:example) do

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -1,6 +1,6 @@
 require 'flipper'
 require 'minitest/autorun'
 require 'minitest/unit'
-Dir['./lib/flipper/test/*.rb'].each { |f| require(f) }
+Dir['./lib/flipper/test/*.rb'].sort.each { |f| require(f) }
 
 FlipperRoot = Pathname(__FILE__).dirname.join('..').expand_path


### PR DESCRIPTION
As mentioned by @yjukaku in https://github.com/jnunemaker/flipper/issues/422#issuecomment-568560018, gates are cleared for disable, but not for enable. They thought it was only for AR but it is actually for all adapters. Though I'd like to get to a place long term where you can enable/disable and retain the gate values in some fashion, it feels like disable and enable should work the same in the short term. This PR makes them work the same. It adds shared tests and updates all supported adapters to clear gate values on enable. This should have zero negative effects. The reason why is that the only revert of enable is disable which clears the gates. 