### PR TITLE
Deprecate superflous sync_method setting

### DIFF
--- a/examples/cloud/app.ru
+++ b/examples/cloud/app.ru
@@ -1,6 +1,6 @@
 # Usage (from the repo root):
-#   env FLIPPER_CLOUD_TOKEN=<token> FLIPPER_CLOUD_SYNC_SECRET=<secret> FLIPPER_CLOUD_SYNC_METHOD=webhook bundle exec rackup examples/cloud/app.ru -p 9999
-#   env FLIPPER_CLOUD_TOKEN=<token> FLIPPER_CLOUD_SYNC_SECRET=<secret> FLIPPER_CLOUD_SYNC_METHOD=webhook bundle exec shotgun examples/cloud/app.ru -p 9999
+#   env FLIPPER_CLOUD_TOKEN=<token> FLIPPER_CLOUD_SYNC_SECRET=<secret> bundle exec rackup examples/cloud/app.ru -p 9999
+#   env FLIPPER_CLOUD_TOKEN=<token> FLIPPER_CLOUD_SYNC_SECRET=<secret> bundle exec shotgun examples/cloud/app.ru -p 9999
 #   http://localhost:9999/
 
 require 'bundler/setup'

--- a/lib/flipper/cloud/configuration.rb
+++ b/lib/flipper/cloud/configuration.rb
@@ -57,10 +57,6 @@ module Flipper
       # the local in sync with cloud (default: 10).
       attr_accessor :sync_interval
 
-      # Public: The method to be used for synchronizing your local flipper
-      # adapter with cloud. (default: :poll, can also be :webhook).
-      attr_reader :sync_method
-
       # Public: The secret used to verify if syncs in the middleware should
       # occur or not.
       attr_accessor :sync_secret
@@ -72,6 +68,11 @@ module Flipper
           raise ArgumentError, "Flipper::Cloud token is missing. Please set FLIPPER_CLOUD_TOKEN or provide the token (e.g. Flipper::Cloud.new('token'))."
         end
 
+        if ENV["FLIPPER_CLOUD_SYNC_METHOD"]
+          warn "FLIPPER_CLOUD_SYNC_METHOD is deprecated and has no effect."
+        end
+        self.sync_method = options[:sync_method] if options[:sync_method]
+
         @instrumenter = options.fetch(:instrumenter, Instrumenters::Noop)
         @read_timeout = options.fetch(:read_timeout) { ENV.fetch("FLIPPER_CLOUD_READ_TIMEOUT", 5).to_f }
         @open_timeout = options.fetch(:open_timeout) { ENV.fetch("FLIPPER_CLOUD_OPEN_TIMEOUT", 5).to_f }
@@ -81,7 +82,6 @@ module Flipper
         @local_adapter = options.fetch(:local_adapter) { Adapters::Memory.new }
         @debug_output = options[:debug_output]
         @adapter_block = ->(adapter) { adapter }
-        self.sync_method = options.fetch(:sync_method) { ENV.fetch("FLIPPER_CLOUD_SYNC_METHOD", :poll).to_sym }
         self.url = options.fetch(:url) { ENV.fetch("FLIPPER_CLOUD_URL", "https://www.flippercloud.io/adapter".freeze) }
       end
 
@@ -114,18 +114,14 @@ module Flipper
         }).call
       end
 
-      def sync_method=(new_sync_method)
-        new_sync_method = new_sync_method.to_sym
+      # Public: The method that will be used to synchronize local adapter with
+      # cloud. (default: :poll, will be :webhook if sync_secret is set).
+      def sync_method
+        sync_secret ? :webhook : :poll
+      end
 
-        unless VALID_SYNC_METHODS.include?(new_sync_method)
-          raise ArgumentError, "Unsupported sync_method. Valid options are (#{VALID_SYNC_METHODS.to_a.join(', ')})"
-        end
-
-        if new_sync_method == :webhook && sync_secret.nil?
-          raise ArgumentError, "Flipper::Cloud sync_secret is missing. Please set FLIPPER_CLOUD_SYNC_SECRET or provide the sync_secret used to validate webhooks."
-        end
-
-        @sync_method = new_sync_method
+      def sync_method=(_)
+        warn "Flipper::Cloud: sync_method is deprecated and has no effect."
       end
 
       private

--- a/spec/flipper/cloud/configuration_spec.rb
+++ b/spec/flipper/cloud/configuration_spec.rb
@@ -127,51 +127,28 @@ RSpec.describe Flipper::Cloud::Configuration do
     end
   end
 
-  it "defaults to sync_method to poll" do
-    memory_adapter = Flipper::Adapters::Memory.new
+  it "defaults sync_method to :poll" do
     instance = described_class.new(required_options)
 
     expect(instance.sync_method).to eq(:poll)
   end
 
-  it "can use webhook for sync_method" do
-    memory_adapter = Flipper::Adapters::Memory.new
+  it "sets sync_method to :webhook if sync_secret provided" do
     instance = described_class.new(required_options.merge({
       sync_secret: "secret",
-      sync_method: :webhook,
-      local_adapter: memory_adapter,
     }))
 
     expect(instance.sync_method).to eq(:webhook)
     expect(instance.adapter).to be_instance_of(Flipper::Adapters::DualWrite)
   end
 
-  it "raises ArgumentError for invalid sync_method" do
-    expect {
-      described_class.new(required_options.merge(sync_method: :foo))
-    }.to raise_error(ArgumentError, "Unsupported sync_method. Valid options are (poll, webhook)")
-  end
-
-  it "can use ENV var for sync_method" do
-    with_modified_env "FLIPPER_CLOUD_SYNC_METHOD" => "webhook" do
-      instance = described_class.new(required_options.merge({
-        sync_secret: "secret",
-      }))
+  it "sets sync_method to :webhook if FLIPPER_CLOUD_SYNC_SECRET set" do
+    with_modified_env "FLIPPER_CLOUD_SYNC_SECRET" => "abc" do
+      instance = described_class.new(required_options)
 
       expect(instance.sync_method).to eq(:webhook)
+      expect(instance.adapter).to be_instance_of(Flipper::Adapters::DualWrite)
     end
-  end
-
-  it "can use string sync_method instead of symbol" do
-    memory_adapter = Flipper::Adapters::Memory.new
-    instance = described_class.new(required_options.merge({
-      sync_secret: "secret",
-      sync_method: "webhook",
-      local_adapter: memory_adapter,
-    }))
-
-    expect(instance.sync_method).to eq(:webhook)
-    expect(instance.adapter).to be_instance_of(Flipper::Adapters::DualWrite)
   end
 
   it "can set sync_secret" do

--- a/spec/flipper/cloud/dsl_spec.rb
+++ b/spec/flipper/cloud/dsl_spec.rb
@@ -9,7 +9,6 @@ RSpec.describe Flipper::Cloud::DSL do
     cloud_configuration = Flipper::Cloud::Configuration.new({
       token: "asdf",
       sync_secret: "tasty",
-      sync_method: :webhook,
     })
     dsl = described_class.new(cloud_configuration)
     expect(dsl.features).to eq(Set.new)
@@ -26,7 +25,6 @@ RSpec.describe Flipper::Cloud::DSL do
     cloud_configuration = Flipper::Cloud::Configuration.new({
       token: "asdf",
       sync_secret: "tasty",
-      sync_method: :webhook,
     })
     dsl = described_class.new(cloud_configuration)
     dsl.sync
@@ -37,7 +35,6 @@ RSpec.describe Flipper::Cloud::DSL do
     cloud_configuration = Flipper::Cloud::Configuration.new({
       token: "asdf",
       sync_secret: "tasty",
-      sync_method: :webhook,
     })
     dsl = described_class.new(cloud_configuration)
     expect(dsl.sync_secret).to eq("tasty")
@@ -52,7 +49,6 @@ RSpec.describe Flipper::Cloud::DSL do
       cloud_configuration = Flipper::Cloud::Configuration.new({
         token: "asdf",
         sync_secret: "tasty",
-        sync_method: :webhook,
         local_adapter: local_adapter
       })
     end

--- a/spec/flipper/cloud/middleware_spec.rb
+++ b/spec/flipper/cloud/middleware_spec.rb
@@ -9,7 +9,6 @@ RSpec.describe Flipper::Cloud::Middleware do
     Flipper::Cloud.new("regular") do |config|
       config.local_adapter = Flipper::Adapters::OperationLogger.new(Flipper::Adapters::Memory.new)
       config.sync_secret = "regular_tasty"
-      config.sync_method = :webhook
     end
   }
 
@@ -17,7 +16,6 @@ RSpec.describe Flipper::Cloud::Middleware do
     Flipper::Cloud.new("env") do |config|
       config.local_adapter = Flipper::Adapters::OperationLogger.new(Flipper::Adapters::Memory.new)
       config.sync_secret = "env_tasty"
-      config.sync_method = :webhook
     end
   }
 

--- a/spec/flipper_spec.rb
+++ b/spec/flipper_spec.rb
@@ -232,7 +232,6 @@ RSpec.describe Flipper do
       cloud_configuration = Flipper::Cloud::Configuration.new({
         token: "asdf",
         sync_secret: "tasty",
-        sync_method: :webhook,
       })
 
       described_class.configure do |config|


### PR DESCRIPTION
`sync_secret` always needs to be set if this is changed, so I don't see a need for both settings.

This change was extracted from #506 to try to reduce the scope of that PR.

