### PR TITLE
pstore thread_safe fix

### DIFF
--- a/lib/flipper/adapters/pstore.rb
+++ b/lib/flipper/adapters/pstore.rb
@@ -22,9 +22,10 @@ module Flipper
 
       # Public
       def initialize(path = 'flipper.pstore', thread_safe = false)
+        @name = :pstore
         @path = path
         @store = ::PStore.new(path, thread_safe)
-        @name = :pstore
+        @thread_safe = thread_safe
       end
 
       # Public: The set of known features.

--- a/spec/flipper/adapters/pstore_spec.rb
+++ b/spec/flipper/adapters/pstore_spec.rb
@@ -15,4 +15,15 @@ RSpec.describe Flipper::Adapters::PStore do
   it 'defaults path to flipper.pstore' do
     expect(described_class.new.path).to eq('flipper.pstore')
   end
+
+  describe '.thread_safe' do
+    it 'defaults to false' do
+      expect(subject.thread_safe).to be false
+    end
+
+    it 'can be set to true' do
+      store = described_class.new(subject.path, true)
+      expect(store.thread_safe).to be true
+    end
+  end
 end


### PR DESCRIPTION
not sure the thread_safe attribute is working.  should we save the value, extract it out of @store via `.instance_variable_get`, or delete the accessor since it may not be needed?  (I also sorted the variables to keep things tidy)