### PR TITLE
Get specs passing in docker

### DIFF
--- a/spec/flipper/adapters/active_support_cache_store_spec.rb
+++ b/spec/flipper/adapters/active_support_cache_store_spec.rb
@@ -9,7 +9,7 @@ RSpec.describe Flipper::Adapters::ActiveSupportCacheStore do
   let(:memory_adapter) do
     Flipper::Adapters::OperationLogger.new(Flipper::Adapters::Memory.new)
   end
-  let(:cache) { ActiveSupport::Cache::DalliStore.new }
+  let(:cache) { ActiveSupport::Cache::DalliStore.new(ENV['MEMCACHED_URL']) }
   let(:adapter) { described_class.new(memory_adapter, cache, expires_in: 10.seconds) }
   let(:flipper) { Flipper.new(adapter) }
 

--- a/spec/flipper/adapters/dalli_spec.rb
+++ b/spec/flipper/adapters/dalli_spec.rb
@@ -7,7 +7,7 @@ RSpec.describe Flipper::Adapters::Dalli do
   let(:memory_adapter) do
     Flipper::Adapters::OperationLogger.new(Flipper::Adapters::Memory.new)
   end
-  let(:cache)   { Dalli::Client.new(ENV['MEMCACHED_URL'] || '127.0.0.1:11211') }
+  let(:cache)   { Dalli::Client.new(ENV['MEMCACHED_URL']) }
   let(:adapter) { described_class.new(memory_adapter, cache) }
   let(:flipper) { Flipper.new(adapter) }
 

--- a/spec/flipper/middleware/memoizer_spec.rb
+++ b/spec/flipper/middleware/memoizer_spec.rb
@@ -342,7 +342,7 @@ RSpec.describe Flipper::Middleware::Memoizer do
     it 'eagerly caches known features for duration of request' do
       memory = Flipper::Adapters::Memory.new
       logged_memory = Flipper::Adapters::OperationLogger.new(memory)
-      cache = ActiveSupport::Cache::DalliStore.new
+      cache = ActiveSupport::Cache::DalliStore.new(ENV['MEMCACHED_URL'])
       cache.clear
       cached = Flipper::Adapters::ActiveSupportCacheStore.new(logged_memory, cache, expires_in: 10)
       logged_cached = Flipper::Adapters::OperationLogger.new(cached)


### PR DESCRIPTION
Most specs relying on Memcached are failing when run in the docker environment. 

This was happening because the Dalli clients used weren't being passed a server URL, and were defaulting to `127.0.0.1:11211`. That works when running the specs in a typical local environment because memcached is usually exposed at that IP/port. But docker exposes it elsewhere!
