### PR TITLE
Remove unnecessary rubocop disabling

### DIFF
--- a/spec/flipper/feature_spec.rb
+++ b/spec/flipper/feature_spec.rb
@@ -208,7 +208,7 @@ RSpec.describe Flipper::Feature do
       percentage_of_time => percentage_of_time,
       percentage_of_actors => percentage_of_actors,
     }.each do |thing, wrapped_thing|
-      it "always instruments #{thing.inspect} as #{wrapped_thing.class} for enable" do # rubocop:disable RSpec/RepeatedDescription
+      it "always instruments #{thing.inspect} as #{wrapped_thing.class} for enable" do
         Flipper.register(:admins) {}
         subject.enable(thing)
 
@@ -297,7 +297,7 @@ RSpec.describe Flipper::Feature do
       user => actor,
       actor => actor,
     }.each do |thing, wrapped_thing|
-      it "always instruments #{thing.inspect} as #{wrapped_thing.class} for enabled?" do # rubocop:disable RSpec/RepeatedDescription
+      it "always instruments #{thing.inspect} as #{wrapped_thing.class} for enabled?" do
         subject.enabled?(thing)
 
         event = instrumenter.events.last


### PR DESCRIPTION
Hi folks, this PR removes two unnecessary rubocop disablings. These disablings cause the CI to fail as they violate linting rules. 

Here's the failing output, without this PR:
```
$ rubocop
Inspecting 220 files
......................................................................................................................................................................W.....................................................

Offenses:

spec/flipper/feature_spec.rb:211:88: W: Lint/RedundantCopDisableDirective: Unnecessary disabling of RSpec/RepeatedDescription.
      it "always instruments #{thing.inspect} as #{wrapped_thing.class} for enable" do # rubocop:disable RSpec/RepeatedDescription
                                                                                       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
spec/flipper/feature_spec.rb:300:90: W: Lint/RedundantCopDisableDirective: Unnecessary disabling of RSpec/RepeatedDescription.
      it "always instruments #{thing.inspect} as #{wrapped_thing.class} for enabled?" do # rubocop:disable RSpec/RepeatedDescription
                                                                                         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

220 files inspected, 2 offenses detected
```