### PR TITLE
Add cloud recommendation to UI

### DIFF
--- a/examples/ui/basic.ru
+++ b/examples/ui/basic.ru
@@ -1,7 +1,11 @@
 #
 # Usage:
-#   bundle exec rackup examples/ui/basic.ru -p 9999
-#   bundle exec shotgun examples/ui/basic.ru -p 9999
+#   # if you want it to not reload and be really fast
+#   bin/rackup examples/ui/basic.ru -p 9999
+#
+#   # if you want reloading
+#   bin/shotgun examples/ui/basic.ru -p 9999
+#
 #   http://localhost:9999/
 #
 require 'bundler/setup'
@@ -32,6 +36,7 @@ Flipper::UI.configure do |config|
   # config.banner_class = 'danger'
   config.feature_creation_enabled = true
   config.feature_removal_enabled = true
+  config.cloud_recommendation = true
   # config.show_feature_description_in_list = true
   config.descriptions_source = lambda do |_keys|
     {

--- a/lib/flipper/ui/configuration.rb
+++ b/lib/flipper/ui/configuration.rb
@@ -26,6 +26,10 @@ module Flipper
       # won't see a videoclip of Taylor Swift when there aren't any features
       attr_accessor :fun
 
+      # Public: Tired of seeing the awesome message about Cloud? Set this to
+      # false and it will go away. Defaults to true.
+      attr_accessor :cloud_recommendation
+
       # Public: What should show up in the form to add actors. This can be
       # different per application since flipper_id's can be whatever an
       # application needs. Defaults to "a flipper id".
@@ -60,6 +64,7 @@ module Flipper
         @feature_creation_enabled = true
         @feature_removal_enabled = true
         @fun = true
+        @cloud_recommendation = true
         @add_actor_placeholder = "a flipper id"
         @descriptions_source = DEFAULT_DESCRIPTIONS_SOURCE
         @show_feature_description_in_list = false

--- a/lib/flipper/ui/views/features.erb
+++ b/lib/flipper/ui/views/features.erb
@@ -1,5 +1,5 @@
 <% if @show_blank_slate %>
-  <div class="jumbotron text-center">
+  <div class="jumbotron text-center m-0">
     <% if Flipper::UI.configuration.fun %>
       <h4>But I've got a blank space baby...</h4>
       <p>And I'll flip your features.</p>

--- a/lib/flipper/ui/views/layout.erb
+++ b/lib/flipper/ui/views/layout.erb
@@ -35,6 +35,21 @@
       <div>
         <%== yield %>
       </div>
+
+      <% if Flipper::UI.configuration.cloud_recommendation %>
+        <div class="d-flex justify-content-center mt-5">
+          <div class="row" style="max-width: 350px;">
+            <div class="col-auto d-flex align-items-center">
+              <a href="https://www.flippercloud.io/?utm_source=oss&utm_medium=ui&utm_campaign=spread_the_love">
+                <img src="<%= script_name %>/images/logo.png" width="50" />
+              </a>
+            </div>
+            <div class="col text-muted p-0">
+              <small>For support, audit history, finer-grained permissions, multi-environment sync, and all your projects in one place check out <a href="https://www.flippercloud.io/?utm_source=oss&utm_medium=ui&utm_campaign=spread_the_love">Flipper&nbsp;Cloud</a>.</small>
+            </div>
+          </div>
+        </div>
+      <% end %>
     </div>
 
     <script src="https://code.jquery.com/jquery-3.2.1.slim.min.js" integrity="sha384-KJ3o2DKtIkvYIK3UENzmM7KCkRr/rE9/Qpg6aAZGJwFDMVNA/GpGFF93hXpG5KkN" crossorigin="anonymous"></script>

--- a/spec/flipper/ui/configuration_spec.rb
+++ b/spec/flipper/ui/configuration_spec.rb
@@ -59,6 +59,17 @@ RSpec.describe Flipper::UI::Configuration do
     end
   end
 
+  describe "#cloud_recommendation" do
+    it "has default value" do
+      expect(configuration.cloud_recommendation).to eq(true)
+    end
+
+    it "can be updated" do
+      configuration.cloud_recommendation = false
+      expect(configuration.cloud_recommendation).to eq(false)
+    end
+  end
+
   describe "#feature_removal_enabled" do
     it "has default value" do
       expect(configuration.feature_removal_enabled).to eq(true)


### PR DESCRIPTION
Just want to help get the word out so people know it exists. This seemed like an easy and unobtrusive way to help. Also it gets that sweet logo in the UI. 😄 

And now you all know I've switched to hey for email due to the pinned tab. 😆 

![flipper ui cloud recommendation](https://user-images.githubusercontent.com/235/111660523-8c3c7e00-87e4-11eb-9ec1-130b1950ef4a.png)


Can be disabled with:

```ruby
Flipper::UI.configure do |config|
  config.cloud_recommendation = false
end
```