### PR TITLE
Add `descriptions` support for `features`

### DIFF
--- a/docs/ui/README.md
+++ b/docs/ui/README.md
@@ -148,6 +148,17 @@ Flipper::UI.configure do |config|
 end
 ```
 
+We can also associate a `description` for each `feature` by providing a descriptions source:
+
+```ruby
+Flipper::UI.configure do |config|
+  config.descriptions_source = ->(keys) do
+    # descriptions loaded from YAML file or database (postgres, mysql, etc)
+    # return has to be hash of {String key => String description}
+  end
+end
+```
+
 results in:
 
 ![configure](images/configured-ui.png)

--- a/lib/flipper/ui/action.rb
+++ b/lib/flipper/ui/action.rb
@@ -1,4 +1,5 @@
 require 'forwardable'
+require 'flipper/ui/configuration'
 require 'flipper/ui/error'
 require 'erubi'
 require 'json'
@@ -63,6 +64,14 @@ module Flipper
       def self.public_path
         @public_path ||= Flipper::UI.root.join('public')
       end
+
+      ##### RFC: What if we place the `descriptions` call here instead ?
+      #####      so we avoid calling it from both `feature` and `features` actions
+
+      # Private: The path to descriptions source
+      # def self.descriptions
+      #   Flipper::UI.configuration.descriptions_source
+      # end
 
       # Public: The instance of the Flipper::DSL the middleware was
       # initialized with.

--- a/lib/flipper/ui/actions/feature.rb
+++ b/lib/flipper/ui/actions/feature.rb
@@ -11,6 +11,8 @@ module Flipper
 
         def get
           @feature = Decorators::Feature.new(flipper[feature_name])
+          descriptions = Flipper::UI.configuration.descriptions_source
+          @feature.description = descriptions[@feature.key]
           @page_title = "#{@feature.key} // Features"
           @percentages = [0, 1, 5, 10, 15, 25, 50, 75, 100]
 

--- a/lib/flipper/ui/actions/features.rb
+++ b/lib/flipper/ui/actions/features.rb
@@ -10,8 +10,11 @@ module Flipper
 
         def get
           @page_title = 'Features'
+          descriptions = Flipper::UI.configuration.descriptions_source
           @features = flipper.features.map do |feature|
-            Decorators::Feature.new(feature)
+            decorator = Decorators::Feature.new(feature)
+            decorator.description = descriptions[feature.key]
+            decorator
           end.sort
 
           @show_blank_slate = @features.empty?

--- a/lib/flipper/ui/configuration.rb
+++ b/lib/flipper/ui/configuration.rb
@@ -35,6 +35,11 @@ module Flipper
       # application needs. Defaults to "a flipper id".
       attr_accessor :add_actor_placeholder
 
+      # Public: If you set this, Flipper::UI will fetch descriptions
+      # from your external source. Descriptions for `features` will be shown on `feature`
+      # and `features` pages. Defaults to empty hash.
+      attr_accessor :descriptions_source
+
       VALID_BANNER_CLASS_VALUES = %w(
         danger
         dark
@@ -58,6 +63,7 @@ module Flipper
         @feature_removal_enabled = true
         @fun = true
         @add_actor_placeholder = "a flipper id"
+        @descriptions_source = ->(args) {}
       end
 
       def banner_class=(value)

--- a/lib/flipper/ui/decorators/feature.rb
+++ b/lib/flipper/ui/decorators/feature.rb
@@ -11,6 +11,8 @@ module Flipper
         # Public: The feature being decorated.
         alias_method :feature, :__getobj__
 
+        attr_accessor :description
+
         # Public: Returns name titleized.
         def pretty_name
           @pretty_name ||= Util.titleize(name)
@@ -22,6 +24,7 @@ module Flipper
           {
             'id' => name.to_s,
             'name' => pretty_name,
+            'description' => description,
             'state' => state.to_s,
             'gates' => gates.map do |gate|
               Decorators::Gate.new(gate, gate_values[gate.key]).as_json

--- a/lib/flipper/ui/views/feature.erb
+++ b/lib/flipper/ui/views/feature.erb
@@ -12,6 +12,9 @@
           <span class="octicon octicon-squirrel <%= @feature.color_class %>"></span>
           <%= @feature.key %>
         </h4>
+        <% if @feature.description %>
+          <p><%= @feature.description %></p>
+        <% end %>
         <div class="card-body">
           <p>
             <% if @feature.boolean_value %>

--- a/lib/flipper/ui/views/features.erb
+++ b/lib/flipper/ui/views/features.erb
@@ -27,6 +27,7 @@
             <span class="octicon octicon-squirrel"></span>
           </th>
           <th class="col">Feature</th>
+          <th class="col-6">Description</th>
           <th class="col">Enabled Gates</th>
         </tr>
       </thead>
@@ -39,6 +40,9 @@
             <td class="col">
               <a href="<%= "#{script_name}/features/#{feature.key}" %>">
                 <%= feature.key %></a>
+            </td>
+            <td class="col-6">
+              <%= feature.description %>
             </td>
             <td class="col">
               <%= feature.pretty_enabled_gate_names %>

--- a/spec/flipper/ui/configuration_spec.rb
+++ b/spec/flipper/ui/configuration_spec.rb
@@ -113,4 +113,24 @@ RSpec.describe Flipper::UI::Configuration do
       expect(configuration.fun).to eq(false)
     end
   end
+
+  describe "#descriptions_source" do
+    it "has default value" do
+      lambda do |key_name, description|
+        expect(key_name).to eq nil
+        expect(description).to eq nil
+      end
+    end
+
+    context "descriptions source is provided" do
+      it "can be updated" do
+        file = YAML.load_file(FlipperRoot.join('spec/support/descriptions.yml'))
+        configuration.descriptions_source = -> { file }
+        lambda do |key_name, description|
+          expect(key_name).to eq("some_awesome_feature")
+          expect(description).to eq("Awesome feature description")
+        end
+      end
+    end
+  end
 end

--- a/spec/flipper/ui/decorators/feature_spec.rb
+++ b/spec/flipper/ui/decorators/feature_spec.rb
@@ -39,6 +39,26 @@ RSpec.describe Flipper::UI::Decorators::Feature do
       expect(@result['name']).to eq('Some Awesome Feature')
     end
 
+    describe 'description' do
+      context 'when a value is present' do
+        subject do
+          instance = described_class.new(feature)
+          instance.description = 'Awesome feature description'
+          instance
+        end
+
+        it 'includes it' do
+          expect(@result['description']).to eq('Awesome feature description')
+        end
+      end
+
+      context 'when a value is not present' do
+        it 'includes it' do
+          expect(@result['description']).to eq(nil)
+        end
+      end
+    end
+
     it 'includes state' do
       expect(@result['state']).to eq('off')
     end

--- a/spec/support/descriptions.yml
+++ b/spec/support/descriptions.yml
@@ -1,0 +1,1 @@
+some_awesome_feature: 'Awesome feature description'


### PR DESCRIPTION
1. Simple way to provide insights/details about a specific feature within `Flipper::UI`.

2. Avoids generating `feature` keys too long when developers/admins/users need more **context** about a feature's behaviour:
- What is it meant to do ?
- What is it not meant to do ?
- Which sections of the platform it applies to ?
- How it differentiates itself from similar features ?
- What user roles does it apply to ?
- Etc.