### PR TITLE
Fix remove button for groups

### DIFF
--- a/lib/flipper/ui/views/feature.erb
+++ b/lib/flipper/ui/views/feature.erb
@@ -130,8 +130,8 @@
                   <%== csrf_input_tag %>
                   <input type="hidden" name="operation" value="disable">
                   <input type="hidden" name="value" value="<%= item %>">
-                  <button type="submit" value="Disable" class="btn btn-link btn-sm text-danger" data-toggle="tooltip" title="Disable <%= item %>" data-placement="left">
-                    <span class="octicon octicon-trashcan"></span>
+                  <button type="submit" value="Disable" class="btn btn-outline-danger" data-toggle="tooltip" title="Disable <%= item %>" data-placement="left">
+                    Remove
                   </button>
                 </form>
               </div>


### PR DESCRIPTION
It seems that when the octicons were removed this was left over. The remove button isn't visible at the moment (it's clickable even if it's invisible)

![WhatsApp Image 2021-09-16 at 11 38 57](https://user-images.githubusercontent.com/3609616/133659771-788c6814-9052-4a99-8d26-301c6e7f4b3b.jpeg)
