### PR TITLE
Handle spaces in names gracefully in UI

### DIFF
--- a/lib/flipper/ui/action.rb
+++ b/lib/flipper/ui/action.rb
@@ -151,7 +151,7 @@ module Flipper
       # location - The String location to set the Location header to.
       def redirect_to(location)
         status 302
-        header 'Location', "#{script_name}#{location}"
+        header 'Location', "#{script_name}#{Rack::Utils.escape_path(location)}"
         halt [@code, @headers, ['']]
       end
 

--- a/lib/flipper/ui/actions/actors_gate.rb
+++ b/lib/flipper/ui/actions/actors_gate.rb
@@ -27,7 +27,7 @@ module Flipper
           value = params['value'].to_s.strip
 
           if Util.blank?(value)
-            error = Rack::Utils.escape("#{value.inspect} is not a valid actor value.")
+            error = "#{value.inspect} is not a valid actor value."
             redirect_to("/features/#{feature.key}/actors?error=#{error}")
           end
 

--- a/lib/flipper/ui/actions/features.rb
+++ b/lib/flipper/ui/actions/features.rb
@@ -49,14 +49,14 @@ module Flipper
           value = params['value'].to_s.strip
 
           if Util.blank?(value)
-            error = Rack::Utils.escape("#{value.inspect} is not a valid feature name.")
+            error = "#{value.inspect} is not a valid feature name."
             redirect_to("/features/new?error=#{error}")
           end
 
           feature = flipper[value]
           feature.add
 
-          redirect_to "/features/#{Rack::Utils.escape_path(value)}"
+          redirect_to "/features/#{value}"
         end
       end
     end

--- a/lib/flipper/ui/actions/groups_gate.rb
+++ b/lib/flipper/ui/actions/groups_gate.rb
@@ -35,7 +35,7 @@ module Flipper
 
             redirect_to("/features/#{feature.key}")
           else
-            error = Rack::Utils.escape("The group named #{value.inspect} has not been registered.")
+            error = "The group named #{value.inspect} has not been registered."
             redirect_to("/features/#{feature.key}/groups?error=#{error}")
           end
         end

--- a/lib/flipper/ui/actions/percentage_of_actors_gate.rb
+++ b/lib/flipper/ui/actions/percentage_of_actors_gate.rb
@@ -16,7 +16,7 @@ module Flipper
           begin
             feature.enable_percentage_of_actors params['value']
           rescue ArgumentError => exception
-            error = Rack::Utils.escape("Invalid percentage of actors value: #{exception.message}")
+            error = "Invalid percentage of actors value: #{exception.message}"
             redirect_to("/features/#{@feature.key}?error=#{error}")
           end
 

--- a/lib/flipper/ui/actions/percentage_of_time_gate.rb
+++ b/lib/flipper/ui/actions/percentage_of_time_gate.rb
@@ -16,7 +16,7 @@ module Flipper
           begin
             feature.enable_percentage_of_time params['value']
           rescue ArgumentError => exception
-            error = Rack::Utils.escape("Invalid percentage of time value: #{exception.message}")
+            error = "Invalid percentage of time value: #{exception.message}"
             redirect_to("/features/#{@feature.key}?error=#{error}")
           end
 

--- a/spec/flipper/api/v1/actions/actors_gate_spec.rb
+++ b/spec/flipper/api/v1/actions/actors_gate_spec.rb
@@ -44,7 +44,7 @@ RSpec.describe Flipper::Api::V1::Actions::ActorsGate do
 
   describe 'enable feature with slash in name' do
     before do
-      flipper[:my_feature].disable_actor(actor)
+      flipper["my/feature"].disable_actor(actor)
       post '/features/my/feature/actors', flipper_id: actor.flipper_id
     end
 
@@ -52,6 +52,24 @@ RSpec.describe Flipper::Api::V1::Actions::ActorsGate do
       expect(last_response.status).to eq(200)
       expect(flipper["my/feature"].enabled?(actor)).to be_truthy
       expect(flipper["my/feature"].enabled_gate_names).to eq([:actor])
+    end
+
+    it 'returns decorated feature with actor enabled' do
+      gate = json_response['gates'].find { |gate| gate['key'] == 'actors' }
+      expect(gate['value']).to eq(['1'])
+    end
+  end
+
+  describe 'enable feature with space in name' do
+    before do
+      flipper["sp ace"].disable_actor(actor)
+      post '/features/sp%20ace/actors', flipper_id: actor.flipper_id
+    end
+
+    it 'enables feature for actor' do
+      expect(last_response.status).to eq(200)
+      expect(flipper["sp ace"].enabled?(actor)).to be_truthy
+      expect(flipper["sp ace"].enabled_gate_names).to eq([:actor])
     end
 
     it 'returns decorated feature with actor enabled' do

--- a/spec/flipper/ui/actions/actors_gate_spec.rb
+++ b/spec/flipper/ui/actions/actors_gate_spec.rb
@@ -61,6 +61,23 @@ RSpec.describe Flipper::UI::Actions::ActorsGate do
         expect(last_response.headers['Location']).to eq('/features/search')
       end
 
+      context "when feature name contains space" do
+        before do
+          post 'features/sp%20ace/actors',
+               { 'value' => value, 'operation' => 'enable', 'authenticity_token' => token },
+               'rack.session' => session
+        end
+
+        it 'adds item to members' do
+          expect(flipper["sp ace"].actors_value).to include('User;6')
+        end
+
+        it "redirects back to feature" do
+          expect(last_response.status).to be(302)
+          expect(last_response.headers['Location']).to eq('/features/sp%20ace')
+        end
+      end
+
       context 'value contains whitespace' do
         let(:value) { '  User;6  ' }
 
@@ -75,7 +92,7 @@ RSpec.describe Flipper::UI::Actions::ActorsGate do
 
           it 'redirects back to feature' do
             expect(last_response.status).to be(302)
-            expect(last_response.headers['Location']).to eq('/features/search/actors?error=%22%22+is+not+a+valid+actor+value.')
+            expect(last_response.headers['Location']).to eq('/features/search/actors?error=%22%22%20is%20not%20a%20valid%20actor%20value.')
           end
         end
 
@@ -84,7 +101,7 @@ RSpec.describe Flipper::UI::Actions::ActorsGate do
 
           it 'redirects back to feature' do
             expect(last_response.status).to be(302)
-            expect(last_response.headers['Location']).to eq('/features/search/actors?error=%22%22+is+not+a+valid+actor+value.')
+            expect(last_response.headers['Location']).to eq('/features/search/actors?error=%22%22%20is%20not%20a%20valid%20actor%20value.')
           end
         end
       end

--- a/spec/flipper/ui/actions/boolean_gate_spec.rb
+++ b/spec/flipper/ui/actions/boolean_gate_spec.rb
@@ -31,6 +31,24 @@ RSpec.describe Flipper::UI::Actions::BooleanGate do
       end
     end
 
+    context "with space in feature name" do
+      before do
+        flipper.disable :search
+        post 'features/sp%20ace/boolean',
+             { 'action' => 'Enable', 'authenticity_token' => token },
+             'rack.session' => session
+      end
+
+      it 'updates feature' do
+        expect(flipper.enabled?("sp ace")).to be(true)
+      end
+
+      it 'redirects back to feature' do
+        expect(last_response.status).to be(302)
+        expect(last_response.headers['Location']).to eq('/features/sp%20ace')
+      end
+    end
+
     context 'with disable' do
       before do
         flipper.enable :search

--- a/spec/flipper/ui/actions/feature_spec.rb
+++ b/spec/flipper/ui/actions/feature_spec.rb
@@ -29,6 +29,24 @@ RSpec.describe Flipper::UI::Actions::Feature do
       expect(last_response.headers['Location']).to eq('/features')
     end
 
+    context "with space in feature name" do
+      before do
+        flipper.enable "sp ace"
+        delete '/features/sp%20ace',
+               { 'authenticity_token' => token },
+               'rack.session' => session
+      end
+
+      it 'removes feature' do
+        expect(flipper.features.map(&:key)).not_to include('sp ace')
+      end
+
+      it 'redirects to features' do
+        expect(last_response.status).to be(302)
+        expect(last_response.headers['Location']).to eq('/features')
+      end
+    end
+
     context 'when feature_removal_enabled is set to false' do
       around do |example|
         begin

--- a/spec/flipper/ui/actions/features_spec.rb
+++ b/spec/flipper/ui/actions/features_spec.rb
@@ -95,11 +95,24 @@ RSpec.describe Flipper::UI::Actions::Features do
         expect(last_response.headers['Location']).to eq('/features/notifications_next')
       end
 
-      context 'feature name contains whitespace' do
+      context 'feature name has whitespace at beginning and end' do
         let(:feature_name) { '  notifications_next   ' }
 
         it 'adds feature without whitespace' do
           expect(flipper.features.map(&:key)).to include('notifications_next')
+        end
+      end
+
+      context 'feature name contains space' do
+        let(:feature_name) { 'notifications next' }
+
+        it 'adds feature with space' do
+          expect(flipper.features.map(&:key)).to include('notifications next')
+        end
+
+        it 'redirects to feature' do
+          expect(last_response.status).to be(302)
+          expect(last_response.headers['Location']).to eq('/features/notifications%20next')
         end
       end
 
@@ -113,7 +126,7 @@ RSpec.describe Flipper::UI::Actions::Features do
 
           it 'redirects back to feature' do
             expect(last_response.status).to be(302)
-            expect(last_response.headers['Location']).to eq('/features/new?error=%22%22+is+not+a+valid+feature+name.')
+            expect(last_response.headers['Location']).to eq('/features/new?error=%22%22%20is%20not%20a%20valid%20feature%20name.')
           end
         end
 
@@ -126,7 +139,7 @@ RSpec.describe Flipper::UI::Actions::Features do
 
           it 'redirects back to feature' do
             expect(last_response.status).to be(302)
-            expect(last_response.headers['Location']).to eq('/features/new?error=%22%22+is+not+a+valid+feature+name.')
+            expect(last_response.headers['Location']).to eq('/features/new?error=%22%22%20is%20not%20a%20valid%20feature%20name.')
           end
         end
       end

--- a/spec/flipper/ui/actions/groups_gate_spec.rb
+++ b/spec/flipper/ui/actions/groups_gate_spec.rb
@@ -60,6 +60,23 @@ RSpec.describe Flipper::UI::Actions::GroupsGate do
         expect(last_response.headers['Location']).to eq('/features/search')
       end
 
+      context 'feature name contains space' do
+        before do
+          post 'features/sp%20ace/groups',
+               { 'value' => group_name, 'operation' => 'enable', 'authenticity_token' => token },
+               'rack.session' => session
+        end
+
+        it 'adds item to members' do
+          expect(flipper["sp ace"].groups_value).to include('admins')
+        end
+
+        it 'redirects back to feature' do
+          expect(last_response.status).to be(302)
+          expect(last_response.headers['Location']).to eq('/features/sp%20ace')
+        end
+      end
+
       context 'group name contains whitespace' do
         let(:group_name) { '  admins  ' }
 
@@ -74,7 +91,7 @@ RSpec.describe Flipper::UI::Actions::GroupsGate do
 
           it 'redirects back to feature' do
             expect(last_response.status).to be(302)
-            expect(last_response.headers['Location']).to eq('/features/search/groups?error=The+group+named+%22not_here%22+has+not+been+registered.')
+            expect(last_response.headers['Location']).to eq('/features/search/groups?error=The%20group%20named%20%22not_here%22%20has%20not%20been%20registered.')
           end
         end
 
@@ -83,7 +100,7 @@ RSpec.describe Flipper::UI::Actions::GroupsGate do
 
           it 'redirects back to feature' do
             expect(last_response.status).to be(302)
-            expect(last_response.headers['Location']).to eq('/features/search/groups?error=The+group+named+%22%22+has+not+been+registered.')
+            expect(last_response.headers['Location']).to eq('/features/search/groups?error=The%20group%20named%20%22%22%20has%20not%20been%20registered.')
           end
         end
 
@@ -92,7 +109,7 @@ RSpec.describe Flipper::UI::Actions::GroupsGate do
 
           it 'redirects back to feature' do
             expect(last_response.status).to be(302)
-            expect(last_response.headers['Location']).to eq('/features/search/groups?error=The+group+named+%22%22+has+not+been+registered.')
+            expect(last_response.headers['Location']).to eq('/features/search/groups?error=The%20group%20named%20%22%22%20has%20not%20been%20registered.')
           end
         end
       end

--- a/spec/flipper/ui/actions/percentage_of_actors_gate_spec.rb
+++ b/spec/flipper/ui/actions/percentage_of_actors_gate_spec.rb
@@ -30,6 +30,23 @@ RSpec.describe Flipper::UI::Actions::PercentageOfActorsGate do
       end
     end
 
+    context 'with space in feature name' do
+      before do
+        post 'features/sp%20ace/percentage_of_actors',
+             { 'value' => '24', 'authenticity_token' => token },
+             'rack.session' => session
+      end
+
+      it 'enables the feature' do
+        expect(flipper["sp ace"].percentage_of_actors_value).to be(24)
+      end
+
+      it 'redirects back to feature' do
+        expect(last_response.status).to be(302)
+        expect(last_response.headers['Location']).to eq('/features/sp%20ace')
+      end
+    end
+
     context 'with invalid value' do
       before do
         post 'features/search/percentage_of_actors',
@@ -43,7 +60,7 @@ RSpec.describe Flipper::UI::Actions::PercentageOfActorsGate do
 
       it 'redirects back to feature' do
         expect(last_response.status).to be(302)
-        expect(last_response.headers['Location']).to eq('/features/search?error=Invalid+percentage+of+actors+value%3A+value+must+be+a+positive+number+less+than+or+equal+to+100%2C+but+was+555')
+        expect(last_response.headers['Location']).to eq('/features/search?error=Invalid%20percentage%20of%20actors%20value:%20value%20must%20be%20a%20positive%20number%20less%20than%20or%20equal%20to%20100,%20but%20was%20555')
       end
     end
   end

--- a/spec/flipper/ui/actions/percentage_of_time_gate_spec.rb
+++ b/spec/flipper/ui/actions/percentage_of_time_gate_spec.rb
@@ -30,6 +30,23 @@ RSpec.describe Flipper::UI::Actions::PercentageOfTimeGate do
       end
     end
 
+    context 'with space in feature name' do
+      before do
+        post 'features/sp%20ace/percentage_of_time',
+             { 'value' => '24', 'authenticity_token' => token },
+             'rack.session' => session
+      end
+
+      it 'enables the feature' do
+        expect(flipper["sp ace"].percentage_of_time_value).to be(24)
+      end
+
+      it 'redirects back to feature' do
+        expect(last_response.status).to be(302)
+        expect(last_response.headers['Location']).to eq('/features/sp%20ace')
+      end
+    end
+
     context 'with invalid value' do
       before do
         post 'features/search/percentage_of_time',
@@ -43,7 +60,7 @@ RSpec.describe Flipper::UI::Actions::PercentageOfTimeGate do
 
       it 'redirects back to feature' do
         expect(last_response.status).to be(302)
-        expect(last_response.headers['Location']).to eq('/features/search?error=Invalid+percentage+of+time+value%3A+value+must+be+a+positive+number+less+than+or+equal+to+100%2C+but+was+555')
+        expect(last_response.headers['Location']).to eq('/features/search?error=Invalid%20percentage%20of%20time%20value:%20value%20must%20be%20a%20positive%20number%20less%20than%20or%20equal%20to%20100,%20but%20was%20555')
       end
     end
   end


### PR DESCRIPTION
Before it would cause browser errors when you enabled or disabled in any way.

Now it will work properly. I don't know if this is the best or right way but it works so I'm shipping it.

closes #496