### PR TITLE
Default to using Memory adapter

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,16 +70,6 @@ Want to get a quick feel for what it looks like to work with Flipper? Check out 
 ```ruby
 require 'flipper'
 
-Flipper.configure do |config|
-  config.default do
-    # pick an adapter, this uses memory, any will do, see docs above
-    adapter = Flipper::Adapters::Memory.new
-
-    # pass adapter to handy DSL instance
-    Flipper.new(adapter)
-  end
-end
-
 # check if search is enabled
 if Flipper.enabled?(:search)
   puts 'Search away!'

--- a/examples/basic.rb
+++ b/examples/basic.rb
@@ -2,16 +2,6 @@ require File.expand_path('../example_setup', __FILE__)
 
 require 'flipper'
 
-Flipper.configure do |config|
-  config.default do
-    # pick an adapter, this uses memory, any will do
-    adapter = Flipper::Adapters::Memory.new
-
-    # pass adapter to handy DSL instance
-    Flipper.new(adapter)
-  end
-end
-
 # check if search is enabled
 if Flipper.enabled?(:search)
   puts 'Search away!'

--- a/examples/cloud/import.rb
+++ b/examples/cloud/import.rb
@@ -17,4 +17,4 @@ Flipper.enable_percentage_of_time(:logging, 5)
 cloud = Flipper::Cloud.new
 
 # makes cloud identical to memory flipper
-cloud.import(Flipper.instance)
+cloud.import(Flipper)

--- a/examples/cloud/import.rb
+++ b/examples/cloud/import.rb
@@ -9,15 +9,12 @@ $:.unshift(lib_path)
 require 'flipper'
 require 'flipper/cloud'
 
-memory_adapter = Flipper::Adapters::Memory.new
-flipper = Flipper.new(memory_adapter)
-
-flipper.enable(:test)
-flipper.enable(:search)
-flipper.enable_actor(:stats, Flipper::Actor.new("jnunemaker"))
-flipper.enable_percentage_of_time(:logging, 5)
+Flipper.enable(:test)
+Flipper.enable(:search)
+Flipper.enable_actor(:stats, Flipper::Actor.new("jnunemaker"))
+Flipper.enable_percentage_of_time(:logging, 5)
 
 cloud = Flipper::Cloud.new
 
 # makes cloud identical to memory flipper
-cloud.import(flipper)
+cloud.import(Flipper.instance)

--- a/examples/dsl.rb
+++ b/examples/dsl.rb
@@ -2,9 +2,6 @@ require File.expand_path('../example_setup', __FILE__)
 
 require 'flipper'
 
-adapter = Flipper::Adapters::Memory.new
-flipper = Flipper.new(adapter)
-
 # create a thing with an identifier
 class Person
   attr_reader :id
@@ -22,14 +19,14 @@ person = Person.new(1)
 puts "Stats are disabled by default\n\n"
 
 # is a feature enabled
-puts "flipper.enabled? :stats: #{flipper.enabled? :stats}"
+puts "flipper.enabled? :stats: #{Flipper.enabled? :stats}"
 
 # is a feature on or off for a particular person
-puts "flipper.enabled? :stats, person: #{flipper.enabled? :stats, person}"
+puts "Flipper.enabled? :stats, person: #{Flipper.enabled? :stats, person}"
 
 # get at a feature
-puts "\nYou can also get an individual feature like this:\nstats = flipper[:stats]\n\n"
-stats = flipper[:stats]
+puts "\nYou can also get an individual feature like this:\nstats = Flipper[:stats]\n\n"
+stats = Flipper[:stats]
 
 # is that feature enabled
 puts "stats.enabled?: #{stats.enabled?}"
@@ -39,7 +36,7 @@ puts "stats.enabled? person: #{stats.enabled? person}"
 
 # enable a feature by name
 puts "\nEnabling stats\n\n"
-flipper.enable :stats
+Flipper.enable :stats
 
 # or, you can use the feature to enable
 stats.enable
@@ -49,7 +46,7 @@ puts "stats.enabled? person: #{stats.enabled? person}"
 
 # oh, no, let's turn this baby off
 puts "\nDisabling stats\n\n"
-flipper.disable :stats
+Flipper.disable :stats
 
 # or we can disable using feature obviously
 stats.disable
@@ -59,18 +56,18 @@ puts "stats.enabled? person: #{stats.enabled? person}"
 puts
 
 # get an instance of the percentage of time type set to 5
-puts flipper.time(5).inspect
+puts Flipper.time(5).inspect
 
 # get an instance of the percentage of actors type set to 15
-puts flipper.actors(15).inspect
+puts Flipper.actors(15).inspect
 
 # get an instance of an actor using an object that responds to flipper_id
 responds_to_flipper_id = Struct.new(:flipper_id).new(10)
-puts flipper.actor(responds_to_flipper_id).inspect
+puts Flipper.actor(responds_to_flipper_id).inspect
 
 # get an instance of an actor using an object
 thing = Struct.new(:flipper_id).new(22)
-puts flipper.actor(thing).inspect
+puts Flipper.actor(thing).inspect
 
 # register a top level group
 admins = Flipper.register(:admins) { |actor|

--- a/examples/enabled_for_actor.rb
+++ b/examples/enabled_for_actor.rb
@@ -22,21 +22,15 @@ end
 user1 = User.new(1, true)
 user2 = User.new(2, false)
 
-# pick an adapter
-adapter = Flipper::Adapters::Memory.new
-
-# get a handy dsl instance
-flipper = Flipper.new(adapter)
-
 Flipper.register :admins do |actor|
   actor.admin?
 end
 
-flipper[:search].enable
-flipper[:stats].enable_actor user1
-flipper[:pro_stats].enable_percentage_of_actors 50
-flipper[:tweets].enable_group :admins
-flipper[:posts].enable_actor user2
+Flipper.enable :search
+Flipper.enable_actor :stats, user1
+Flipper.enable_percentage_of_actors :pro_stats, 50
+Flipper.enable_group :tweets, :admins
+Flipper.enable_actor :posts, user2
 
-pp flipper.features.select { |feature| feature.enabled?(user1) }.map(&:name)
-pp flipper.features.select { |feature| feature.enabled?(user2) }.map(&:name)
+pp Flipper.features.select { |feature| feature.enabled?(user1) }.map(&:name)
+pp Flipper.features.select { |feature| feature.enabled?(user2) }.map(&:name)

--- a/examples/group.rb
+++ b/examples/group.rb
@@ -33,7 +33,7 @@ puts "Stats for admin: #{stats.enabled?(admin)}"
 puts "Stats for non_admin: #{stats.enabled?(non_admin)}"
 
 puts "\nEnabling Stats for admins...\n\n"
-stats.enable(Flipper.group(:admins))
+stats.enable_group :admins
 
 puts "Stats for admin: #{stats.enabled?(admin)}"
 puts "Stats for non_admin: #{stats.enabled?(non_admin)}"

--- a/examples/group.rb
+++ b/examples/group.rb
@@ -2,9 +2,7 @@ require File.expand_path('../example_setup', __FILE__)
 
 require 'flipper'
 
-adapter = Flipper::Adapters::Memory.new
-flipper = Flipper.new(adapter)
-stats = flipper[:stats]
+stats = Flipper[:stats]
 
 # Register group
 Flipper.register(:admins) do |actor|
@@ -35,7 +33,7 @@ puts "Stats for admin: #{stats.enabled?(admin)}"
 puts "Stats for non_admin: #{stats.enabled?(non_admin)}"
 
 puts "\nEnabling Stats for admins...\n\n"
-stats.enable(flipper.group(:admins))
+stats.enable(Flipper.group(:admins))
 
 puts "Stats for admin: #{stats.enabled?(admin)}"
 puts "Stats for non_admin: #{stats.enabled?(non_admin)}"

--- a/examples/group_dynamic_lookup.rb
+++ b/examples/group_dynamic_lookup.rb
@@ -2,9 +2,7 @@ require File.expand_path('../example_setup', __FILE__)
 
 require 'flipper'
 
-adapter = Flipper::Adapters::Memory.new
-flipper = Flipper.new(adapter)
-stats = flipper[:stats]
+stats = Flipper[:stats]
 
 # Register group
 Flipper.register(:enabled_team_member) do |actor, context|

--- a/examples/group_with_members.rb
+++ b/examples/group_with_members.rb
@@ -2,9 +2,7 @@ require File.expand_path('../example_setup', __FILE__)
 
 require 'flipper'
 
-adapter = Flipper::Adapters::Memory.new
-flipper = Flipper.new(adapter)
-stats = flipper[:stats]
+stats = Flipper[:stats]
 
 # Register group
 Flipper.register(:team_actor) do |actor|

--- a/examples/individual_actor.rb
+++ b/examples/individual_actor.rb
@@ -2,9 +2,7 @@ require File.expand_path('../example_setup', __FILE__)
 
 require 'flipper'
 
-adapter = Flipper::Adapters::Memory.new
-flipper = Flipper.new(adapter)
-stats = flipper[:stats]
+stats = Flipper[:stats]
 
 # Some class that represents what will be trying to do something
 class User

--- a/examples/percentage_of_actors.rb
+++ b/examples/percentage_of_actors.rb
@@ -25,7 +25,7 @@ perform_test = lambda { |number|
   Flipper.enable_percentage_of_actors :stats, number
 
   enabled = users.map { |user|
-    Flipper[:stats].enabled?(user) ? true : nil
+    Flipper.enabled?(:stats, user) ? true : nil
   }.compact
 
   actual = (enabled.size / total.to_f * 100).round(3)

--- a/examples/percentage_of_actors.rb
+++ b/examples/percentage_of_actors.rb
@@ -22,7 +22,7 @@ total = 100_000
 users = (1..total).map { |n| User.new(n) }
 
 perform_test = lambda { |number|
-  Flipper[:stats].enable Flipper.actors(number)
+  Flipper.enable_percentage_of_actors :stats, number
 
   enabled = users.map { |user|
     Flipper[:stats].enabled?(user) ? true : nil

--- a/examples/percentage_of_actors.rb
+++ b/examples/percentage_of_actors.rb
@@ -2,9 +2,7 @@ require File.expand_path('../example_setup', __FILE__)
 
 require 'flipper'
 
-adapter = Flipper::Adapters::Memory.new
-flipper = Flipper.new(adapter)
-stats = flipper[:stats]
+stats = Flipper[:stats]
 
 # Some class that represents what will be trying to do something
 class User
@@ -24,10 +22,10 @@ total = 100_000
 users = (1..total).map { |n| User.new(n) }
 
 perform_test = lambda { |number|
-  flipper[:stats].enable flipper.actors(number)
+  Flipper[:stats].enable Flipper.actors(number)
 
   enabled = users.map { |user|
-    flipper[:stats].enabled?(user) ? true : nil
+    Flipper[:stats].enabled?(user) ? true : nil
   }.compact
 
   actual = (enabled.size / total.to_f * 100).round(3)

--- a/examples/percentage_of_actors_enabled_check.rb
+++ b/examples/percentage_of_actors_enabled_check.rb
@@ -2,9 +2,6 @@ require File.expand_path('../example_setup', __FILE__)
 
 require 'flipper'
 
-adapter = Flipper::Adapters::Memory.new
-flipper = Flipper.new(adapter)
-
 # Some class that represents what will be trying to do something
 class User
   attr_reader :id
@@ -18,15 +15,16 @@ class User
 end
 
 # checking a bunch
-gate = Flipper::Gates::PercentageOfActors.new
-feature_name = "data_migration"
-percentage_enabled = 10
 total = 20_000
 enabled = []
+percentage_enabled = 10
+
+feature = Flipper[:data_migration]
+feature.enable_percentage_of_actors 10
 
 (1..total).each do |id|
   user = User.new(id)
-  if gate.open?(user, percentage_enabled, feature_name: feature_name)
+  if feature.enabled? user
     enabled << user
   end
 end
@@ -35,4 +33,4 @@ p actual: enabled.size, expected: total * (percentage_enabled * 0.01)
 
 # checking one
 user = User.new(1)
-p user_1_enabled: Flipper::Gates::PercentageOfActors.new.open?(user, percentage_enabled, feature_name: feature_name)
+p user_1_enabled: feature.enabled?(user)

--- a/examples/percentage_of_actors_group.rb
+++ b/examples/percentage_of_actors_group.rb
@@ -6,9 +6,7 @@
 require File.expand_path('../example_setup', __FILE__)
 require 'flipper'
 
-adapter = Flipper::Adapters::Memory.new
-flipper = Flipper.new(adapter)
-stats = flipper[:stats]
+stats = Flipper[:stats]
 
 # Some class that represents what will be trying to do something
 class User

--- a/examples/percentage_of_time.rb
+++ b/examples/percentage_of_time.rb
@@ -2,12 +2,10 @@ require File.expand_path('../example_setup', __FILE__)
 
 require 'flipper'
 
-adapter = Flipper::Adapters::Memory.new
-flipper = Flipper.new(adapter)
-logging = flipper[:logging]
+logging = Flipper[:logging]
 
 perform_test = lambda do |number|
-  logging.enable flipper.time(number)
+  logging.enable Flipper.time(number)
 
   total = 100_000
   enabled = []

--- a/examples/percentage_of_time.rb
+++ b/examples/percentage_of_time.rb
@@ -5,7 +5,7 @@ require 'flipper'
 logging = Flipper[:logging]
 
 perform_test = lambda do |number|
-  logging.enable Flipper.time(number)
+  logging.enable_percentage_of_time number
 
   total = 100_000
   enabled = []

--- a/lib/flipper/configuration.rb
+++ b/lib/flipper/configuration.rb
@@ -1,7 +1,7 @@
 module Flipper
   class Configuration
     def initialize
-      @default = -> { raise DefaultNotSet }
+      @default = -> { Flipper.new(Flipper::Adapters::Memory.new) }
     end
 
     # Controls the default instance for flipper. When used with a block it
@@ -9,15 +9,15 @@ module Flipper
     # without a block, it performs a block invocation and returns the result.
     #
     #   configuration = Flipper::Configuration.new
-    #   configuration.default # => raises DefaultNotSet error.
+    #   configuration.default # => Flipper::DSL instance using Memory adapter
     #
-    #   # sets the default block to generate a new instance using Memory adapter
+    #   # sets the default block to generate a new instance using ActiveRecord adapter
     #   configuration.default do
-    #     require "flipper/adapters/memory"
-    #     Flipper.new(Flipper::Adapters::Memory.new)
+    #     require "flipper-active-record"
+    #     Flipper.new(Flipper::Adapters::ActiveRecord.new)
     #   end
     #
-    #   configuration.default # => Flipper::DSL instance using Memory adapter
+    #   configuration.default # => Flipper::DSL instance using ActiveRecord adapter
     #
     # Returns result of default block invocation if called without block. If
     # called with block, assigns the default block.

--- a/lib/flipper/configuration.rb
+++ b/lib/flipper/configuration.rb
@@ -13,7 +13,7 @@ module Flipper
     #
     #   # sets the default block to generate a new instance using ActiveRecord adapter
     #   configuration.default do
-    #     require "flipper-active-record"
+    #     require "flipper-active_record"
     #     Flipper.new(Flipper::Adapters::ActiveRecord.new)
     #   end
     #

--- a/lib/flipper/errors.rb
+++ b/lib/flipper/errors.rb
@@ -16,9 +16,8 @@ module Flipper
   # use it.
   class DefaultNotSet < Flipper::Error
     def initialize(message = nil)
-      default = "Default flipper instance not configured. See " \
-                "Flipper.configure for how to configure the default instance."
-      super(message || default)
+      warn "Flipper::DefaultNotSet is deprecated and will be removed in 1.0"
+      super
     end
   end
 

--- a/spec/flipper/configuration_spec.rb
+++ b/spec/flipper/configuration_spec.rb
@@ -3,12 +3,15 @@ require 'flipper/configuration'
 
 RSpec.describe Flipper::Configuration do
   describe '#default' do
-    it 'raises if default not configured' do
-      expect { subject.default }.to raise_error(Flipper::DefaultNotSet)
+    it 'returns instance using Memory adapter' do
+      expect(subject.default).to be_a(Flipper::DSL)
+      # All adapter are wrapped in Memoizable
+      expect(subject.default.adapter.adapter).to be_a(Flipper::Adapters::Memory)
     end
 
     it 'can be set default' do
       instance = Flipper.new(Flipper::Adapters::Memory.new)
+      expect(subject.default).not_to be(instance)
       subject.default { instance }
       expect(subject.default).to be(instance)
     end

--- a/spec/flipper/middleware/setup_env_spec.rb
+++ b/spec/flipper/middleware/setup_env_spec.rb
@@ -93,20 +93,4 @@ RSpec.describe Flipper::Middleware::SetupEnv do
       expect(last_response.body).to eq(Flipper.object_id.to_s)
     end
   end
-
-  context 'when flipper instance or block are nil and default Flipper is NOT configured' do
-    let(:app) do
-      app = lambda do |env|
-        [200, { 'Content-Type' => 'text/html' }, [env['flipper'].enabled?(:search)]]
-      end
-      builder = Rack::Builder.new
-      builder.use described_class
-      builder.run app
-      builder
-    end
-
-    it 'can use env flipper' do
-      expect { get '/' }.to raise_error(Flipper::DefaultNotSet)
-    end
-  end
 end


### PR DESCRIPTION
This updates the configuration to default to the `Memory` adapter. This allows  the docs and usage examples to be simplified so the first step isn't always "choose an adapter".

This is related to #500 for improving the onboarding experience.

