### PR TITLE
Simplify example setup with bundler/setup, run in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -47,3 +47,5 @@ jobs:
         run: bundle install --jobs 4 --retry 3
       - name: Run Rake
         run: bundle exec rake
+      - name: Run Examples
+        run: script/examples

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -49,5 +49,5 @@ jobs:
         run: bundle exec rake
       - name: Run Examples
         env:
-          FLIPPER_CLOUD_TOKEN: ${ secrets.FLIPPER_CLOUD_TOKEN }
+          FLIPPER_CLOUD_TOKEN: ${{ secrets.FLIPPER_CLOUD_TOKEN }}
         run: script/examples

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -48,4 +48,6 @@ jobs:
       - name: Run Rake
         run: bundle exec rake
       - name: Run Examples
+        env:
+          FLIPPER_CLOUD_TOKEN: ${ secrets.FLIPPER_CLOUD_TOKEN }
         run: script/examples

--- a/Gemfile
+++ b/Gemfile
@@ -18,6 +18,7 @@ gem 'minitest', '~> 5.8'
 gem 'minitest-documentation'
 gem 'webmock', '~> 3.0'
 gem 'climate_control'
+gem 'redis-namespace'
 
 group(:guard) do
   gem 'guard', '~> 2.15'

--- a/examples/active_record/ar_setup.rb
+++ b/examples/active_record/ar_setup.rb
@@ -1,10 +1,4 @@
-require 'pathname'
-require 'logger'
-
-root_path = Pathname(__FILE__).dirname.join('..').expand_path
-lib_path  = root_path.join('lib')
-$:.unshift(lib_path)
-
+require 'bundler/setup'
 require 'active_record'
 ActiveRecord::Base.establish_connection({
   adapter: 'sqlite3',

--- a/examples/basic.rb
+++ b/examples/basic.rb
@@ -1,5 +1,4 @@
-require File.expand_path('../example_setup', __FILE__)
-
+require 'bundler/setup'
 require 'flipper'
 
 # check if search is enabled

--- a/examples/cloud/app.ru
+++ b/examples/cloud/app.ru
@@ -3,11 +3,7 @@
 #   env FLIPPER_CLOUD_TOKEN=<token> FLIPPER_CLOUD_SYNC_SECRET=<secret> FLIPPER_CLOUD_SYNC_METHOD=webhook bundle exec shotgun examples/cloud/app.ru -p 9999
 #   http://localhost:9999/
 
-require 'pathname'
-root_path = Pathname(__FILE__).dirname.join('..').expand_path
-lib_path  = root_path.join('lib')
-$:.unshift(lib_path)
-
+require 'bundler/setup'
 require 'flipper/cloud'
 Flipper.configure do |config|
   config.default { Flipper::Cloud.new }

--- a/examples/cloud/basic.rb
+++ b/examples/cloud/basic.rb
@@ -1,11 +1,6 @@
 # Usage (from the repo root):
 # env FLIPPER_CLOUD_TOKEN=<token> bundle exec ruby examples/cloud/basic.rb
-require 'pathname'
-require 'logger'
-root_path = Pathname(__FILE__).dirname.join('..').expand_path
-lib_path  = root_path.join('lib')
-$:.unshift(lib_path)
-
+require 'bundler/setup'
 require 'flipper/cloud'
 flipper = Flipper::Cloud.new
 

--- a/examples/cloud/cached_in_memory.rb
+++ b/examples/cloud/cached_in_memory.rb
@@ -1,6 +1,5 @@
 # env FLIPPER_CLOUD_TOKEN=<token> bundle exec ruby examples/cloud/cached_in_memory.rb
-require File.expand_path('../../example_setup', __FILE__)
-
+require 'bundler/setup'
 require 'flipper/cloud'
 require 'flipper/adapters/active_support_cache_store'
 require 'active_support/cache'

--- a/examples/cloud/import.rb
+++ b/examples/cloud/import.rb
@@ -1,11 +1,6 @@
 # Usage (from the repo root):
 #   env FLIPPER_CLOUD_TOKEN=<token> bundle exec ruby examples/cloud/import.rb
-require 'pathname'
-require 'logger'
-root_path = Pathname(__FILE__).dirname.join('..').expand_path
-lib_path  = root_path.join('lib')
-$:.unshift(lib_path)
-
+require 'bundler/setup'
 require 'flipper'
 require 'flipper/cloud'
 

--- a/examples/cloud/local_adapter.rb
+++ b/examples/cloud/local_adapter.rb
@@ -6,8 +6,7 @@
 # unavailable, but we are hoping to fix that soon by doing the cloud update in a
 # background thread.
 # env FLIPPER_CLOUD_TOKEN=<token> bundle exec ruby examples/cloud/local_adapter.rb
-require File.expand_path('../../example_setup', __FILE__)
-
+require 'bundler/setup'
 require 'logger'
 require 'flipper/cloud'
 require 'flipper/adapters/redis'

--- a/examples/configuring_default.rb
+++ b/examples/configuring_default.rb
@@ -1,5 +1,4 @@
-require File.expand_path('../example_setup', __FILE__)
-
+require 'bundler/setup'
 require 'flipper'
 
 # sets up default adapter so Flipper works like Flipper::DSL

--- a/examples/dsl.rb
+++ b/examples/dsl.rb
@@ -1,5 +1,4 @@
-require File.expand_path('../example_setup', __FILE__)
-
+require 'bundler/setup'
 require 'flipper'
 
 # create a thing with an identifier

--- a/examples/enabled_for_actor.rb
+++ b/examples/enabled_for_actor.rb
@@ -1,5 +1,4 @@
-require File.expand_path('../example_setup', __FILE__)
-
+require 'bundler/setup'
 require 'flipper'
 
 # Some class that represents what will be trying to do something

--- a/examples/example_setup.rb
+++ b/examples/example_setup.rb
@@ -1,8 +1,0 @@
-# Nothing to see here... move along.
-# Sets up load path for examples and requires some stuff
-require 'pp'
-require 'pathname'
-
-root_path = Pathname(__FILE__).dirname.join('..').expand_path
-lib_path  = root_path.join('lib')
-$:.unshift(lib_path)

--- a/examples/group.rb
+++ b/examples/group.rb
@@ -1,5 +1,4 @@
-require File.expand_path('../example_setup', __FILE__)
-
+require 'bundler/setup'
 require 'flipper'
 
 stats = Flipper[:stats]

--- a/examples/group_dynamic_lookup.rb
+++ b/examples/group_dynamic_lookup.rb
@@ -1,5 +1,4 @@
-require File.expand_path('../example_setup', __FILE__)
-
+require 'bundler/setup'
 require 'flipper'
 
 stats = Flipper[:stats]

--- a/examples/group_with_members.rb
+++ b/examples/group_with_members.rb
@@ -1,5 +1,4 @@
-require File.expand_path('../example_setup', __FILE__)
-
+require 'bundler/setup'
 require 'flipper'
 
 stats = Flipper[:stats]

--- a/examples/importing.rb
+++ b/examples/importing.rb
@@ -1,4 +1,4 @@
-require File.expand_path('../example_setup', __FILE__)
+require 'bundler/setup'
 require_relative 'active_record/ar_setup'
 require 'flipper'
 require 'flipper/adapters/redis'

--- a/examples/individual_actor.rb
+++ b/examples/individual_actor.rb
@@ -1,5 +1,4 @@
-require File.expand_path('../example_setup', __FILE__)
-
+require 'bundler/setup'
 require 'flipper'
 
 stats = Flipper[:stats]

--- a/examples/instrumentation.rb
+++ b/examples/instrumentation.rb
@@ -1,5 +1,4 @@
-require File.expand_path('../example_setup', __FILE__)
-
+require 'bundler/setup'
 require 'securerandom'
 require 'active_support/notifications'
 

--- a/examples/memoizing.rb
+++ b/examples/memoizing.rb
@@ -1,5 +1,4 @@
-require File.expand_path('../example_setup', __FILE__)
-
+require 'bundler/setup'
 require 'flipper'
 require 'flipper/adapters/operation_logger'
 require 'flipper/instrumentation/log_subscriber'

--- a/examples/mongo/basic.rb
+++ b/examples/mongo/basic.rb
@@ -1,9 +1,5 @@
-require 'pathname'
+require 'bundler/setup'
 require 'logger'
-
-root_path = Pathname(__FILE__).dirname.join('..').expand_path
-lib_path  = root_path.join('lib')
-$:.unshift(lib_path)
 
 require 'flipper/adapters/mongo'
 Mongo::Logger.logger.level = Logger::INFO

--- a/examples/mongo/internals.rb
+++ b/examples/mongo/internals.rb
@@ -1,10 +1,6 @@
+require 'bundler/setup'
 require 'pp'
-require 'pathname'
 require 'logger'
-
-root_path = Pathname(__FILE__).dirname.join('..').expand_path
-lib_path  = root_path.join('lib')
-$:.unshift(lib_path)
 
 require 'flipper/adapters/mongo'
 Mongo::Logger.logger.level = Logger::INFO

--- a/examples/percentage_of_actors.rb
+++ b/examples/percentage_of_actors.rb
@@ -1,5 +1,4 @@
-require File.expand_path('../example_setup', __FILE__)
-
+require 'bundler/setup'
 require 'flipper'
 
 stats = Flipper[:stats]

--- a/examples/percentage_of_actors_enabled_check.rb
+++ b/examples/percentage_of_actors_enabled_check.rb
@@ -1,5 +1,4 @@
-require File.expand_path('../example_setup', __FILE__)
-
+require 'bundler/setup'
 require 'flipper'
 
 # Some class that represents what will be trying to do something

--- a/examples/percentage_of_actors_group.rb
+++ b/examples/percentage_of_actors_group.rb
@@ -3,10 +3,8 @@
 # feature for actors in a particular location or on a particular plan, but only
 # for a percentage of them. The percentage is a constant, but could easily be
 # plucked from memcached, redis, mysql or whatever.
-require File.expand_path('../example_setup', __FILE__)
+require 'bundler/setup'
 require 'flipper'
-
-stats = Flipper[:stats]
 
 # Some class that represents what will be trying to do something
 class User
@@ -32,13 +30,13 @@ Flipper.register(:experimental) do |actor|
 end
 
 # enable the experimental group
-flipper[:stats].enable_group :experimental
+Flipper.enable_group :stats, :experimental
 
 # create a bunch of fake users and see how many are enabled
 total = 10_000
 users = (1..total).map { |n| User.new(n) }
 enabled = users.map { |user|
-  flipper[:stats].enabled?(user) ? true : nil
+  Flipper.enabled?(:stats, user) ? true : nil
 }.compact
 
 # show the results

--- a/examples/percentage_of_time.rb
+++ b/examples/percentage_of_time.rb
@@ -1,5 +1,4 @@
-require File.expand_path('../example_setup', __FILE__)
-
+require 'bundler/setup'
 require 'flipper'
 
 logging = Flipper[:logging]

--- a/examples/redis/basic.rb
+++ b/examples/redis/basic.rb
@@ -1,9 +1,5 @@
-require 'pathname'
+require 'bundler/setup'
 require 'logger'
-
-root_path = Pathname(__FILE__).dirname.join('..').expand_path
-lib_path  = root_path.join('lib')
-$:.unshift(lib_path)
 
 require 'flipper/adapters/redis'
 options = {}

--- a/examples/redis/internals.rb
+++ b/examples/redis/internals.rb
@@ -1,10 +1,6 @@
+require 'bundler/setup'
 require 'pp'
-require 'pathname'
 require 'logger'
-
-root_path = Pathname(__FILE__).dirname.join('..').expand_path
-lib_path  = root_path.join('lib')
-$:.unshift(lib_path)
 
 require 'flipper/adapters/redis'
 

--- a/examples/redis/namespaced.rb
+++ b/examples/redis/namespaced.rb
@@ -1,5 +1,5 @@
+require 'bundler/setup'
 require 'pp'
-require 'pathname'
 require 'logger'
 begin
   require 'redis-namespace'

--- a/examples/redis/namespaced.rb
+++ b/examples/redis/namespaced.rb
@@ -1,18 +1,7 @@
 require 'bundler/setup'
-require 'pp'
-require 'logger'
-begin
-  require 'redis-namespace'
-rescue LoadError
-  puts 'you must have redis-namespace gem installed'
-  exit 1
-end
-
-root_path = Pathname(__FILE__).dirname.join('..').expand_path
-lib_path  = root_path.join('lib')
-$:.unshift(lib_path)
-
+require 'redis-namespace'
 require 'flipper/adapters/redis'
+
 options = {url: 'redis://127.0.0.1:6379'}
 if ENV['REDIS_URL']
   options[:url] = ENV['REDIS_URL']

--- a/examples/rollout/basic.rb
+++ b/examples/rollout/basic.rb
@@ -1,10 +1,4 @@
-require 'pathname'
-require 'logger'
-
-root_path = Pathname(__FILE__).dirname.join('..').expand_path
-lib_path  = root_path.join('lib')
-$:.unshift(lib_path)
-
+require 'bundler/setup'
 require 'redis'
 require 'rollout'
 require 'flipper'

--- a/examples/rollout/import.rb
+++ b/examples/rollout/import.rb
@@ -1,10 +1,4 @@
-require 'pathname'
-require 'logger'
-
-root_path = Pathname(__FILE__).dirname.join('..').expand_path
-lib_path  = root_path.join('lib')
-$:.unshift(lib_path)
-
+require 'bundler/setup'
 require 'redis'
 require 'rollout'
 require 'flipper'

--- a/examples/sequel/basic.rb
+++ b/examples/sequel/basic.rb
@@ -1,10 +1,4 @@
-require 'pathname'
-require 'logger'
-
-root_path = Pathname(__FILE__).dirname.join('..').expand_path
-lib_path  = root_path.join('lib')
-$:.unshift(lib_path)
-
+require 'bundler/setup'
 require 'sequel'
 Sequel::Model.db =  Sequel.sqlite(':memory:')
 Sequel.extension :migration, :core_extensions

--- a/examples/sequel/internals.rb
+++ b/examples/sequel/internals.rb
@@ -1,11 +1,4 @@
-require 'pp'
-require 'pathname'
-require 'logger'
-
-root_path = Pathname(__FILE__).dirname.join('..').expand_path
-lib_path  = root_path.join('lib')
-$:.unshift(lib_path)
-
+require 'bundler/setup'
 require 'sequel'
 Sequel::Model.db =  Sequel.sqlite(':memory:')
 Sequel.extension :migration, :core_extensions

--- a/examples/ui/authorization.ru
+++ b/examples/ui/authorization.ru
@@ -4,13 +4,8 @@
 #   bundle exec shotgun examples/ui/authorization.ru -p 9999
 #   http://localhost:9999/
 #
-require "pp"
+require 'bundler/setup'
 require "logger"
-require "pathname"
-
-root_path = Pathname(__FILE__).dirname.join("..").expand_path
-lib_path  = root_path.join("lib")
-$:.unshift(lib_path)
 
 require "flipper-ui"
 require "flipper/adapters/pstore"

--- a/examples/ui/basic.ru
+++ b/examples/ui/basic.ru
@@ -4,14 +4,7 @@
 #   bundle exec shotgun examples/ui/basic.ru -p 9999
 #   http://localhost:9999/
 #
-require "pp"
-require "logger"
-require "pathname"
-
-root_path = Pathname(__FILE__).dirname.join("..").expand_path
-lib_path  = root_path.join("lib")
-$:.unshift(lib_path)
-
+require 'bundler/setup'
 require "flipper-ui"
 require "flipper/adapters/pstore"
 require "active_support/notifications"

--- a/lib/flipper/adapters/http/error.rb
+++ b/lib/flipper/adapters/http/error.rb
@@ -6,7 +6,7 @@ module Flipper
 
         def initialize(response)
           @response = response
-          super("Failed with status: #{response.code} #{response.body}")
+          super("Failed with status: #{response.code}")
         end
       end
     end

--- a/lib/flipper/adapters/http/error.rb
+++ b/lib/flipper/adapters/http/error.rb
@@ -6,7 +6,7 @@ module Flipper
 
         def initialize(response)
           @response = response
-          super("Failed with status: #{response.code}")
+          super("Failed with status: #{response.code} #{response.body}")
         end
       end
     end

--- a/script/examples
+++ b/script/examples
@@ -1,0 +1,13 @@
+#!/usr/bin/env sh
+
+# Exit if any example fails
+set -e
+
+# Run all examples individually
+for example in examples/**/*.rb; do
+  # Skip examples with a loop for now
+  if ! grep -q "loop do" "$example"; then
+    echo $example
+    ruby $example
+  fi
+done

--- a/spec/flipper/cloud/middleware_spec.rb
+++ b/spec/flipper/cloud/middleware_spec.rb
@@ -105,7 +105,7 @@ RSpec.describe Flipper::Cloud::Middleware do
 
       expect(last_response.status).to eq(402)
       expect(last_response.headers["Flipper-Cloud-Response-Error-Class"]).to eq("Flipper::Adapters::Http::Error")
-      expect(last_response.headers["Flipper-Cloud-Response-Error-Message"]).to eq("Failed with status: 402")
+      expect(last_response.headers["Flipper-Cloud-Response-Error-Message"]).to include("Failed with status: 402")
       expect(stub).to have_been_requested
     end
   end
@@ -128,7 +128,7 @@ RSpec.describe Flipper::Cloud::Middleware do
 
       expect(last_response.status).to eq(500)
       expect(last_response.headers["Flipper-Cloud-Response-Error-Class"]).to eq("Flipper::Adapters::Http::Error")
-      expect(last_response.headers["Flipper-Cloud-Response-Error-Message"]).to eq("Failed with status: 503")
+      expect(last_response.headers["Flipper-Cloud-Response-Error-Message"]).to include("Failed with status: 503")
       expect(stub).to have_been_requested
     end
   end


### PR DESCRIPTION
The setup for the `examples/cloud/*` is currently broken. It looks like they were maybe moved into a subdirectory at some point.

This PR simplifies the setup for each example, replacing path munging with [`require 'bundler/setup'`](https://bundler.io/guides/bundler_setup.html#setting-up-your-application-to-use-bundler), which will set up paths based on the contents of `Gemfile`. It also runs all the examples in GitHub Actions, and should fail if any of the scripts exit with a non-zero status.