### PR TITLE
Only perform memoization and preloading once

### DIFF
--- a/lib/flipper/middleware/memoizer.rb
+++ b/lib/flipper/middleware/memoizer.rb
@@ -61,9 +61,11 @@ module Flipper
         reset_on_body_close = false
         flipper = env.fetch(@env_key) { Flipper }
 
-        # Already memoizing. Maybe the memization middleware is mounted twice?
-        # This instance does not need to do anything.
-        return @app.call(env) if flipper.memoizing?
+        # Already memoizing. This instance does not need to do anything.
+        if flipper.memoizing?
+          warn "Flipper::Middleware::Memoizer appears to be running twice. Read how to resolve this at https://github.com/jnunemaker/flipper/pull/523"
+          return @app.call(env)
+        end
 
         flipper.memoize = true
 

--- a/spec/flipper/middleware/memoizer_spec.rb
+++ b/spec/flipper/middleware/memoizer_spec.rb
@@ -239,13 +239,18 @@ RSpec.describe Flipper::Middleware::Memoizer do
       end.to_app
     end
 
+    def get(uri, params = {}, env = {}, &block)
+      silence { super(uri, params, env, &block) }
+    end
+
     include_examples 'flipper middleware'
 
     it 'does not call preload in second instance' do
       expect(flipper).not_to receive(:preload_all)
 
-      get '/', {}, 'flipper' => flipper
+      output = get '/', {}, 'flipper' => flipper
 
+      expect(output).to match(/Flipper::Middleware::Memoizer appears to be running twice/)
       expect(adapter.count(:get_multi)).to be(1)
       expect(adapter.last(:get_multi).args).to eq([[flipper[:stats]]])
     end


### PR DESCRIPTION
When upgrading to the next release of flipper, anyone using the Memoizer middleware will need to make some changes. Specifically, they will need to either remove the mounting of the middleware and update the `preload` config, if they are using it…

```diff
- Rails.application.middleware.use Flipper::Middleware::Memoizer, preload: [:some, :features]

+ Rails.application.configure do
+  config.flipper.preload = [:some, :features]
+ end
```

…or disable memoizing from the Railtie:

```diff
+ Rails.application.configure do
+  config.flipper.memoize = false
+ end
```

This pull request updates the Memoizer middleware to be a noop if `flipper.memoizing?` is already true.  This should allow for the first instance of the middleware (manually mounted in `config/initializers/*`) to continue working, and the second one (added by the Railtie after `config/initializers/*`) to be a noop.