### PR TITLE
Gates.md: update Percentage of Time documentation

### DIFF
--- a/docs/Gates.md
+++ b/docs/Gates.md
@@ -93,11 +93,11 @@ Turn this on for a percentage of time. Think load testing new features behind th
 # Register a feature called logging and turn it on for 5 percent of the time.
 # This could be on during one request and off the next
 # could even be on first time in request and off second time
-Flipper.enable_percentage_of_time 5
+Flipper.enable_percentage_of_time :logging, 5
 
 Flipper.enabled? :logging # this will return true 5% of the time.
 
-Flipper.disable_percentage_of_time # sets to 0
+Flipper.disable_percentage_of_time :logging # sets to 0
 
 # you can also save a reference to a specific feature
 feature = Flipper[:search]


### PR DESCRIPTION
I was going through this to write some internal documentation, and I think the `percentage_of_time` documentation has a small bug.

Calling `Flipper.enable_percentage_of_time 5` results in 

```
ArgumentError: wrong number of arguments (given 1, expected 2)
```