### PR TITLE
HTTP Client tweaks

### DIFF
--- a/lib/flipper/adapters/http/client.rb
+++ b/lib/flipper/adapters/http/client.rb
@@ -70,9 +70,19 @@ module Flipper
         end
 
         def build_request(http_method, uri, headers, options)
+          request_headers = {
+            "Client-Language" => "ruby",
+            "Client-Language-Version" => "#{RUBY_VERSION} p#{RUBY_PATCHLEVEL} (#{RUBY_RELEASE_DATE})",
+            "Client-Platform" => RUBY_PLATFORM,
+            "Client-Engine" => defined?(RUBY_ENGINE) ? RUBY_ENGINE : "",
+            "Client-Pid" => Process.pid.to_s,
+            "Client-Thread" => Thread.current.object_id.to_s,
+            "Client-Hostname" => Socket.gethostname,
+          }.merge(headers)
+
           body = options[:body]
           request = http_method.new(uri.request_uri)
-          request.initialize_http_header(headers) if headers
+          request.initialize_http_header(request_headers)
           request.body = body if body
 
           if @basic_auth_username && @basic_auth_password

--- a/lib/flipper/cloud/configuration.rb
+++ b/lib/flipper/cloud/configuration.rb
@@ -151,15 +151,11 @@ module Flipper
           debug_output: @debug_output,
           headers: {
             "Flipper-Cloud-Token" => @token,
-            "Feature-Flipper-Token" => @token,
-            "Client-Lang" => "ruby",
-            "Client-Lang-Version" => "#{RUBY_VERSION} p#{RUBY_PATCHLEVEL} (#{RUBY_RELEASE_DATE})",
-            "Client-Platform" => RUBY_PLATFORM,
-            "Client-Engine" => defined?(RUBY_ENGINE) ? RUBY_ENGINE : "",
-            "Client-Hostname" => Socket.gethostname,
           },
         })
       end
     end
   end
 end
+
+# "FLIPPER_TIMESTAMP".freeze => Flipper::Timestamp.generate.to_s,

--- a/spec/flipper/cloud_spec.rb
+++ b/spec/flipper/cloud_spec.rb
@@ -117,10 +117,7 @@ RSpec.describe Flipper::Cloud do
 
   it 'can import' do
     stub_request(:post, /www\.flippercloud\.io\/adapter\/features.*/).
-      with(headers: {
-          'Feature-Flipper-Token'=>'asdf',
-          'Flipper-Cloud-Token'=>'asdf',
-      }).to_return(status: 200, body: "{}", headers: {})
+      with(headers: {'Flipper-Cloud-Token'=>'asdf'}).to_return(status: 200, body: "{}", headers: {})
 
     flipper = Flipper.new(Flipper::Adapters::Memory.new)
 
@@ -146,10 +143,7 @@ RSpec.describe Flipper::Cloud do
 
   it 'raises error for failure while importing' do
     stub_request(:post, /www\.flippercloud\.io\/adapter\/features.*/).
-      with(headers: {
-          'Feature-Flipper-Token'=>'asdf',
-          'Flipper-Cloud-Token'=>'asdf',
-      }).to_return(status: 500, body: "{}")
+      with(headers: {'Flipper-Cloud-Token'=>'asdf'}).to_return(status: 500, body: "{}")
 
     flipper = Flipper.new(Flipper::Adapters::Memory.new)
 
@@ -174,10 +168,7 @@ RSpec.describe Flipper::Cloud do
 
   it 'raises error for timeout while importing' do
     stub_request(:post, /www\.flippercloud\.io\/adapter\/features.*/).
-      with(headers: {
-          'Feature-Flipper-Token'=>'asdf',
-          'Flipper-Cloud-Token'=>'asdf',
-      }).to_timeout
+      with(headers: {'Flipper-Cloud-Token'=>'asdf'}).to_timeout
 
     flipper = Flipper.new(Flipper::Adapters::Memory.new)
 


### PR DESCRIPTION
Moves more default headers from cloud to client. Also removes feature flipper token from cloud since its deprecated anyway.