### PR TITLE
Enable log subscriber by default in Rails

### DIFF
--- a/lib/flipper/railtie.rb
+++ b/lib/flipper/railtie.rb
@@ -5,7 +5,8 @@ module Flipper
         env_key: "flipper",
         memoize: true,
         preload: true,
-        instrumenter: ActiveSupport::Notifications
+        instrumenter: ActiveSupport::Notifications,
+        logging: true
       )
     end
 
@@ -27,6 +28,10 @@ module Flipper
           if: config.memoize.respond_to?(:call) ? config.memoize : nil
         }
       end
+    end
+
+    initializer "flipper.logging", after: :load_config_initializers do |app|
+      require "flipper/instrumentation/log_subscriber" if app.config.flipper.logging
     end
 
     initializer "flipper.identifier" do

--- a/lib/flipper/railtie.rb
+++ b/lib/flipper/railtie.rb
@@ -31,7 +31,10 @@ module Flipper
     end
 
     initializer "flipper.log", after: :load_config_initializers do |app|
-      require "flipper/instrumentation/log_subscriber" if app.config.flipper.log
+      config = app.config.flipper
+      if config.log && config.instrumenter == ActiveSupport::Notifications
+        require "flipper/instrumentation/log_subscriber"
+      end
     end
 
     initializer "flipper.identifier" do

--- a/lib/flipper/railtie.rb
+++ b/lib/flipper/railtie.rb
@@ -6,7 +6,7 @@ module Flipper
         memoize: true,
         preload: true,
         instrumenter: ActiveSupport::Notifications,
-        logging: true
+        log: true
       )
     end
 
@@ -30,8 +30,8 @@ module Flipper
       end
     end
 
-    initializer "flipper.logging", after: :load_config_initializers do |app|
-      require "flipper/instrumentation/log_subscriber" if app.config.flipper.logging
+    initializer "flipper.log", after: :load_config_initializers do |app|
+      require "flipper/instrumentation/log_subscriber" if app.config.flipper.log
     end
 
     initializer "flipper.identifier" do


### PR DESCRIPTION
Requires `flipper/instrumentation/log_subscriber` in the Railtie unless logging is explicitly disabled. The log subscriber already does a check for `logger.debug?`, so I think it makes sense to require this regardless of environment.