### PR TITLE
Skip adapter tests if connection fails

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,6 +19,7 @@ jobs:
       RAILS_VERSION: 6.0.0
       SQLITE3_VERSION: 1.4.1
       REDIS_URL: redis://localhost:6379/0
+      CI: true
     steps:
       - name: Setup memcached
         uses: KeisukeYamashita/memcached-actions@v1

--- a/spec/flipper/adapters/active_support_cache_store_spec.rb
+++ b/spec/flipper/adapters/active_support_cache_store_spec.rb
@@ -9,7 +9,7 @@ RSpec.describe Flipper::Adapters::ActiveSupportCacheStore do
   let(:memory_adapter) do
     Flipper::Adapters::OperationLogger.new(Flipper::Adapters::Memory.new)
   end
-  let(:cache) { ActiveSupport::Cache::DalliStore.new(ENV['MEMCACHED_URL']) }
+  let(:cache) { ActiveSupport::Cache::MemoryStore.new }
   let(:adapter) { described_class.new(memory_adapter, cache, expires_in: 10.seconds) }
   let(:flipper) { Flipper.new(adapter) }
 

--- a/spec/flipper/adapters/dalli_spec.rb
+++ b/spec/flipper/adapters/dalli_spec.rb
@@ -19,7 +19,7 @@ RSpec.describe Flipper::Adapters::Dalli do
     begin
       cache.flush
     rescue Dalli::NetworkError
-      skip 'Memcached not available' unless ENV['CI']
+      ENV['CI'] ? raise : skip('Memcached not available')
     end
   end
 

--- a/spec/flipper/adapters/dalli_spec.rb
+++ b/spec/flipper/adapters/dalli_spec.rb
@@ -2,6 +2,7 @@ require 'helper'
 require 'flipper/adapters/operation_logger'
 require 'flipper/adapters/dalli'
 require 'flipper/spec/shared_adapter_specs'
+require 'logger'
 
 RSpec.describe Flipper::Adapters::Dalli do
   let(:memory_adapter) do
@@ -14,7 +15,12 @@ RSpec.describe Flipper::Adapters::Dalli do
   subject { adapter }
 
   before do
-    cache.flush
+    Dalli.logger = Logger.new('/dev/null')
+    begin
+      cache.flush
+    rescue Dalli::NetworkError
+      skip "Memcached not available"
+    end
   end
 
   it_should_behave_like 'a flipper adapter'

--- a/spec/flipper/adapters/dalli_spec.rb
+++ b/spec/flipper/adapters/dalli_spec.rb
@@ -19,7 +19,7 @@ RSpec.describe Flipper::Adapters::Dalli do
     begin
       cache.flush
     rescue Dalli::NetworkError
-      skip "Memcached not available"
+      skip 'Memcached not available' unless ENV['CI']
     end
   end
 

--- a/spec/flipper/adapters/mongo_spec.rb
+++ b/spec/flipper/adapters/mongo_spec.rb
@@ -20,7 +20,7 @@ RSpec.describe Flipper::Adapters::Mongo do
     begin
       collection.drop
     rescue Mongo::Error::NoServerAvailable
-      skip "Mongo not available"
+      skip 'Mongo not available' unless ENV['CI']
     rescue Mongo::Error::OperationFailure
     end
     collection.create

--- a/spec/flipper/adapters/mongo_spec.rb
+++ b/spec/flipper/adapters/mongo_spec.rb
@@ -20,7 +20,7 @@ RSpec.describe Flipper::Adapters::Mongo do
     begin
       collection.drop
     rescue Mongo::Error::NoServerAvailable
-      skip 'Mongo not available' unless ENV['CI']
+      ENV['CI'] ? raise : skip('Mongo not available')
     rescue Mongo::Error::OperationFailure
     end
     collection.create

--- a/spec/flipper/adapters/mongo_spec.rb
+++ b/spec/flipper/adapters/mongo_spec.rb
@@ -11,13 +11,16 @@ RSpec.describe Flipper::Adapters::Mongo do
   let(:port) { ENV['MONGODB_PORT'] || 27017 }
 
   let(:client) do
-    Mongo::Client.new(["#{host}:#{port}"], server_selection_timeout: 1, database: 'testing')
+    logger = Logger.new('/dev/null')
+    Mongo::Client.new(["#{host}:#{port}"], server_selection_timeout: 0.01, database: 'testing', logger: logger)
   end
   let(:collection) { client['testing'] }
 
   before do
     begin
       collection.drop
+    rescue Mongo::Error::NoServerAvailable
+      skip "Mongo not available"
     rescue Mongo::Error::OperationFailure
     end
     collection.create

--- a/spec/flipper/adapters/redis_cache_spec.rb
+++ b/spec/flipper/adapters/redis_cache_spec.rb
@@ -22,7 +22,7 @@ RSpec.describe Flipper::Adapters::RedisCache do
     begin
       client.flushdb
     rescue Redis::CannotConnectError
-      skip 'Redis is not available' unless ENV['CI']
+      ENV['CI'] ? raise : skip('Redis not available')
     end
   end
 

--- a/spec/flipper/adapters/redis_cache_spec.rb
+++ b/spec/flipper/adapters/redis_cache_spec.rb
@@ -19,7 +19,11 @@ RSpec.describe Flipper::Adapters::RedisCache do
   subject { adapter }
 
   before do
-    client.flushdb
+    begin
+      client.flushdb
+    rescue Redis::CannotConnectError
+      skip 'Redis is not available' unless ENV['CI']
+    end
   end
 
   it_should_behave_like 'a flipper adapter'

--- a/spec/flipper/adapters/redis_spec.rb
+++ b/spec/flipper/adapters/redis_spec.rb
@@ -17,7 +17,7 @@ RSpec.describe Flipper::Adapters::Redis do
     begin
       client.flushdb
     rescue Redis::CannotConnectError
-      skip 'Redis is not available' unless ENV['CI']
+      ENV['CI'] ? raise : skip('Redis not available')
     end
   end
 

--- a/spec/flipper/adapters/redis_spec.rb
+++ b/spec/flipper/adapters/redis_spec.rb
@@ -14,7 +14,11 @@ RSpec.describe Flipper::Adapters::Redis do
   subject { described_class.new(client) }
 
   before do
-    client.flushdb
+    begin
+      client.flushdb
+    rescue Redis::CannotConnectError
+      skip 'Redis is not available' unless ENV['CI']
+    end
   end
 
   it_should_behave_like 'a flipper adapter'

--- a/spec/flipper/adapters/rollout_spec.rb
+++ b/spec/flipper/adapters/rollout_spec.rb
@@ -13,7 +13,11 @@ RSpec.describe Flipper::Adapters::Rollout do
   let(:destination_flipper) { Flipper.new(destination_adapter) }
 
   before do
-    redis.flushdb
+    begin
+      redis.flushdb
+    rescue Redis::CannotConnectError
+      skip 'Redis is not available' unless ENV['CI']
+    end
   end
 
   describe '#name' do

--- a/spec/flipper/adapters/rollout_spec.rb
+++ b/spec/flipper/adapters/rollout_spec.rb
@@ -16,7 +16,7 @@ RSpec.describe Flipper::Adapters::Rollout do
     begin
       redis.flushdb
     rescue Redis::CannotConnectError
-      skip 'Redis is not available' unless ENV['CI']
+      ENV['CI'] ? raise : skip('Redis not available')
     end
   end
 

--- a/spec/flipper/middleware/memoizer_spec.rb
+++ b/spec/flipper/middleware/memoizer_spec.rb
@@ -342,7 +342,7 @@ RSpec.describe Flipper::Middleware::Memoizer do
     it 'eagerly caches known features for duration of request' do
       memory = Flipper::Adapters::Memory.new
       logged_memory = Flipper::Adapters::OperationLogger.new(memory)
-      cache = ActiveSupport::Cache::DalliStore.new(ENV['MEMCACHED_URL'])
+      cache = ActiveSupport::Cache::MemoryStore.new
       cache.clear
       cached = Flipper::Adapters::ActiveSupportCacheStore.new(logged_memory, cache, expires_in: 10)
       logged_cached = Flipper::Adapters::OperationLogger.new(cached)

--- a/test/adapters/dalli_test.rb
+++ b/test/adapters/dalli_test.rb
@@ -13,7 +13,7 @@ class DalliTest < MiniTest::Test
     memory_adapter = Flipper::Adapters::Memory.new
     @adapter = Flipper::Adapters::Dalli.new(memory_adapter, @cache)
   rescue Dalli::NetworkError
-    skip 'Memcached not available' unless ENV['CI']
+    ENV['CI'] ? raise : skip('Memcached not available')
   end
 
   def teardown

--- a/test/adapters/dalli_test.rb
+++ b/test/adapters/dalli_test.rb
@@ -1,5 +1,6 @@
 require 'test_helper'
 require 'flipper/adapters/dalli'
+require 'logger'
 
 class DalliTest < MiniTest::Test
   prepend Flipper::Test::SharedAdapterTests
@@ -7,9 +8,12 @@ class DalliTest < MiniTest::Test
   def setup
     url = ENV.fetch('MEMCACHED_URL', 'localhost:11211')
     @cache = Dalli::Client.new(url)
+    Dalli.logger = Logger.new('/dev/null')
     @cache.flush
     memory_adapter = Flipper::Adapters::Memory.new
     @adapter = Flipper::Adapters::Dalli.new(memory_adapter, @cache)
+  rescue Dalli::NetworkError
+    skip "Memcached not available"
   end
 
   def teardown

--- a/test/adapters/dalli_test.rb
+++ b/test/adapters/dalli_test.rb
@@ -13,7 +13,7 @@ class DalliTest < MiniTest::Test
     memory_adapter = Flipper::Adapters::Memory.new
     @adapter = Flipper::Adapters::Dalli.new(memory_adapter, @cache)
   rescue Dalli::NetworkError
-    skip "Memcached not available"
+    skip 'Memcached not available' unless ENV['CI']
   end
 
   def teardown

--- a/test/adapters/mongo_test.rb
+++ b/test/adapters/mongo_test.rb
@@ -17,7 +17,7 @@ class MongoTest < MiniTest::Test
       collection.drop
       collection.create
     rescue Mongo::Error::NoServerAvailable
-      skip "Mongo not available"
+      skip 'Mongo not available' unless ENV['CI']
     rescue Mongo::Error::OperationFailure
     end
     @adapter = Flipper::Adapters::Mongo.new(collection)

--- a/test/adapters/mongo_test.rb
+++ b/test/adapters/mongo_test.rb
@@ -17,7 +17,7 @@ class MongoTest < MiniTest::Test
       collection.drop
       collection.create
     rescue Mongo::Error::NoServerAvailable
-      skip 'Mongo not available' unless ENV['CI']
+      ENV['CI'] ? raise : skip('Mongo not available')
     rescue Mongo::Error::OperationFailure
     end
     @adapter = Flipper::Adapters::Mongo.new(collection)

--- a/test/adapters/mongo_test.rb
+++ b/test/adapters/mongo_test.rb
@@ -9,13 +9,15 @@ class MongoTest < MiniTest::Test
     port = '27017'
     logger = Logger.new('/dev/null')
     client = Mongo::Client.new(["#{host}:#{port}"],
-                               server_selection_timeout: 1,
+                               server_selection_timeout: 0.01,
                                database: 'testing',
                                logger: logger)
     collection = client['testing']
     begin
       collection.drop
       collection.create
+    rescue Mongo::Error::NoServerAvailable
+      skip "Mongo not available"
     rescue Mongo::Error::OperationFailure
     end
     @adapter = Flipper::Adapters::Mongo.new(collection)

--- a/test/adapters/redis_cache_test.rb
+++ b/test/adapters/redis_cache_test.rb
@@ -9,6 +9,8 @@ class RedisCacheTest < MiniTest::Test
     @cache = Redis.new(url: url).tap(&:flushdb)
     memory_adapter = Flipper::Adapters::Memory.new
     @adapter = Flipper::Adapters::RedisCache.new(memory_adapter, @cache)
+  rescue Redis::CannotConnectError
+    skip 'Redis is not available' unless ENV['CI']
   end
 
   def teardown

--- a/test/adapters/redis_cache_test.rb
+++ b/test/adapters/redis_cache_test.rb
@@ -10,7 +10,7 @@ class RedisCacheTest < MiniTest::Test
     memory_adapter = Flipper::Adapters::Memory.new
     @adapter = Flipper::Adapters::RedisCache.new(memory_adapter, @cache)
   rescue Redis::CannotConnectError
-    skip 'Redis is not available' unless ENV['CI']
+    ENV['CI'] ? raise : skip('Reids not available')
   end
 
   def teardown

--- a/test/adapters/redis_test.rb
+++ b/test/adapters/redis_test.rb
@@ -8,5 +8,7 @@ class RedisTest < MiniTest::Test
     url = ENV.fetch('REDIS_URL', 'redis://localhost:6379')
     client = Redis.new(url: url).tap(&:flushdb)
     @adapter = Flipper::Adapters::Redis.new(client)
+  rescue Redis::CannotConnectError
+    skip 'Redis is not available' unless ENV['CI']
   end
 end

--- a/test/adapters/redis_test.rb
+++ b/test/adapters/redis_test.rb
@@ -9,6 +9,6 @@ class RedisTest < MiniTest::Test
     client = Redis.new(url: url).tap(&:flushdb)
     @adapter = Flipper::Adapters::Redis.new(client)
   rescue Redis::CannotConnectError
-    skip 'Redis is not available' unless ENV['CI']
+    ENV['CI'] ? raise : skip('Redis not available')
   end
 end

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -1,3 +1,4 @@
+require 'bundler/setup'
 require 'flipper'
 require 'minitest/autorun'
 require 'minitest/unit'


### PR DESCRIPTION
My soul can't handle having failing tests locally. This skips the tests that depend on local services if they fail to connect.