### PR TITLE
100% of actors now considered conditional rollout

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -1,3 +1,9 @@
+## 0.19.0
+
+## Additions/Changes
+
+* 100% of actors is now considered conditional. Feature#on?, Feature#conditional?, Feature#state would all be affected. See https://github.com/jnunemaker/flipper/issues/463 for more.
+
 ## 0.18.0
 
 ## Additions/Changes

--- a/lib/flipper/feature.rb
+++ b/lib/flipper/feature.rb
@@ -205,7 +205,7 @@ module Flipper
       boolean = gate(:boolean)
       non_boolean_gates = gates - [boolean]
 
-      if values.boolean || values.percentage_of_actors == 100 || values.percentage_of_time == 100
+      if values.boolean || values.percentage_of_time == 100
         :on
       elsif non_boolean_gates.detect { |gate| gate.enabled?(values[gate.key]) }
         :conditional

--- a/spec/flipper/feature_spec.rb
+++ b/spec/flipper/feature_spec.rb
@@ -359,19 +359,19 @@ RSpec.describe Flipper::Feature do
       end
 
       it 'returns :on' do
-        expect(subject.state).to be(:on)
+        expect(subject.state).to be(:conditional)
       end
 
-      it 'returns true for on?' do
-        expect(subject.on?).to be(true)
+      it 'returns false for on?' do
+        expect(subject.on?).to be(false)
       end
 
       it 'returns false for off?' do
         expect(subject.off?).to be(false)
       end
 
-      it 'returns false for conditional?' do
-        expect(subject.conditional?).to be(false)
+      it 'returns true for conditional?' do
+        expect(subject.conditional?).to be(true)
       end
     end
 


### PR DESCRIPTION
The tldr is that 100% of actors could still return false if the actor doesn't include traffic from users that are not signed in. It would be true for 100% of sessions where session was the actor but not for 100% of users where users may be signed in or signed out. Signed out user would be nil and would return false for enabled.

closes #463 