### PR TITLE
Proposed feature: Check if enabled only for some actors

### DIFF
--- a/lib/flipper.rb
+++ b/lib/flipper.rb
@@ -56,7 +56,7 @@ module Flipper
   # Public: All the methods delegated to instance. These should match the
   # interface of Flipper::DSL.
   def_delegators :instance,
-                 :enabled?, :enabled_for_some?, :enable, :disable, :bool, :boolean,
+                 :enabled?, :strict_enabled?, :enable, :disable, :bool, :boolean,
                  :enable_actor, :disable_actor, :actor,
                  :enable_group, :disable_group,
                  :enable_percentage_of_actors, :disable_percentage_of_actors,

--- a/lib/flipper.rb
+++ b/lib/flipper.rb
@@ -56,7 +56,7 @@ module Flipper
   # Public: All the methods delegated to instance. These should match the
   # interface of Flipper::DSL.
   def_delegators :instance,
-                 :enabled?, :enable, :disable, :bool, :boolean,
+                 :enabled?, :enabled_for_some?, :enable, :disable, :bool, :boolean,
                  :enable_actor, :disable_actor, :actor,
                  :enable_group, :disable_group,
                  :enable_percentage_of_actors, :disable_percentage_of_actors,

--- a/lib/flipper/dsl.rb
+++ b/lib/flipper/dsl.rb
@@ -34,6 +34,14 @@ module Flipper
       feature(name).enabled?(*args)
     end
 
+    def enabled_for_some?(name, *args)
+      if enabled?(name)
+        raise Flipper::Error, "The feature #{name.inspect} is enabled for all!"
+      end
+
+      enabled?(name, *args)
+    end
+
     # Public: Enable a feature.
     #
     # name - The String or Symbol name of the feature.

--- a/lib/flipper/dsl.rb
+++ b/lib/flipper/dsl.rb
@@ -34,7 +34,7 @@ module Flipper
       feature(name).enabled?(*args)
     end
 
-    def enabled_for_some?(name, actor)
+    def strict_enabled?(name, actor)
       if enabled?(name)
         yield if block_given?
         return false

--- a/lib/flipper/dsl.rb
+++ b/lib/flipper/dsl.rb
@@ -36,7 +36,8 @@ module Flipper
 
     def enabled_for_some?(name, actor)
       if enabled?(name)
-        raise Flipper::Error, "The feature #{name.inspect} is enabled for all!"
+        yield if block_given?
+        return false
       end
 
       enabled?(name, actor)

--- a/lib/flipper/dsl.rb
+++ b/lib/flipper/dsl.rb
@@ -34,12 +34,12 @@ module Flipper
       feature(name).enabled?(*args)
     end
 
-    def enabled_for_some?(name, *args)
+    def enabled_for_some?(name, actor)
       if enabled?(name)
         raise Flipper::Error, "The feature #{name.inspect} is enabled for all!"
       end
 
-      enabled?(name, *args)
+      enabled?(name, actor)
     end
 
     # Public: Enable a feature.

--- a/spec/flipper_integration_spec.rb
+++ b/spec/flipper_integration_spec.rb
@@ -532,10 +532,14 @@ RSpec.describe Flipper do
       expect(flipper.enabled_for_some?(:search, pitt)).to eq(true)
     end
 
-    it "errors when enabled for all" do
+    it "is false when enabled for all" do
       feature.enable
-      expect { flipper.enabled_for_some?(:search, pitt) }
-        .to raise_error(/enabled for all/)
+      expect(flipper.enabled_for_some?(:search, pitt)).to be(false)
+    end
+
+    it "provides optional argument for responding to global case" do
+      feature.enable
+      expect { |b| flipper.enabled_for_some?(:search, pitt, &b) }.to yield_control
     end
   end
 

--- a/spec/flipper_integration_spec.rb
+++ b/spec/flipper_integration_spec.rb
@@ -522,24 +522,24 @@ RSpec.describe Flipper do
     end
   end
 
-  describe "#enabled_for_some?" do
+  describe "#strict_enabled?" do
     it "is false when not enabled for actor" do
-      expect(flipper.enabled_for_some?(:search, pitt)).to be(false)
+      expect(flipper.strict_enabled?(:search, pitt)).to be(false)
     end
 
     it "is true when enabled for actor" do
       feature.enable pitt
-      expect(flipper.enabled_for_some?(:search, pitt)).to eq(true)
+      expect(flipper.strict_enabled?(:search, pitt)).to eq(true)
     end
 
     it "is false when enabled for all" do
       feature.enable
-      expect(flipper.enabled_for_some?(:search, pitt)).to be(false)
+      expect(flipper.strict_enabled?(:search, pitt)).to be(false)
     end
 
     it "provides optional argument for responding to global case" do
       feature.enable
-      expect { |b| flipper.enabled_for_some?(:search, pitt, &b) }.to yield_control
+      expect { |b| flipper.strict_enabled?(:search, pitt, &b) }.to yield_control
     end
   end
 

--- a/spec/flipper_integration_spec.rb
+++ b/spec/flipper_integration_spec.rb
@@ -522,6 +522,23 @@ RSpec.describe Flipper do
     end
   end
 
+  describe "#enabled_for_some?" do
+    it "is false when not enabled for actor" do
+      expect(flipper.enabled_for_some?(:search, pitt)).to be(false)
+    end
+
+    it "is true when enabled for actor" do
+      feature.enable pitt
+      expect(flipper.enabled_for_some?(:search, pitt)).to eq(true)
+    end
+
+    it "errors when enabled for all" do
+      feature.enable
+      expect { flipper.enabled_for_some?(:search, pitt) }
+        .to raise_error(/enabled for all/)
+    end
+  end
+
   context 'enabling multiple groups, disabling everything, then enabling one group' do
     before do
       feature.enable(admin_group)

--- a/spec/flipper_spec.rb
+++ b/spec/flipper_spec.rb
@@ -78,10 +78,10 @@ RSpec.describe Flipper do
       expect(described_class.enabled?(:search)).to eq(described_class.instance.enabled?(:search))
     end
 
-    it 'delegates enabled_for_some? to instance' do
-      expect(described_class.enabled_for_some?(:search, actor)).to be(false)
+    it 'delegates strict_enabled? to instance' do
+      expect(described_class.strict_enabled?(:search, actor)).to be(false)
       described_class.instance.enable(:search, actor)
-      expect(described_class.enabled_for_some?(:search, actor)).to be(true)
+      expect(described_class.strict_enabled?(:search, actor)).to be(true)
     end
 
     it 'delegates enable to instance' do

--- a/spec/flipper_spec.rb
+++ b/spec/flipper_spec.rb
@@ -78,6 +78,12 @@ RSpec.describe Flipper do
       expect(described_class.enabled?(:search)).to eq(described_class.instance.enabled?(:search))
     end
 
+    it 'delegates enabled_for_some? to instance' do
+      expect(described_class.enabled_for_some?(:search, actor)).to be(false)
+      described_class.instance.enable(:search, actor)
+      expect(described_class.enabled_for_some?(:search, actor)).to be(true)
+    end
+
     it 'delegates enable to instance' do
       described_class.enable(:search)
       expect(described_class.instance.enabled?(:search)).to be(true)


### PR DESCRIPTION
## Context

I realize that this may not be a feature you want to support, but it came up in a use case that we have for Flipper, so I wanted to at least open the conversation here in case there is an opportunity to pay it forward. I will also say that the PR as it is being opened is more a conversation starter than anything, so please know that I'm not deeply committed to the implementation. I'm happy to iterate on the solution.

## Problem

We recently started using Flipper as a way of empowering some testing-in-production features in our infrastructure. In particular, we wanted a way to flag certain domain object flowing through our system to behave in a certain way. For example:

> Any time user:1234 attempts to buy something, behave as if their card is declined.

To do this, we use Flipper, but as a safety mechanism we added an additional check to make certain that the features aren't enabled globally, because we wouldn't want to decline every purchase for all users by accident 😎 

## Solution

Our solution involved a small wrapper around Flipper, so we thought I might be something to add to the library. It essentially amounts to checking for a feature which is globally enabled and faulting on that condition.

Please let me know your thoughts! I would love to understand your perspective on this problem and whether it is something you could like to include in Flipper. 