### PR TITLE
Fix railtie initialization to avoid altering middleware order

### DIFF
--- a/lib/flipper/railtie.rb
+++ b/lib/flipper/railtie.rb
@@ -18,7 +18,7 @@ module Flipper
       end
     end
 
-    initializer "flipper.memoizer", after: :load_config_initializers do |app|
+    initializer "flipper.memoizer" do |app|
       config = app.config.flipper
 
       if config.memoize
@@ -30,7 +30,7 @@ module Flipper
       end
     end
 
-    initializer "flipper.log", after: :load_config_initializers do |app|
+    initializer "flipper.log" do |app|
       config = app.config.flipper
       if config.log && config.instrumenter == ActiveSupport::Notifications
         require "flipper/instrumentation/log_subscriber"


### PR DESCRIPTION
The railtie was using `after: : load_config_initializers` to ensure app initializers were run before mounting the middleware. As described in #562, this appears to cause the middleware stack to be initialized prematurely and changing the order of middleware. That option is not needed here and was only added to be explicit because we have another initializer that is `before: :load_config_initializers`. Looking closer at the [rails booting process](https://api.rubyonrails.org/classes/Rails/Application.html#class-Rails::Application-label-Booting+process), initializers from railties run after `config/initializers`.

Fixes #562