### PR TITLE
Update docs: Include Rails 6 in list of versions

### DIFF
--- a/docs/Adapters.md
+++ b/docs/Adapters.md
@@ -4,7 +4,7 @@ I plan on supporting the adapters in the flipper repo. Other adapters are welcom
 
 ## Officially Supported
 
-* [ActiveRecord adapter](https://github.com/jnunemaker/flipper/blob/master/docs/active_record) - Rails 3, 4, and 5.
+* [ActiveRecord adapter](https://github.com/jnunemaker/flipper/blob/master/docs/active_record) - Rails 3, 4, 5, and 6.
 * [ActiveSupportCacheStore adapter](https://github.com/jnunemaker/flipper/blob/master/docs/active_support_cache_store) - ActiveSupport::Cache::Store
 * [Cassanity adapter](https://github.com/jnunemaker/flipper-cassanity)
 * [Http adapter](https://github.com/jnunemaker/flipper/blob/master/docs/http)


### PR DESCRIPTION
Tiny doc update for you. I noticed rails 6 is mentioned elsewhere, just not here. 