### PR TITLE
Add config option for displaying descriptions on features page

### DIFF
--- a/lib/flipper/ui/actions/features.rb
+++ b/lib/flipper/ui/actions/features.rb
@@ -10,9 +10,11 @@ module Flipper
 
         def get
           @page_title = 'Features'
-          keys = flipper.features.map(&:key)
+          @keys = flipper.features.map(&:key)
           @features = flipper.features.map do |feature|
-            Decorators::Feature.new(feature)
+            Decorators::Feature.new(feature).tap do |decorator|
+              decorator.description = descriptions[feature.key]
+            end
           end.sort
 
           @show_blank_slate = @features.empty?
@@ -45,6 +47,14 @@ module Flipper
           feature.add
 
           redirect_to "/features/#{Rack::Utils.escape_path(value)}"
+        end
+
+        private
+
+        def descriptions
+          return {} unless Flipper::UI.configuration.display_descriptions_on_features_page?
+
+          @descriptions ||= Flipper::UI.configuration.descriptions_source.call(@keys)
         end
       end
     end

--- a/lib/flipper/ui/configuration.rb
+++ b/lib/flipper/ui/configuration.rb
@@ -33,8 +33,11 @@ module Flipper
 
       # Public: If you set this, Flipper::UI will fetch descriptions
       # from your external source. Descriptions for `features` will be shown on `feature`
-      # and `features` pages. Defaults to empty block.
+      # page, and optionally the `features` pages. Defaults to empty block.
       attr_accessor :descriptions_source
+
+      # Public: when using descriptions, show them on the `features` page. Default false. 
+      attr_accessor :display_descriptions_on_features_page
 
       VALID_BANNER_CLASS_VALUES = %w(
         danger
@@ -58,10 +61,15 @@ module Flipper
         @fun = true
         @add_actor_placeholder = "a flipper id"
         @descriptions_source = DEFAULT_DESCRIPTIONS_SOURCE
+        @display_descriptions_on_features_page = false
       end
 
       def using_descriptions?
         @descriptions_source != DEFAULT_DESCRIPTIONS_SOURCE
+      end
+
+      def display_descriptions_on_features_page?
+        using_descriptions? && @display_descriptions_on_features_page
       end
 
       def banner_class=(value)

--- a/lib/flipper/ui/views/features.erb
+++ b/lib/flipper/ui/views/features.erb
@@ -44,7 +44,12 @@
           </div>
           <div class="col-10">
             <a href="<%= "#{script_name}/features/#{feature.key}" %>" class="d-block px-0 py-3 btn text-left text-dark">
-              <div class="text-truncate"><%= feature.key %></div>
+              <div class="text-truncate" style="font-weight: 500"><%= feature.key %></div>
+              <% if Flipper::UI.configuration.display_descriptions_on_features_page? && feature.description.present? %>
+                <div class="text-muted font-weight-light" style="line-height: 1.4; white-space: initial; padding: 8px 0">
+                  <%= feature.description %>
+                </div>
+              <% end %>
               <div class="text-muted text-truncate">
                 <%== feature.gates_in_words %>
               </div>

--- a/spec/flipper/ui/configuration_spec.rb
+++ b/spec/flipper/ui/configuration_spec.rb
@@ -100,4 +100,41 @@ RSpec.describe Flipper::UI::Configuration do
       end
     end
   end
+
+  describe "#display_descriptions_on_features_page" do
+    it "has default value" do
+      expect(configuration.display_descriptions_on_features_page).to eq(false)
+    end
+
+    it "can be updated" do
+      configuration.display_descriptions_on_features_page = true
+      expect(configuration.display_descriptions_on_features_page).to eq(true)
+    end
+  end
+
+  describe "#display_descriptions_on_features_page?" do
+    subject { configuration.display_descriptions_on_features_page? }
+
+    context 'when using_descriptions? is false and display_descriptions_on_features_page is false' do
+      it { is_expected.to eq(false) }
+    end
+
+    context 'when using_descriptions? is false and display_descriptions_on_features_page is true' do
+      before { configuration.display_descriptions_on_features_page = true }
+      it { is_expected.to eq(false) }
+    end
+
+    context 'when using_descriptions? is true and display_descriptions_on_features_page is false' do
+      before { allow(configuration).to receive(:using_descriptions?).and_return(true) }
+      it { is_expected.to eq(false) }
+    end
+
+    context 'when using_descriptions? is true and display_descriptions_on_features_page is true' do
+      before do
+        allow(configuration).to receive(:using_descriptions?).and_return(true)
+        configuration.display_descriptions_on_features_page = true
+      end
+      it { is_expected.to eq(true) }
+    end
+  end
 end


### PR DESCRIPTION
This adds a configuration option to display feature descriptions on the 'features' page. Closes https://github.com/jnunemaker/flipper/issues/477.

The recent UI redesign cleaned things up nicely, but having the option to trade a bit of the simplify for the ability more easily find/understand features at-a-glance would be great too.



### After
![image](https://user-images.githubusercontent.com/5838323/90179786-fcc97b00-dd7b-11ea-9994-02b30e63c157.png)
