### PR TITLE
Replace feature_name.strip for gsub

### DIFF
--- a/lib/flipper/ui/actions/features.rb
+++ b/lib/flipper/ui/actions/features.rb
@@ -46,7 +46,7 @@ module Flipper
             halt view_response(:feature_creation_disabled)
           end
 
-          value = params['value'].to_s.strip
+          value = params['value'].to_s.gsub(/\s/, '')
 
           if Util.blank?(value)
             error = Rack::Utils.escape("#{value.inspect} is not a valid feature name.")

--- a/spec/flipper/ui/actions/features_spec.rb
+++ b/spec/flipper/ui/actions/features_spec.rb
@@ -103,6 +103,14 @@ RSpec.describe Flipper::UI::Actions::Features do
         end
       end
 
+      context 'feature name contains whitespace between the words' do
+        let(:feature_name) { '  notifications _next   ' }
+
+        it 'adds feature without whitespace' do
+          expect(flipper.features.map(&:key)).to include('notifications_next')
+        end
+      end
+
       context 'for an invalid feature name' do
         context 'empty feature name' do
           let(:feature_name) { '' }


### PR DESCRIPTION
I had a problem with `InvalidURIError` for accidentally creating a feature with whitespace between the words of the feature name using the Flipper UI. For example "feature _name". The error is due to the problem of accessing a URL with whitespaces like: `.../features/feature _name`.

The `strip` method didn’t fix this because it only removes whitespaces from the "edges":
```rb
"   feature _name      ".strip
=> "feature _name"
```

So I switched to a `gsub` to remove all whitespaces in the feature name:
```rb
"   feature _name    ".gsub(/\s/, '')
=> "feature_name"
```