### PR TITLE
Bump rack-protection version to < 2.2

### DIFF
--- a/flipper-ui.gemspec
+++ b/flipper-ui.gemspec
@@ -21,7 +21,7 @@ Gem::Specification.new do |gem|
   gem.metadata      = Flipper::METADATA
 
   gem.add_dependency 'rack', '>= 1.4', '< 3'
-  gem.add_dependency 'rack-protection', '>= 1.5.3', '< 2.1.0'
+  gem.add_dependency 'rack-protection', '>= 1.5.3', '< 2.2.0'
   gem.add_dependency 'flipper', "~> #{Flipper::VERSION}"
   gem.add_dependency 'erubi', '>= 1.0.0', '< 2.0.0'
 end


### PR DESCRIPTION
In https://github.com/jnunemaker/flipper/pull/156 rack-protection was set to >= 1.5.3 and < 2.1.0, which was because it no longer worked with `session["_csrf_token"]`, but did work with `session[:csrf]` in both 1.5.3 and 2.0.0.beta2. Hoping to update it now that that beta changes are live, as this allows installation of flipper alongside the current version of rack-protection.