### PR TITLE
docs: fix Flipper::Identifier.flipper_id example

### DIFF
--- a/docs/Gates.md
+++ b/docs/Gates.md
@@ -35,7 +35,7 @@ feature.enabled? user # true
 feature.disable_actor user
 ```
 
-The only requirement for an individual actor is that it must have a unique `flipper_id`. Include the `Flipper::Identifier` module for a default implementation which combines the class name and `id` (e.g. `User:6`).
+The only requirement for an individual actor is that it must have a unique `flipper_id`. Include the `Flipper::Identifier` module for a default implementation which combines the class name and `id` (e.g. `User;6`).
 
 ```ruby
 class User < Struct.new(:id)


### PR DESCRIPTION
The [default implementation][1] of `Flipper::Identifier` uses a semicolon (instead of a colon) to separate class and id.

[1]: https://github.com/jnunemaker/flipper/blob/f4a50467a6da84f4d886b8bec1df56127446002b/lib/flipper/identifier.rb#L14