### PR TITLE
feat: allow HTML in banner and feature descriptions

### DIFF
--- a/flipper-ui.gemspec
+++ b/flipper-ui.gemspec
@@ -24,4 +24,5 @@ Gem::Specification.new do |gem|
   gem.add_dependency 'rack-protection', '>= 1.5.3', '< 2.2.0'
   gem.add_dependency 'flipper', "~> #{Flipper::VERSION}"
   gem.add_dependency 'erubi', '>= 1.0.0', '< 2.0.0'
+  gem.add_dependency 'sanitize', '< 7'
 end

--- a/lib/flipper/ui/action.rb
+++ b/lib/flipper/ui/action.rb
@@ -3,6 +3,7 @@ require 'flipper/ui/configuration'
 require 'flipper/ui/error'
 require 'erubi'
 require 'json'
+require 'sanitize'
 
 module Flipper
   module UI

--- a/lib/flipper/ui/views/feature.erb
+++ b/lib/flipper/ui/views/feature.erb
@@ -9,7 +9,7 @@
     <div class="col">
       <div class="card">
         <div class="card-body">
-          <%== @feature.description %>
+          <%== Sanitize.fragment(@feature.description, Sanitize::Config::BASIC) %>
         </div>
       </div>
     </div>

--- a/lib/flipper/ui/views/feature.erb
+++ b/lib/flipper/ui/views/feature.erb
@@ -9,7 +9,7 @@
     <div class="col">
       <div class="card">
         <div class="card-body">
-          <%= @feature.description %>
+          <%== @feature.description %>
         </div>
       </div>
     </div>

--- a/lib/flipper/ui/views/features.erb
+++ b/lib/flipper/ui/views/features.erb
@@ -47,7 +47,7 @@
               <div class="text-truncate" style="font-weight: 500"><%= feature.key %></div>
               <% if Flipper::UI.configuration.show_feature_description_in_list? && Flipper::UI::Util.present?(feature.description) %>
                 <div class="text-muted font-weight-light" style="line-height: 1.4; white-space: initial; padding: 8px 0">
-                  <%= feature.description %>
+                  <%== feature.description %>
                 </div>
               <% end %>
               <div class="text-muted text-truncate">

--- a/lib/flipper/ui/views/features.erb
+++ b/lib/flipper/ui/views/features.erb
@@ -47,7 +47,7 @@
               <div class="text-truncate" style="font-weight: 500"><%= feature.key %></div>
               <% if Flipper::UI.configuration.show_feature_description_in_list? && Flipper::UI::Util.present?(feature.description) %>
                 <div class="text-muted font-weight-light" style="line-height: 1.4; white-space: initial; padding: 8px 0">
-                  <%== feature.description %>
+                  <%== Sanitize.fragment(feature.description, Sanitize::Config::BASIC) %>
                 </div>
               <% end %>
               <div class="text-muted text-truncate">

--- a/lib/flipper/ui/views/layout.erb
+++ b/lib/flipper/ui/views/layout.erb
@@ -13,7 +13,7 @@
     <div class="container mw-600">
       <%- unless Flipper::UI.configuration.banner_text.nil? -%>
         <div class="alert alert-<%= Flipper::UI.configuration.banner_class %> text-center font-weight-bold">
-          <%== Flipper::UI.configuration.banner_text %>
+          <%== Sanitize.fragment(Flipper::UI.configuration.banner_text, Sanitize::Config::BASIC) %>
         </div>
       <%- end -%>
 

--- a/lib/flipper/ui/views/layout.erb
+++ b/lib/flipper/ui/views/layout.erb
@@ -13,7 +13,7 @@
     <div class="container mw-600">
       <%- unless Flipper::UI.configuration.banner_text.nil? -%>
         <div class="alert alert-<%= Flipper::UI.configuration.banner_class %> text-center font-weight-bold">
-          <%= Flipper::UI.configuration.banner_text %>
+          <%== Flipper::UI.configuration.banner_text %>
         </div>
       <%- end -%>
 


### PR DESCRIPTION
Hi!

I was looking for a way to format the banner / descriptions a little bit more, but it's a bit tricky since Flipper UI is Rack middleware. Would you be open to something like this where HTML is allowed to render in the ERBs?

There _shouldn't_ be any user-inputted text here since this would all come from config values, but also happy to make it an option (possibly that just changes the `escape` option passed to Erubi) if that's preferred.

Thanks!