### PR TITLE
Feature: Passing list of new actors

### DIFF
--- a/lib/flipper/ui/actions/actors_gate.rb
+++ b/lib/flipper/ui/actions/actors_gate.rb
@@ -26,12 +26,12 @@ module Flipper
           feature = flipper[feature_name]
           values = params['value'].to_s.strip.split(',').map(&:strip)
 
-          if Util.blank?(values)
-            error = "#{values.inspect} is not a valid actor value."
-            redirect_to("/features/#{feature.key}/actors?error=#{error}")
-          end
-
           values.each do |value|
+            if Util.blank?(value)
+              error = "#{value.inspect} is not a valid actor value."
+              return redirect_to("/features/#{feature.key}/actors?error=#{error}")
+            end
+
             actor = Flipper::Actor.new(value)
 
             case params['operation']

--- a/lib/flipper/ui/actions/actors_gate.rb
+++ b/lib/flipper/ui/actions/actors_gate.rb
@@ -24,20 +24,22 @@ module Flipper
 
         def post
           feature = flipper[feature_name]
-          value = params['value'].to_s.strip
+          values = params['value'].to_s.strip.split(',').map(&:strip)
 
-          if Util.blank?(value)
-            error = "#{value.inspect} is not a valid actor value."
+          if Util.blank?(values)
+            error = "#{values.inspect} is not a valid actor value."
             redirect_to("/features/#{feature.key}/actors?error=#{error}")
           end
 
-          actor = Flipper::Actor.new(value)
+          values.each do |value|
+            actor = Flipper::Actor.new(value)
 
-          case params['operation']
-          when 'enable'
-            feature.enable_actor actor
-          when 'disable'
-            feature.disable_actor actor
+            case params['operation']
+            when 'enable'
+              feature.enable_actor actor
+            when 'disable'
+              feature.disable_actor actor
+            end
           end
 
           redirect_to("/features/#{feature.key}")

--- a/lib/flipper/ui/actions/actors_gate.rb
+++ b/lib/flipper/ui/actions/actors_gate.rb
@@ -26,12 +26,12 @@ module Flipper
           feature = flipper[feature_name]
           values = params['value'].to_s.strip.split(',').map(&:strip)
 
-          values.each do |value|
-            if Util.blank?(value)
-              error = "#{value.inspect} is not a valid actor value."
-              return redirect_to("/features/#{feature.key}/actors?error=#{error}")
-            end
+          if Util.blank?(params['value'].to_s.strip)
+            error = "#{params['value'].to_s.strip.inspect} is not a valid actor value."
+            redirect_to("/features/#{feature.key}/actors?error=#{error}")
+          end
 
+          values.each do |value|
             actor = Flipper::Actor.new(value)
 
             case params['operation']

--- a/spec/flipper/ui/actions/actors_gate_spec.rb
+++ b/spec/flipper/ui/actions/actors_gate_spec.rb
@@ -45,6 +45,7 @@ RSpec.describe Flipper::UI::Actions::ActorsGate do
   describe 'POST /features/:feature/actors' do
     context 'enabling an actor' do
       let(:value) { 'User;6' }
+      let(:multi_value) { 'User;5, User;7, User;9, User;12' }
 
       before do
         post 'features/search/actors',
@@ -53,7 +54,18 @@ RSpec.describe Flipper::UI::Actions::ActorsGate do
       end
 
       it 'adds item to members' do
-        expect(flipper[:search].actors_value).to include('User;6')
+        expect(flipper[:search].actors_value).to include(value)
+      end
+
+      it 'adds item to multiple members' do
+        post 'features/search/actors',
+             { 'value' => multi_value, 'operation' => 'enable', 'authenticity_token' => token },
+             'rack.session' => session
+
+        expect(flipper[:search].actors_value).to include('User;5')
+        expect(flipper[:search].actors_value).to include('User;7')
+        expect(flipper[:search].actors_value).to include('User;9')
+        expect(flipper[:search].actors_value).to include('User;12')
       end
 
       it 'redirects back to feature' do
@@ -80,9 +92,21 @@ RSpec.describe Flipper::UI::Actions::ActorsGate do
 
       context 'value contains whitespace' do
         let(:value) { '  User;6  ' }
+        let(:multi_value) { '  User;5  ,  User;7   ,  User;9 ,  User;12 ' }
 
         it 'adds item without whitespace' do
           expect(flipper[:search].actors_value).to include('User;6')
+        end
+
+        it 'adds item to multi members without whitespace' do
+          post 'features/search/actors',
+             { 'value' => multi_value, 'operation' => 'enable', 'authenticity_token' => token },
+             'rack.session' => session
+
+          expect(flipper[:search].actors_value).to include('User;5')
+          expect(flipper[:search].actors_value).to include('User;7')
+          expect(flipper[:search].actors_value).to include('User;9')
+          expect(flipper[:search].actors_value).to include('User;12')
         end
       end
 
@@ -109,16 +133,29 @@ RSpec.describe Flipper::UI::Actions::ActorsGate do
 
     context 'disabling an actor' do
       let(:value) { 'User;6' }
+      let(:multi_value) { 'User;5, User;7, User;9, User;12' }
 
       before do
-        flipper[:search].enable_actor Flipper::Actor.new('User;6')
+        flipper[:search].enable_actor Flipper::Actor.new(value)
         post 'features/search/actors',
              { 'value' => value, 'operation' => 'disable', 'authenticity_token' => token },
              'rack.session' => session
       end
 
       it 'removes item from members' do
-        expect(flipper[:search].actors_value).not_to include('User;6')
+        expect(flipper[:search].actors_value).not_to include(value)
+      end
+
+      it 'removes item from multi members' do
+        multi_value.split(',').map(&:strip).each do |value|
+          flipper[:search].enable_actor Flipper::Actor.new(value)
+        end
+
+        post 'features/search/actors',
+             { 'value' => multi_value, 'operation' => 'disable', 'authenticity_token' => token },
+             'rack.session' => session
+
+        expect(flipper[:search].actors_value).not_to eq(Set.new(multi_value.split(',').map(&:strip)))
       end
 
       it 'redirects back to feature' do
@@ -128,9 +165,20 @@ RSpec.describe Flipper::UI::Actions::ActorsGate do
 
       context 'value contains whitespace' do
         let(:value) { '  User;6  ' }
+        let(:multi_value) { '  User;5  ,  User;7   ,  User;9 ,  User;12 ' }
 
         it 'removes item without whitespace' do
           expect(flipper[:search].actors_value).not_to include('User;6')
+        end
+
+        it 'removes item without whitespace' do
+          multi_value.split(',').map(&:strip).each do |value|
+            flipper[:search].enable_actor Flipper::Actor.new(value)
+          end
+          post 'features/search/actors',
+              { 'value' => multi_value, 'operation' => 'disable', 'authenticity_token' => token },
+              'rack.session' => session
+          expect(flipper[:search].actors_value).not_to eq(Set.new(multi_value.split(',').map(&:strip)))
         end
       end
     end


### PR DESCRIPTION
Ability to pass multiple actors in 1 request. 
Sometimes our product team asks us to turn on some feature for specific users. We just select them using SQL by some condition or our analytics/marketing provides this list of us. Right now nonprogramming guys or developers without prod access are forced to add each user separated. This PR could solve their pain when they need to handle a big list of users. 
