### PR TITLE
fix(active-record): arelize get_all query

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -19,6 +19,7 @@ gem 'minitest-documentation'
 gem 'webmock', '~> 3.0'
 gem 'climate_control'
 gem 'redis-namespace'
+gem 'webrick'
 
 group(:guard) do
   gem 'guard', '~> 2.15'


### PR DESCRIPTION
Arel and Sequel know how to handle reserved words in terms of escape characters for the given underlying database technology. This way we don't have to assume that DB-specific knowledge.

Closes #535 