### PR TITLE
Allow actors and time gates to deal with decimal percentages

### DIFF
--- a/lib/flipper/api/v1/actions/percentage_of_actors_gate.rb
+++ b/lib/flipper/api/v1/actions/percentage_of_actors_gate.rb
@@ -30,9 +30,17 @@ module Flipper
 
           private
 
+          def percentage_param
+            @percentage_param ||= params['percentage'].to_s
+          end
+
           def percentage
             @percentage ||= begin
-              Integer(params['percentage'])
+              unless percentage_param.match(/\d/)
+                raise ArgumentError, "invalid numeric value: #{percentage_param}"
+              end
+
+              Flipper::Types::Percentage.new(percentage_param).value
             rescue ArgumentError, TypeError
               -1
             end

--- a/lib/flipper/api/v1/actions/percentage_of_time_gate.rb
+++ b/lib/flipper/api/v1/actions/percentage_of_time_gate.rb
@@ -31,9 +31,17 @@ module Flipper
 
           private
 
+          def percentage_param
+            @percentage_param ||= params['percentage'].to_s
+          end
+
           def percentage
             @percentage ||= begin
-              Integer(params['percentage'])
+              unless percentage_param.match(/\d/)
+                raise ArgumentError, "invalid numeric value: #{percentage_param}"
+              end
+
+              Flipper::Types::Percentage.new(percentage_param).value
             rescue ArgumentError, TypeError
               -1
             end


### PR DESCRIPTION
The current implementation of percentage actors and time gates allows only integer values.

In [this commit](https://github.com/danielvidal/flipper/commit/82f3b960e127cdebb5e951b14ac04308ea7ddd64) the `Typecast` class started to deal with percentages and I didn't find a reason to not allow the gates to work with decimal values.

cc/ @jnunemaker 