### PR TITLE
Adds method disabled, inverse of enabled

### DIFF
--- a/lib/flipper/gate.rb
+++ b/lib/flipper/gate.rb
@@ -22,6 +22,10 @@ module Flipper
       raise 'Not implemented'
     end
 
+    def disabled?(value)
+      !enabled?(value)
+    end
+
     # Internal: Check if a gate is open for a thing. Implemented in subclass.
     #
     # Returns true if gate open for thing, false if not.


### PR DESCRIPTION
Hello there!

First of all, a lot of thanks to @jnunemaker, the maintainers and the community for this wonderful gem. We use it a lot @dmstk ([domestika.org](https://domestika.org) and we can't be more happy.

One thing we've noticed with heavy use (around 20-25 feature flags and more to come) is that we usually end up doing this in order to have the inverse of a gate:

```ruby
return if counter == 1 and !Flipper.enabled?(:feature)
```

This is okay, but it's not as explicit as we would like.
v
The proposed change adds a new method in the `Gate` class in order to have the inverse of the method, like so:

```ruby
return if counter == 1 and Flipper.disabled?(:feature)
```

We can of course do this downstream, but having it as part of the gem would be golden.

I did not see the necessity of adding tests for this since the `enabled?` method is being tested in all the gates, but let me know if you want me do so.

Thank you!