### PR TITLE
Add `write_through` to ActiveSupport cache adapter

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -4,6 +4,7 @@
 
 * Allow actors and time gates to deal with decimal percentages (https://github.com/jnunemaker/flipper/pull/492)
 * Change Flipper::Cloud::Middleware to receive webhooks at / in addition to /webhooks.
+* Add `write_through` option to ActiveSupportCacheStore adapter to support write-through caching (https://github.com/jnunemaker/flipper/pull/512)
 
 ## 0.20.3
 

--- a/lib/flipper/spec/shared_adapter_specs.rb
+++ b/lib/flipper/spec/shared_adapter_specs.rb
@@ -205,7 +205,7 @@ RSpec.shared_examples_for 'a flipper adapter' do
 
     expect(subject.remove(feature)).to eq(true)
 
-    expect(subject.get(feature)).to eq(subject.default_config)
+    expect(subject.get(feature).values).to all(be_blank)
   end
 
   it 'can clear all the gate values for a feature' do


### PR DESCRIPTION
The current approach with caching adapters does something like this:

1. On write, delete the entry from the cache.
2. On the next read, repopulate the cache.

Unfortunately this can be subject to subtle race conditions if the
underlying storage (in our case, a replicated database) gives a stale
read for item 2 - which may be in a different process / thread / host
entirely. More details on our specific case are available at
https://gitlab.com/gitlab-org/gitlab/-/issues/325452.

The new `write_through` option to the ActiveSupportCacheStore adapter's
initialiser allows the user to opt in to write-through caching, where
the new value is immediately written to the cache in step 1.
