### PR TITLE
Remove memoizer from UI

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,7 +17,7 @@ test/tmp
 test/version_tmp
 tmp
 log
-flipper.pstore
+*.pstore
 .sass-cache
 bin
 .DS_Store

--- a/Guardfile
+++ b/Guardfile
@@ -16,6 +16,8 @@ rspec_options = {
 guard 'rspec', rspec_options do
   watch(%r{^spec/.+_spec\.rb$})
   watch(%r{^lib/(.+)\.rb$}) { |m| "spec/#{m[1]}_spec.rb" }
+  watch('lib/flipper/ui/middleware.rb') { 'spec/flipper/ui_spec.rb' }
+  watch('lib/flipper/api/middleware.rb') { 'spec/flipper/api_spec.rb' }
   watch(/shared_adapter_specs\.rb$/) { 'spec' }
   watch('spec/helper.rb') { 'spec' }
 end

--- a/examples/api/basic.ru
+++ b/examples/api/basic.ru
@@ -1,0 +1,25 @@
+#
+# Usage:
+#   # if you want it to not reload and be really fast
+#   bin/rackup examples/api/basic.ru -p 9999
+#
+#   # if you want reloading
+#   bin/shotgun examples/api/basic.ru -p 9999
+#
+#   http://localhost:9999/
+#
+
+require 'bundler/setup'
+require "flipper/api"
+require "flipper/adapters/pstore"
+
+Flipper.register(:admins) { |actor|
+  actor.respond_to?(:admin?) && actor.admin?
+}
+
+# You can uncomment this to get some default data:
+# Flipper.enable :logging
+
+run Flipper::Api.app { |builder|
+  builder.use Flipper::Middleware::Memoizer, preload: true
+}

--- a/examples/api/basic.ru
+++ b/examples/api/basic.ru
@@ -13,13 +13,7 @@ require 'bundler/setup'
 require "flipper/api"
 require "flipper/adapters/pstore"
 
-Flipper.register(:admins) { |actor|
-  actor.respond_to?(:admin?) && actor.admin?
-}
-
 # You can uncomment this to get some default data:
 # Flipper.enable :logging
 
-run Flipper::Api.app { |builder|
-  builder.use Flipper::Middleware::Memoizer, preload: true
-}
+run Flipper::Api.app

--- a/examples/api/custom_memoized.ru
+++ b/examples/api/custom_memoized.ru
@@ -1,0 +1,37 @@
+#
+# Usage:
+#   # if you want it to not reload and be really fast
+#   bin/rackup examples/api/custom_memoized.ru -p 9999
+#
+#   # if you want reloading
+#   bin/shotgun examples/api/custom_memoized.ru -p 9999
+#
+#   http://localhost:9999/
+#
+
+require 'bundler/setup'
+require "active_support/notifications"
+require "flipper/api"
+require "flipper/adapters/pstore"
+
+adapter = Flipper::Adapters::Instrumented.new(
+  Flipper::Adapters::PStore.new,
+  instrumenter: ActiveSupport::Notifications,
+)
+flipper = Flipper.new(adapter)
+
+ActiveSupport::Notifications.subscribe(/.*/, ->(*args) {
+  p args: args
+})
+
+Flipper.register(:admins) { |actor|
+  actor.respond_to?(:admin?) && actor.admin?
+}
+
+# You can uncomment this to get some default data:
+# flipper[:logging].enable_percentage_of_time 5
+
+run Flipper::Api.app(flipper) { |builder|
+  builder.use Flipper::Middleware::SetupEnv, flipper, env_key: "flipper_api"
+  builder.use Flipper::Middleware::Memoizer, env_key: "flipper_api", preload: true
+}

--- a/examples/api/custom_memoized.ru
+++ b/examples/api/custom_memoized.ru
@@ -21,17 +21,17 @@ adapter = Flipper::Adapters::Instrumented.new(
 flipper = Flipper.new(adapter)
 
 ActiveSupport::Notifications.subscribe(/.*/, ->(*args) {
-  p args: args
+  name, start, finish, id, data = args
+  case name
+  when "adapter_operation.flipper"
+    p data[:adapter_name] => data[:operation]
+  end
 })
-
-Flipper.register(:admins) { |actor|
-  actor.respond_to?(:admin?) && actor.admin?
-}
 
 # You can uncomment this to get some default data:
 # flipper[:logging].enable_percentage_of_time 5
 
 run Flipper::Api.app(flipper) { |builder|
-  builder.use Flipper::Middleware::SetupEnv, flipper, env_key: "flipper_api"
-  builder.use Flipper::Middleware::Memoizer, env_key: "flipper_api", preload: true
+  builder.use Flipper::Middleware::SetupEnv, flipper
+  builder.use Flipper::Middleware::Memoizer, preload: true
 }

--- a/examples/api/memoized.ru
+++ b/examples/api/memoized.ru
@@ -1,0 +1,39 @@
+#
+# Usage:
+#   # if you want it to not reload and be really fast
+#   bin/rackup examples/api/memoized.ru -p 9999
+#
+#   # if you want reloading
+#   bin/shotgun examples/api/memoized.ru -p 9999
+#
+#   http://localhost:9999/
+#
+
+require 'bundler/setup'
+require "active_support/notifications"
+require "flipper/api"
+require "flipper/adapters/pstore"
+
+Flipper.configure do |config|
+  config.adapter {
+    Flipper::Adapters::Instrumented.new(
+      Flipper::Adapters::PStore.new,
+      instrumenter: ActiveSupport::Notifications,
+    )
+  }
+end
+
+ActiveSupport::Notifications.subscribe(/.*/, ->(*args) {
+  p args: args
+})
+
+Flipper.register(:admins) { |actor|
+  actor.respond_to?(:admin?) && actor.admin?
+}
+
+# You can uncomment this to get some default data:
+# Flipper.enable :logging
+
+run Flipper::Api.app { |builder|
+  builder.use Flipper::Middleware::Memoizer, preload: true
+}

--- a/examples/api/memoized.ru
+++ b/examples/api/memoized.ru
@@ -24,7 +24,11 @@ Flipper.configure do |config|
 end
 
 ActiveSupport::Notifications.subscribe(/.*/, ->(*args) {
-  p args: args
+  name, start, finish, id, data = args
+  case name
+  when "adapter_operation.flipper"
+    p data[:adapter_name] => data[:operation]
+  end
 })
 
 Flipper.register(:admins) { |actor|

--- a/examples/ui/authorization.ru
+++ b/examples/ui/authorization.ru
@@ -5,49 +5,12 @@
 #   http://localhost:9999/
 #
 require 'bundler/setup'
-require "logger"
-
 require "flipper/ui"
 require "flipper/adapters/pstore"
-require "active_support/notifications"
 
 Flipper.register(:admins) { |actor|
   actor.respond_to?(:admin?) && actor.admin?
 }
-
-Flipper.register(:early_access) { |actor|
-  actor.respond_to?(:early?) && actor.early?
-}
-
-# Setup logging of flipper calls.
-if ENV["LOG"] == "1"
-  $logger = Logger.new(STDOUT)
-  require "flipper/instrumentation/log_subscriber"
-  Flipper::Instrumentation::LogSubscriber.logger = $logger
-end
-
-adapter = Flipper::Adapters::PStore.new
-flipper = Flipper.new(adapter, instrumenter: ActiveSupport::Notifications)
-
-Flipper::UI.configure do |config|
-  # config.banner_text = 'Production Environment'
-  # config.banner_class = 'danger'
-  config.feature_creation_enabled = true
-  config.feature_removal_enabled = true
-  # config.show_feature_description_in_list = true
-  config.descriptions_source = lambda do |_keys|
-    {
-      "search_performance_another_long_thing" => "Just to test feature name length.",
-      "gauges_tracking" => "Should we track page views with gaug.es.",
-      "unused" => "Not used.",
-      "suits" => "Are suits necessary in business?",
-      "secrets" => "Secrets are lies.",
-      "logging" => "Log all the things.",
-      "new_cache" => "Like the old cache but newer.",
-      "a/b" => "Why would someone use a slash? I don't know but someone did. Let's make this really long so they regret using slashes. Please don't use slashes.",
-    }
-  end
-end
 
 # Example middleware to allow reading the Flipper UI but nothing else.
 class FlipperReadOnlyMiddleware
@@ -67,18 +30,17 @@ class FlipperReadOnlyMiddleware
 end
 
 # You can uncomment these to get some default data:
-# flipper[:search_performance_another_long_thing].enable
-# flipper[:gauges_tracking].enable
-# flipper[:unused].disable
-# flipper[:suits].enable_actor Flipper::Actor.new('1')
-# flipper[:suits].enable_actor Flipper::Actor.new('6')
-# flipper[:secrets].enable_group :admins
-# flipper[:secrets].enable_group :early_access
-# flipper[:logging].enable_percentage_of_time 5
-# flipper[:new_cache].enable_percentage_of_actors 15
-# flipper["something/slashed"].add
+# Flipper.enable(:search_performance_another_long_thing)
+# Flipper.disable(:gauges_tracking)
+# Flipper.disable(:unused)
+# Flipper.enable_actor(:suits, Flipper::Actor.new('1'))
+# Flipper.enable_actor(:suits, Flipper::Actor.new('6'))
+# Flipper.enable_group(:secrets, :admins)
+# Flipper.enable_percentage_of_time(:logging, 5)
+# Flipper.enable_percentage_of_actors(:new_cache, 15)
+# Flipper.add("a/b")
 
-run Flipper::UI.app(flipper) { |builder|
+run Flipper::UI.app { |builder|
   builder.use Rack::Session::Cookie, secret: "_super_secret"
   builder.use FlipperReadOnlyMiddleware
 }

--- a/examples/ui/basic.ru
+++ b/examples/ui/basic.ru
@@ -42,16 +42,16 @@ Flipper::UI.configure do |config|
 end
 
 # You can uncomment these to get some default data:
-# flipper[:search_performance_another_long_thing].enable
-# flipper[:gauges_tracking].enable
-# flipper[:unused].disable
-# flipper[:suits].enable_actor Flipper::Actor.new('1')
-# flipper[:suits].enable_actor Flipper::Actor.new('6')
-# flipper[:secrets].enable_group :admins
-# flipper[:secrets].enable_group :early_access
-# flipper[:logging].enable_percentage_of_time 5
-# flipper[:new_cache].enable_percentage_of_actors 15
-# flipper["a/b"].add
+# Flipper.enable(:search_performance_another_long_thing)
+# Flipper.disable(:gauges_tracking)
+# Flipper.disable(:unused)
+# Flipper.enable_actor(:suits, Flipper::Actor.new('1'))
+# Flipper.enable_actor(:suits, Flipper::Actor.new('6'))
+# Flipper.enable_group(:secrets, :admins)
+# Flipper.enable_group(:secrets, :early_access)
+# Flipper.enable_percentage_of_time(:logging, 5)
+# Flipper.enable_percentage_of_actors(:new_cache, 15)
+# Flipper.add("a/b")
 
 run Flipper::UI.app { |builder|
   builder.use Rack::Session::Cookie, secret: "_super_secret"

--- a/lib/flipper/api.rb
+++ b/lib/flipper/api.rb
@@ -15,9 +15,7 @@ module Flipper
       builder = Rack::Builder.new
       yield builder if block_given?
       builder.use Flipper::Api::JsonParams
-      builder.use Flipper::Middleware::SetupEnv, flipper, env_key: env_key
-      builder.use Flipper::Middleware::Memoizer, memoizer_options.merge(env_key: env_key)
-      builder.use Flipper::Api::Middleware, env_key: env_key
+      builder.use Flipper::Api::Middleware, flipper, env_key: env_key
       builder.run app
       klass = self
       builder.define_singleton_method(:inspect) { klass.inspect } # pretty rake routes output

--- a/lib/flipper/api.rb
+++ b/lib/flipper/api.rb
@@ -9,13 +9,12 @@ module Flipper
 
     def self.app(flipper = nil, options = {})
       env_key = options.fetch(:env_key, 'flipper')
-      memoizer_options = options.fetch(:memoizer_options, {})
-
       app = ->(_) { [404, { 'Content-Type'.freeze => CONTENT_TYPE }, ['{}'.freeze]] }
       builder = Rack::Builder.new
       yield builder if block_given?
       builder.use Flipper::Api::JsonParams
-      builder.use Flipper::Api::Middleware, flipper, env_key: env_key
+      builder.use Flipper::Middleware::SetupEnv, flipper, env_key: env_key
+      builder.use Flipper::Api::Middleware, env_key: env_key
       builder.run app
       klass = self
       builder.define_singleton_method(:inspect) { klass.inspect } # pretty rake routes output

--- a/lib/flipper/api/middleware.rb
+++ b/lib/flipper/api/middleware.rb
@@ -9,15 +9,9 @@ end
 module Flipper
   module Api
     class Middleware
-      def initialize(app, flipper = nil, options = {})
+      def initialize(app, options = {})
         @app = app
         @env_key = options.fetch(:env_key, 'flipper')
-
-        if flipper.respond_to?(:call)
-          @flipper_block = flipper
-        else
-          @flipper = flipper || Flipper
-        end
 
         @action_collection = ActionCollection.new
         @action_collection.add Api::V1::Actions::PercentageOfTimeGate
@@ -42,14 +36,9 @@ module Flipper
         if action_class.nil?
           @app.call(env)
         else
-          action_class.run(env[@env_key] || flipper, request)
+          flipper = env.fetch(@env_key) { Flipper }
+          action_class.run(flipper, request)
         end
-      end
-
-      private
-
-      def flipper
-        @flipper ||= @flipper_block.call
       end
     end
   end

--- a/lib/flipper/api/middleware.rb
+++ b/lib/flipper/api/middleware.rb
@@ -9,9 +9,15 @@ end
 module Flipper
   module Api
     class Middleware
-      def initialize(app, options = {})
+      def initialize(app, flipper = nil, options = {})
         @app = app
         @env_key = options.fetch(:env_key, 'flipper')
+
+        if flipper.respond_to?(:call)
+          @flipper_block = flipper
+        else
+          @flipper = flipper || Flipper
+        end
 
         @action_collection = ActionCollection.new
         @action_collection.add Api::V1::Actions::PercentageOfTimeGate
@@ -32,12 +38,18 @@ module Flipper
       def call!(env)
         request = Rack::Request.new(env)
         action_class = @action_collection.action_for_request(request)
+
         if action_class.nil?
           @app.call(env)
         else
-          flipper = env.fetch(@env_key)
-          action_class.run(flipper, request)
+          action_class.run(env[@env_key] || flipper, request)
         end
+      end
+
+      private
+
+      def flipper
+        @flipper ||= @flipper_block.call
       end
     end
   end

--- a/lib/flipper/middleware/memoizer.rb
+++ b/lib/flipper/middleware/memoizer.rb
@@ -15,7 +15,7 @@ module Flipper
       #   use Flipper::Middleware::Memoizer
       #
       #   # using with preload_all features
-      #   use Flipper::Middleware::Memoizer, preload_all: true
+      #   use Flipper::Middleware::Memoizer, preload: true
       #
       #   # using with preload specific features
       #   use Flipper::Middleware::Memoizer, preload: [:stats, :search, :some_feature]

--- a/lib/flipper/ui.rb
+++ b/lib/flipper/ui.rb
@@ -45,7 +45,8 @@ module Flipper
       yield builder if block_given?
       builder.use Rack::Protection, rack_protection_options
       builder.use Rack::MethodOverride
-      builder.use Flipper::UI::Middleware, flipper, env_key: env_key
+      builder.use Flipper::Middleware::SetupEnv, flipper, env_key: env_key
+      builder.use Flipper::UI::Middleware, flipper: flipper, env_key: env_key
       builder.run app
       klass = self
       builder.define_singleton_method(:inspect) { klass.inspect } # pretty rake routes output

--- a/lib/flipper/ui.rb
+++ b/lib/flipper/ui.rb
@@ -44,9 +44,7 @@ module Flipper
       yield builder if block_given?
       builder.use Rack::Protection, rack_protection_options
       builder.use Rack::MethodOverride
-      builder.use Flipper::Middleware::SetupEnv, flipper, env_key: env_key
-      builder.use Flipper::Middleware::Memoizer, env_key: env_key
-      builder.use Flipper::UI::Middleware, env_key: env_key
+      builder.use Flipper::UI::Middleware, flipper, env_key: env_key
       builder.run app
       klass = self
       builder.define_singleton_method(:inspect) { klass.inspect } # pretty rake routes output

--- a/lib/flipper/ui.rb
+++ b/lib/flipper/ui.rb
@@ -39,6 +39,7 @@ module Flipper
     def self.app(flipper = nil, options = {})
       env_key = options.fetch(:env_key, 'flipper')
       rack_protection_options = options.fetch(:rack_protection, use: :authenticity_token)
+
       app = ->(_) { [200, { 'Content-Type' => 'text/html' }, ['']] }
       builder = Rack::Builder.new
       yield builder if block_given?

--- a/lib/flipper/ui/middleware.rb
+++ b/lib/flipper/ui/middleware.rb
@@ -9,15 +9,10 @@ end
 module Flipper
   module UI
     class Middleware
-      def initialize(app, flipper = nil, options = {})
+      def initialize(app, options = {})
         @app = app
         @env_key = options.fetch(:env_key, 'flipper')
-
-        if flipper.respond_to?(:call)
-          @flipper_block = flipper
-        else
-          @flipper = flipper || Flipper
-        end
+        @flipper = options.fetch(:flipper) { Flipper }
 
         @action_collection = ActionCollection.new
 
@@ -49,14 +44,9 @@ module Flipper
         if action_class.nil?
           @app.call(env)
         else
-          action_class.run(env[@env_key] || flipper, request)
+          flipper = env.fetch(@env_key) { Flipper }
+          action_class.run(flipper, request)
         end
-      end
-
-      private
-
-      def flipper
-        @flipper ||= @flipper_block.call
       end
     end
   end

--- a/spec/flipper/api_spec.rb
+++ b/spec/flipper/api_spec.rb
@@ -1,6 +1,36 @@
 require 'helper'
 
 RSpec.describe Flipper::Api do
+  describe 'Initializing middleware with flipper instance' do
+    let(:app) { build_api(flipper) }
+
+    it 'works' do
+      flipper.enable :a
+      flipper.disable :b
+
+      get '/features'
+
+      expect(last_response.status).to be(200)
+      feature_names = json_response.fetch('features').map { |feature| feature.fetch('key') }
+      expect(feature_names).to eq(%w(a b))
+    end
+  end
+
+  describe 'Initializing middleware lazily with a block' do
+    let(:app) { build_api(-> { flipper }) }
+
+    it 'works' do
+      flipper.enable :a
+      flipper.disable :b
+
+      get '/features'
+
+      expect(last_response.status).to be(200)
+      feature_names = json_response.fetch('features').map { |feature| feature.fetch('key') }
+      expect(feature_names).to eq(%w(a b))
+    end
+  end
+
   context 'when initialized with flipper instance and flipper instance in env' do
     let(:app) { build_api(flipper) }
 
@@ -74,6 +104,12 @@ RSpec.describe Flipper::Api do
       get '/gibberish'
       expect(last_response.status).to eq(404)
       expect(json_response).to eq({})
+    end
+  end
+
+  describe 'Inspecting the built Rack app' do
+    it 'returns a String' do
+      expect(build_api(flipper).inspect).to be_a(String)
     end
   end
 end

--- a/spec/flipper/ui_spec.rb
+++ b/spec/flipper/ui_spec.rb
@@ -24,19 +24,6 @@ RSpec.describe Flipper::UI do
     end
   end
 
-  describe 'Initializing middleware lazily with a block' do
-    let(:app) do
-      build_app(-> { flipper })
-    end
-
-    it 'works' do
-      flipper.enable :some_great_feature
-      get '/features'
-      expect(last_response.status).to be(200)
-      expect(last_response.body).to include('some_great_feature')
-    end
-  end
-
   describe 'Request method unsupported by action' do
     it 'raises error' do
       expect do


### PR DESCRIPTION
Default rails and flipper setups will use memoizer so having ui include it causes the double memoize warning message, which can be confusing.

This removes the memoizer from UI and adds the backwards compatibility stuff we need to make it all work the same.

We can add a doc on how to add your own memoizer for just the ui:

```ruby
run Flipper::UI.app { |builder|
  builder.use Flipper::Middleware::SetupEnv, some_flipper, env_key: "some_flipper"
  builder.use Flipper::Middleware::Memoizer, env_key: "some_flipper"
  # etc
}
```

We can also add a doc on how to add your own memoizer for just the api: 

```ruby
run Flipper::Api.app { |builder|
  builder.use Flipper::Middleware::SetupEnv, api_flipper, env_key: "api_flipper"
  builder.use Flipper::Middleware::Memoizer, env_key: "api_flipper"
  # etc
}
```

I'm open to doing something different. Just figured I'd throw out a first example to react to.

href #526 