### PR TITLE
Development with Docker - Ruby version adjusted to avoid gem issues

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM ruby:2.2.5
+FROM ruby:2.5
 
 RUN apt-get update && apt-get install -y \
   # build-essential \


### PR DESCRIPTION
Hello folks!

Ive found issues with Ruby versions while setting up my Development environment following Docker instructions from here:

`Docker Compose for contributors`
https://github.com/jnunemaker/flipper/blob/master/docs/DockerCompose.md

```ruby
flipper % docker-compose build
...
OK

flipper % docker-compose run --rm app bundle install
Starting flipper_mongo ... done
Starting flipper_redis ... done
Starting flipper_bundle_cache ... done
Starting flipper_memcached    ... done
Fetching gem metadata from https://rubygems.org/..........
Fetching version metadata from https://rubygems.org/..
Fetching dependency metadata from https://rubygems.org/.
Resolving dependencies...
i18n-1.8.2 requires ruby version >= 2.3.0, which is incompatible with the current version, ruby 2.2.5p319
```

After upgrading ruby version to `2.3.0` within `Dockerfile`:

```ruby
flipper % docker-compose build
...
OK

flipper % docker-compose run --rm app bundle install
Creating flipper_bundle_cache ... done
Creating flipper_redis        ... done
Creating flipper_mongo        ... done
Creating flipper_memcached    ... done
Fetching gem metadata from https://rubygems.org/...........
Fetching version metadata from https://rubygems.org/...
Fetching dependency metadata from https://rubygems.org/..
Resolving dependencies....
Installing builder 3.2.4
Installing rake 12.3.3
Installing erubi 1.9.0
Installing zeitwerk 2.3.0

Gem::InstallError: zeitwerk requires Ruby version >= 2.4.4.
...
```

After upgrading ruby version to `2.4.4` within `Dockerfile`:

```ruby
flipper % docker-compose build
...
OK

flipper % docker-compose run --rm app bundle install
Creating flipper_bundle_cache ... done
Creating flipper_redis        ... done
Creating flipper_mongo        ... done
Creating flipper_memcached    ... done
Fetching gem metadata from https://rubygems.org/.........
activesupport-6.0.3 requires ruby version >= 2.5.0, which is incompatible with the current version, ruby 2.4.4p296
```

After upgrading ruby version to `2.5` within `Dockerfile`:

```ruby
flipper % docker-compose build
...
OK

flipper % docker-compose run --rm app bundle install
Creating flipper_bundle_cache ... done
Creating flipper_redis        ... done
Creating flipper_mongo        ... done
Creating flipper_memcached    ... done
Fetching gem metadata from https://rubygems.org/.........
Fetching rake 12.3.3
Fetching zeitwerk 2.3.0
Fetching concurrent-ruby 1.1.6
Fetching builder 3.2.4
Fetching erubi 1.9.0
Fetching thread_safe 0.3.6
Fetching minitest 5.14.0
Installing zeitwerk 2.3.0
Installing rake 12.3.3
Fetching mini_portile2 2.4.0
Installing erubi 1.9.0
Installing builder 3.2.4
Fetching crass 1.0.6
Fetching rack 2.2.2
Fetching nio4r 2.5.2
Installing concurrent-ruby 1.1.6
Fetching websocket-extensions 0.1.4
Installing mini_portile2 2.4.0
Fetching mimemagic 0.3.5
Installing thread_safe 0.3.6
Fetching mini_mime 1.0.2
Installing nio4r 2.5.2 with native extensions
Installing crass 1.0.6
Fetching public_suffix 4.0.5
Installing websocket-extensions 0.1.4
Fetching ast 2.4.0
Installing mini_mime 1.0.2
Fetching bson 4.8.2
Installing rack 2.2.2
Installing minitest 5.14.0
Using bundler 1.16.1
Fetching coderay 1.1.2
Fetching coffee-script-source 1.12.2
Installing ast 2.4.0
Fetching execjs 2.7.0
Installing public_suffix 4.0.5
Fetching safe_yaml 1.0.5
Installing mimemagic 0.3.5
Fetching dalli 2.7.10
Installing coderay 1.1.2
Installing coffee-script-source 1.12.2
Fetching diff-lcs 1.3
Installing bson 4.8.2 with native extensions
Installing execjs 2.7.0
Fetching ffi 1.12.2
Using flipper 0.17.2 from source at `.`
Installing safe_yaml 1.0.5
Fetching moneta 1.1.1
Installing dalli 2.7.10
Fetching redis 4.1.4
Installing diff-lcs 1.3
Fetching sequel 5.32.0
Installing moneta 1.1.1
Fetching formatador 0.2.5
Fetching rb-fsevent 0.10.4
Fetching lumberjack 1.2.4
Installing ffi 1.12.2 with native extensions
Installing formatador 0.2.5
Fetching nenv 0.3.0
Fetching shellany 0.0.1
Installing shellany 0.0.1
Fetching method_source 1.0.0
Installing nenv 0.3.0
Fetching thor 1.0.1
Installing method_source 1.0.0
Fetching guard-compat 1.2.1
Installing lumberjack 1.2.4
Fetching rspec-support 3.9.3
Installing thor 1.0.1
Installing rb-fsevent 0.10.4
Fetching parallel 1.19.1
Fetching rainbow 3.0.0
Installing guard-compat 1.2.1
Fetching rexml 3.2.4
Installing parallel 1.19.1
Installing rspec-support 3.9.3
Installing rainbow 3.0.0
Fetching ruby-progressbar 1.10.1
Fetching unicode-display_width 1.7.0
Fetching hashdiff 1.0.1
Installing unicode-display_width 1.7.0
Fetching sqlite3 1.3.13
Installing hashdiff 1.0.1
Installing rexml 3.2.4
Fetching statsd-ruby 1.2.1
Fetching i18n 1.8.2
Installing ruby-progressbar 1.10.1
Fetching nokogiri 1.10.9
Installing sqlite3 1.3.13 with native extensions
Installing statsd-ruby 1.2.1
Fetching tzinfo 1.2.7
Installing sequel 5.32.0
Installing i18n 1.8.2
Fetching websocket-driver 0.7.1
Fetching mail 2.7.1
Installing redis 4.1.4
Fetching minitest-documentation 1.0.0
Installing websocket-driver 0.7.1 with native extensions
Installing tzinfo 1.2.7
Fetching rack-test 0.6.3
Installing minitest-documentation 1.0.0
Fetching rack-protection 2.0.8.1
Installing rack-test 0.6.3
Fetching sprockets 4.0.0
Installing rack-protection 2.0.8.1
Fetching shotgun 0.9.2
Fetching parser 2.7.1.2
Installing mail 2.7.1
Fetching addressable 2.7.0
Installing shotgun 0.9.2
Fetching marcel 0.3.3
Installing sprockets 4.0.0
Fetching coffee-script 2.4.1
Installing marcel 0.3.3
Fetching crack 0.4.3
Installing addressable 2.7.0
Using flipper-api 0.17.2 from source at `.`
Installing coffee-script 2.4.1
Using flipper-cloud 0.17.2 from source at `.`
Installing parser 2.7.1.2
Using flipper-dalli 0.17.2 from source at `.`
Installing crack 0.4.3
Using flipper-moneta 0.17.2 from source at `.`
Fetching mongo 2.12.1
Fetching notiffany 0.1.3
Fetching rspec-mocks 3.9.1
Fetching rspec-core 3.9.2
Fetching rspec-expectations 3.9.2
Fetching pry 0.13.1
Installing notiffany 0.1.3
Using flipper-sequel 0.17.2 from source at `.`
Using flipper-redis 0.17.2 from source at `.`
Fetching rollout 2.4.5
Installing rspec-expectations 3.9.2
Fetching activesupport 6.0.3
Installing rspec-mocks 3.9.1
Using flipper-ui 0.17.2 from source at `.`
Fetching rb-inotify 0.10.1
Installing rspec-core 3.9.2
Fetching rubocop 0.83.0
Installing rollout 2.4.5
Fetching webmock 3.8.3
Installing pry 0.13.1
Fetching rspec 3.9.0
Installing rb-inotify 0.10.1
Using flipper-rollout 0.17.2 from source at `.`
Fetching listen 3.2.1
Installing rspec 3.9.0
Fetching sass-listen 4.0.0
Installing activesupport 6.0.3
Fetching globalid 0.4.2
Installing listen 3.2.1
Fetching activemodel 6.0.3
Installing webmock 3.8.3
Using flipper-active_support_cache_store 0.17.2 from source at `.`
Fetching guard 2.16.2
Installing sass-listen 4.0.0
Fetching sass 3.7.4
Installing globalid 0.4.2
Fetching activejob 6.0.3
Installing rubocop 0.83.0
Installing guard 2.16.2
Installing activemodel 6.0.3
Fetching guard-bundler 2.2.1
Fetching guard-coffeescript 2.0.1
Installing activejob 6.0.3
Fetching guard-rspec 4.7.3
Fetching activerecord 6.0.3
Installing guard-bundler 2.2.1
Fetching guard-rubocop 1.3.0
Installing guard-coffeescript 2.0.1
Fetching rubocop-rspec 1.39.0
Installing sass 3.7.4
Fetching guard-sass 1.6.1
Installing guard-rspec 4.7.3
Installing guard-rubocop 1.3.0
Installing guard-sass 1.6.1
Installing rubocop-rspec 1.39.0
Installing mongo 2.12.1
Using flipper-mongo 0.17.2 from source at `.`
Installing activerecord 6.0.3
Using flipper-active_record 0.17.2 from source at `.`
Installing nokogiri 1.10.9 with native extensions
Fetching rails-dom-testing 2.0.3
Fetching loofah 2.5.0
Installing rails-dom-testing 2.0.3
Installing loofah 2.5.0
Fetching rails-html-sanitizer 1.3.0
Installing rails-html-sanitizer 1.3.0
Fetching actionview 6.0.3
Installing actionview 6.0.3
Fetching actionpack 6.0.3
Installing actionpack 6.0.3
Fetching actioncable 6.0.3
Fetching actionmailer 6.0.3
Fetching railties 6.0.3
Fetching sprockets-rails 3.2.1
Fetching activestorage 6.0.3
Installing sprockets-rails 3.2.1
Installing actionmailer 6.0.3
Installing actioncable 6.0.3
Installing activestorage 6.0.3
Fetching actionmailbox 6.0.3
Fetching actiontext 6.0.3
Installing actiontext 6.0.3
Installing actionmailbox 6.0.3
Installing railties 6.0.3
Fetching rails 6.0.3
Installing rails 6.0.3
Bundle complete! 32 Gemfile dependencies, 111 gems now installed.
Bundled gems are installed into `/bundle_cache`
Post-install message from i18n:

HEADS UP! i18n 1.1 changed fallbacks to exclude default locale.
But that may break your application.

If you are upgrading your Rails application from an older version of Rails:

Please check your Rails app for 'config.i18n.fallbacks = true'.
If you're using I18n (>= 1.1.0) and Rails (< 5.2.2), this should be
'config.i18n.fallbacks = [I18n.default_locale]'.
If not, fallbacks will be broken in your app by I18n 1.1.x.

If you are starting a NEW Rails application, you can ignore this notice.

For more info see:
https://github.com/svenfuchs/i18n/releases/tag/v1.1.0

Post-install message from sass:

Ruby Sass has reached end-of-life and should no longer be used.

* If you use Sass as a command-line tool, we recommend using Dart Sass, the new
  primary implementation: https://sass-lang.com/install

* If you use Sass as a plug-in for a Ruby web framework, we recommend using the
  sassc gem: https://github.com/sass/sassc-ruby#readme

* For more details, please refer to the Sass blog:
  https://sass-lang.com/blog/posts/7828841
```