### PR TITLE
Fix configuration of Cloud webhook app

### DIFF
--- a/lib/flipper/cloud/routes.rb
+++ b/lib/flipper/cloud/routes.rb
@@ -3,7 +3,7 @@ Rails.application.routes.draw do
   if ENV["FLIPPER_CLOUD_TOKEN"] && ENV["FLIPPER_CLOUD_SYNC_SECRET"]
     config = Rails.application.config.flipper
 
-    cloud_app = Flipper::Cloud.app(
+    cloud_app = Flipper::Cloud.app(nil,
       env_key: config.env_key,
       memoizer_options: { preload: config.preload }
     )

--- a/spec/flipper/cloud/engine_spec.rb
+++ b/spec/flipper/cloud/engine_spec.rb
@@ -4,7 +4,7 @@ require 'flipper/cloud'
 
 RSpec.describe Flipper::Cloud::Engine do
   let(:env) do
-    { "FLIPPER_CLOUD_TOKEN" => "ASDF" }
+    { "FLIPPER_CLOUD_TOKEN" => "test-token" }
   end
 
   let(:application) do
@@ -34,14 +34,46 @@ RSpec.describe Flipper::Cloud::Engine do
 
   context "with CLOUD_SYNC_SECRET" do
     before do
-      env.update "FLIPPER_CLOUD_SYNC_SECRET" => "abc"
+      env.update "FLIPPER_CLOUD_SYNC_SECRET" => "test-secret"
     end
 
-    it "configures webhook app" do
+    let(:app) { application.routes }
+    let(:request_body) do
+      JSON.generate({
+        "environment_id" => 1,
+        "webhook_id" => 1,
+        "delivery_id" => SecureRandom.uuid,
+        "action" => "sync",
+      })
+    end
+    let(:timestamp) { Time.now }
+    let(:signature) {
+      Flipper::Cloud::MessageVerifier.new(secret: env["FLIPPER_CLOUD_SYNC_SECRET"]).generate(request_body, timestamp)
+    }
+    let(:signature_header_value) {
+      Flipper::Cloud::MessageVerifier.new(secret: "").header(signature, timestamp)
+    }
+
+    it "mounts webhook app" do
       with_modified_env env do
         application.initialize!
 
         expect(find_route("/_flipper")).to be_a(ActionDispatch::Journey::Route)
+      end
+    end
+
+    it "properly configures webhook app" do
+      with_modified_env env do
+        application.initialize!
+
+        stub = stub_request(:get, "https://www.flippercloud.io/adapter/features").with({
+          headers: { "Flipper-Cloud-Token" => ENV["FLIPPER_CLOUD_TOKEN"] },
+        }).to_return(status: 200, body: JSON.generate({ features: {} }), headers: {})
+
+        post "/_flipper", request_body, { "HTTP_FLIPPER_CLOUD_SIGNATURE" => signature_header_value }
+
+        expect(last_response.status).to eq(200)
+        expect(stub).to have_been_requested
       end
     end
   end


### PR DESCRIPTION
`Cloud.app` takes the flipper instance as the first argument. Unfortunately, the tests didn't expose the mis-configuration.

This updates the tests to make a real request to the webhook app to ensure it is configured properly.