### PR TITLE
Fix small typo in README.md in installing flipper-active_record part.

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ Add this line to your application's Gemfile:
 
 You'll also want to pick a storage [adapter](#adapters), for example:
 
-    gem 'flipper-active_record'`
+    gem 'flipper-active_record'
 
 And then execute:
 


### PR DESCRIPTION
I found a typo when trying to install the gem, especially when installing the flipper with an active record adapter. So this PR is just to fix the typo :)