### PR TITLE
Add a Content-Security-Policy

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -5,10 +5,10 @@ services:
   #   image: postgres:9.4
   redis:
     container_name: flipper_redis
-    image: redis:2.8
+    image: redis:6.2.5
   mongo:
     container_name: flipper_mongo
-    image: mongo:3.3
+    image: mongo:4.4.8
   memcached:
     container_name: flipper_memcached
     image: memcached:1.4.33

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,34 +1,37 @@
-# postgres:
-#   container_name: flipper_postgres
-#   image: postgres:9.4
-redis:
-  container_name: flipper_redis
-  image: redis:2.8
-mongo:
-  container_name: flipper_mongo
-  image: mongo:3.3
-memcached:
-  container_name: flipper_memcached
-  image: memcached:1.4.33
-app:
-  container_name: flipper_app
-  build: .
-  dockerfile: Dockerfile
-  volumes:
-    - .:/srv/app
-  volumes_from:
-    - bundle_cache
-  links:
-    # - postgres
-    - redis
-    - mongo
-    - memcached
-  environment:
-    - REDIS_URL=redis://redis:6379
-    - MONGODB_HOST=mongo
-    - MEMCACHED_URL=memcached:11211
-bundle_cache:
-  container_name: flipper_bundle_cache
-  image: busybox
-  volumes:
-    - /bundle_cache
+version: "2.4"
+services:
+  # postgres:
+  #   container_name: flipper_postgres
+  #   image: postgres:9.4
+  redis:
+    container_name: flipper_redis
+    image: redis:2.8
+  mongo:
+    container_name: flipper_mongo
+    image: mongo:3.3
+  memcached:
+    container_name: flipper_memcached
+    image: memcached:1.4.33
+  app:
+    container_name: flipper_app
+    build:
+      context: .
+      dockerfile: Dockerfile
+    volumes:
+      - .:/srv/app
+    volumes_from:
+      - bundle_cache
+    links:
+      # - postgres
+      - redis
+      - mongo
+      - memcached
+    environment:
+      - REDIS_URL=redis://redis:6379
+      - MONGODB_HOST=mongo
+      - MEMCACHED_URL=memcached:11211
+  bundle_cache:
+    container_name: flipper_bundle_cache
+    image: busybox
+    volumes:
+      - /bundle_cache

--- a/lib/flipper/ui/action.rb
+++ b/lib/flipper/ui/action.rb
@@ -26,6 +26,16 @@ module Flipper
                                              'delete'.freeze,
                                            ]).freeze
 
+      CONTENT_SECURITY_POLICY = <<-CSP.delete("\n")
+        default-src 'none';
+        img-src 'self';
+        font-src 'self';
+        script-src 'report-sample' 'self' https://cdnjs.cloudflare.com/ajax/libs/popper.js/1.12.9/umd/popper.min.js https://code.jquery.com/jquery-3.2.1.slim.min.js https://maxcdn.bootstrapcdn.com/bootstrap/4.0.0/js/bootstrap.min.js;
+        style-src 'self' 'unsafe-inline' https://maxcdn.bootstrapcdn.com;
+        style-src-attr 'unsafe-inline' ;
+        style-src-elem 'self' https://maxcdn.bootstrapcdn.com;
+      CSP
+
       # Public: Call this in subclasses so the action knows its route.
       #
       # regex - The Regexp that this action should run for.
@@ -130,6 +140,7 @@ module Flipper
       # Returns a response.
       def view_response(name)
         header 'Content-Type', 'text/html'
+        header 'Content-Security-Policy', CONTENT_SECURITY_POLICY
         body = view_with_layout { view_without_layout name }
         halt [@code, @headers, [body]]
       end

--- a/lib/flipper/ui/action.rb
+++ b/lib/flipper/ui/action.rb
@@ -26,14 +26,34 @@ module Flipper
                                              'delete'.freeze,
                                            ]).freeze
 
+      SOURCES = {
+        bootstrap_css: {
+          src: "https://maxcdn.bootstrapcdn.com/bootstrap/4.0.0/css/bootstrap.min.css".freeze,
+          hash: "sha384-Gn5384xqQ1aoWXA+058RXPxPg6fy4IWvTNh0E263XmFcJlSAwiGgFAW/dAiS6JXm".freeze
+        }.freeze,
+        jquery_js: {
+          src: "https://code.jquery.com/jquery-3.2.1.slim.min.js".freeze,
+          hash: "sha384-KJ3o2DKtIkvYIK3UENzmM7KCkRr/rE9/Qpg6aAZGJwFDMVNA/GpGFF93hXpG5KkN".freeze
+        }.freeze,
+        popper_js: {
+          src: "https://cdnjs.cloudflare.com/ajax/libs/popper.js/1.12.9/umd/popper.min.js".freeze,
+          hash: "sha384-ApNbgh9B+Y1QKtv3Rn7W3mgPxhU9K/ScQsAP7hUibX39j7fakFPskvXusvfa0b4Q".freeze
+        }.freeze,
+        bootstrap_js: {
+          src: "https://maxcdn.bootstrapcdn.com/bootstrap/4.0.0/js/bootstrap.min.js".freeze,
+          hash: "sha384-JZR6Spejh4U02d8jOt6vLEHfe/JQGiRRSQQxSfFWpi1MquVdAyjUar5+76PVCmYl".freeze
+        }.freeze
+      }.freeze
+      SCRIPT_SRCS = SOURCES.values_at(:jquery_js, :popper_js, :bootstrap_js).map { |s| s[:src] }
+      STYLE_SRCS = SOURCES.values_at(:bootstrap_css).map { |s| s[:src] }
       CONTENT_SECURITY_POLICY = <<-CSP.delete("\n")
         default-src 'none';
         img-src 'self';
         font-src 'self';
-        script-src 'report-sample' 'self' https://cdnjs.cloudflare.com/ajax/libs/popper.js/1.12.9/umd/popper.min.js https://code.jquery.com/jquery-3.2.1.slim.min.js https://maxcdn.bootstrapcdn.com/bootstrap/4.0.0/js/bootstrap.min.js;
-        style-src 'self' 'unsafe-inline' https://maxcdn.bootstrapcdn.com;
+        script-src 'report-sample' 'self' #{SCRIPT_SRCS.join(' ')};
+        style-src 'self' 'unsafe-inline' #{STYLE_SRCS.join(' ')};
         style-src-attr 'unsafe-inline' ;
-        style-src-elem 'self' https://maxcdn.bootstrapcdn.com;
+        style-src-elem 'self' #{STYLE_SRCS.join(' ')};
       CSP
 
       # Public: Call this in subclasses so the action knows its route.
@@ -247,6 +267,22 @@ module Flipper
 
       def valid_request_method?
         VALID_REQUEST_METHOD_NAMES.include?(request_method_name)
+      end
+
+      def bootstrap_css
+        SOURCES[:bootstrap_css]
+      end
+
+      def bootstrap_js
+        SOURCES[:bootstrap_js]
+      end
+
+      def popper_js
+        SOURCES[:popper_js]
+      end
+
+      def jquery_js
+        SOURCES[:jquery_js]
       end
     end
   end

--- a/lib/flipper/ui/views/layout.erb
+++ b/lib/flipper/ui/views/layout.erb
@@ -6,7 +6,7 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge">
     <meta name="viewport" content="width=device-width, initial-scale=1">
 
-    <link rel="stylesheet" href="https://maxcdn.bootstrapcdn.com/bootstrap/4.0.0/css/bootstrap.min.css" integrity="sha384-Gn5384xqQ1aoWXA+058RXPxPg6fy4IWvTNh0E263XmFcJlSAwiGgFAW/dAiS6JXm" crossorigin="anonymous">
+    <link rel="stylesheet" href="<%= bootstrap_css[:src] %>" integrity="<%= bootstrap_css[:hash] %>" crossorigin="anonymous">
     <link rel="stylesheet" href="<%= script_name %>/octicons/octicons.css">
     <link rel="stylesheet" href="<%= script_name %>/css/application.css">
   </head>
@@ -52,9 +52,9 @@
       <% end %>
     </div>
 
-    <script src="https://code.jquery.com/jquery-3.2.1.slim.min.js" integrity="sha384-KJ3o2DKtIkvYIK3UENzmM7KCkRr/rE9/Qpg6aAZGJwFDMVNA/GpGFF93hXpG5KkN" crossorigin="anonymous"></script>
-    <script src="https://cdnjs.cloudflare.com/ajax/libs/popper.js/1.12.9/umd/popper.min.js" integrity="sha384-ApNbgh9B+Y1QKtv3Rn7W3mgPxhU9K/ScQsAP7hUibX39j7fakFPskvXusvfa0b4Q" crossorigin="anonymous"></script>
-    <script src="https://maxcdn.bootstrapcdn.com/bootstrap/4.0.0/js/bootstrap.min.js" integrity="sha384-JZR6Spejh4U02d8jOt6vLEHfe/JQGiRRSQQxSfFWpi1MquVdAyjUar5+76PVCmYl" crossorigin="anonymous"></script>
+    <script src="<%= jquery_js[:src] %>" integrity="<%= jquery_js[:hash] %>" crossorigin="anonymous"></script>
+    <script src="<%= popper_js[:src] %>" integrity="<%= popper_js[:hash] %>" crossorigin="anonymous"></script>
+    <script src="<%= bootstrap_js[:src] %>" integrity="<%= bootstrap_js[:hash] %>" crossorigin="anonymous"></script>
     <script src="<%= script_name %>/js/application.js"></script>
   </body>
 </html>


### PR DESCRIPTION
Should fix #538.

Only the first commit (3686e8ae33ec47eac2b9e24f02c84ffd40e2dfff) is strictly necessary - the next one (6009d1534a63f5f9feba257f0672c16176d14fcb) tries to remove the duplicated source urls between the CSP & the layout template, but I don't know that the extra indirection is worth it - see what you think.

I was getting fun errors testing this in docker-compose on an M1 mac (eg Mongo failing with `runtime: failed to create new OS thread`) so updated that too.