### PR TITLE
Avoid running examples if secrets not available

### DIFF
--- a/.github/workflows/examples.yml
+++ b/.github/workflows/examples.yml
@@ -2,7 +2,7 @@ name: Examples
 on: [push, pull_request]
 jobs:
   test:
-    if: secrets.FLIPPER_CLOUD_TOKEN
+    if: github.repository_owner == 'jnunemaker'
     name: Test on ruby ${{ matrix.ruby }} and rails ${{ matrix.rails }}
     runs-on: ubuntu-latest
     services:

--- a/.github/workflows/examples.yml
+++ b/.github/workflows/examples.yml
@@ -2,6 +2,7 @@ name: Examples
 on: [push, pull_request]
 jobs:
   test:
+    if: secrets.FLIPPER_CLOUD_TOKEN
     name: Test on ruby ${{ matrix.ruby }} and rails ${{ matrix.rails }}
     runs-on: ubuntu-latest
     services:


### PR DESCRIPTION
All PRs from external contributors currently have failing tests due to FLIPPER_CLOUD_TOKEN not being available. This skips the examples if secrets are not available.

Most externals contributions don't impact examples. If we do get a major contribution, we can just run the examples manually.