### PR TITLE
Randomize order of specs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,5 +1,8 @@
 name: CI
-on: [push, pull_request]
+on:
+  push:
+    branches: [master]
+  pull_request:
 jobs:
   build:
     runs-on: ubuntu-latest

--- a/spec/flipper/adapters/active_record_spec.rb
+++ b/spec/flipper/adapters/active_record_spec.rb
@@ -51,7 +51,7 @@ RSpec.describe Flipper::Adapters::ActiveRecord do
       Flipper.configuration = nil
       Flipper.instance = nil
 
-      require 'flipper-active_record'
+      load 'flipper-active_record.rb'
       ActiveSupport.run_load_hooks(:active_record, ActiveRecord::Base)
     end
 

--- a/spec/flipper/adapters/mongo_spec.rb
+++ b/spec/flipper/adapters/mongo_spec.rb
@@ -32,7 +32,7 @@ RSpec.describe Flipper::Adapters::Mongo do
     Flipper.configuration = nil
     Flipper.instance = nil
 
-    require 'flipper-mongo'
+    load 'flipper-mongo.rb'
 
     ENV["MONGO_URL"] ||= "mongodb://127.0.0.1:27017/testing"
     expect(Flipper.adapter.adapter).to be_a(Flipper::Adapters::Mongo)

--- a/spec/flipper/adapters/redis_spec.rb
+++ b/spec/flipper/adapters/redis_spec.rb
@@ -27,7 +27,7 @@ RSpec.describe Flipper::Adapters::Redis do
     Flipper.configuration = nil
     Flipper.instance = nil
 
-    require 'flipper-redis'
+    load 'flipper-redis.rb'
 
     expect(Flipper.adapter.adapter).to be_a(Flipper::Adapters::Redis)
   end

--- a/spec/flipper/adapters/sequel_spec.rb
+++ b/spec/flipper/adapters/sequel_spec.rb
@@ -34,14 +34,15 @@ RSpec.describe Flipper::Adapters::Sequel do
       Flipper.configuration = nil
       Flipper.instance = nil
 
-      require 'flipper-sequel'
+      # Use load to force-require even if previously required
+      load 'flipper-sequel.rb'
     end
 
     it 'configures itself' do
       expect(Flipper.adapter.adapter).to be_a(Flipper::Adapters::Sequel)
     end
 
-    it "defines #flipper_id on AR::Base" do
+    it "defines #flipper_id on Sequel::Model" do
       expect(Sequel::Model.ancestors).to include(Flipper::Identifier)
     end
   end

--- a/spec/flipper/adapters/sequel_spec.rb
+++ b/spec/flipper/adapters/sequel_spec.rb
@@ -34,7 +34,6 @@ RSpec.describe Flipper::Adapters::Sequel do
       Flipper.configuration = nil
       Flipper.instance = nil
 
-      # Use load to force-require even if previously required
       load 'flipper-sequel.rb'
     end
 

--- a/spec/support/spec_helpers.rb
+++ b/spec/support/spec_helpers.rb
@@ -64,6 +64,9 @@ module SpecHelpers
 end
 
 RSpec.configure do |config|
+  config.order = :random
+  Kernel.srand config.seed
+
   config.include Rack::Test::Methods
   config.include SpecHelpers
 end


### PR DESCRIPTION
#502 introduced a failure when running specs in different order. This sets `config.order = :random` in rspec to hopefully expose issues like this sooner.

It also updates GitHub Actions to not run on `push` unless to master.