### PR TITLE
synchronizer now

### DIFF
--- a/lib/flipper/adapters/sync/interval_synchronizer.rb
+++ b/lib/flipper/adapters/sync/interval_synchronizer.rb
@@ -7,11 +7,6 @@ module Flipper
         # Private: Number of seconds between syncs (default: 10).
         DEFAULT_INTERVAL = 10
 
-        # Private
-        def self.now
-          Process.clock_gettime(Process::CLOCK_MONOTONIC, :second)
-        end
-
         # Public: The Float or Integer number of seconds between invocations of
         # the wrapped synchronizer.
         attr_reader :interval
@@ -46,7 +41,7 @@ module Flipper
         end
 
         def now
-          self.class.now
+          Process.clock_gettime(Process::CLOCK_MONOTONIC, :second)
         end
       end
     end

--- a/spec/flipper/adapters/sync/interval_synchronizer_spec.rb
+++ b/spec/flipper/adapters/sync/interval_synchronizer_spec.rb
@@ -3,8 +3,9 @@ require "flipper/adapters/sync/interval_synchronizer"
 
 RSpec.describe Flipper::Adapters::Sync::IntervalSynchronizer do
   let(:events) { [] }
-  let(:synchronizer) { -> { events << described_class.now } }
+  let(:synchronizer) { -> { events << now } }
   let(:interval) { 10 }
+  let(:now) { subject.send(:now) }
 
   subject { described_class.new(synchronizer, interval: interval) }
 
@@ -15,19 +16,18 @@ RSpec.describe Flipper::Adapters::Sync::IntervalSynchronizer do
   end
 
   it "only invokes wrapped synchronizer every interval seconds" do
-    now = described_class.now
     subject.call
     events.clear
 
     # move time to one millisecond less than last sync + interval
     1.upto(interval) do |i|
-      allow(described_class).to receive(:now).and_return(now + i - 1)
+      allow(subject).to receive(:now).and_return(now + i - 1)
       subject.call
     end
     expect(events.size).to be(0)
 
     # move time to last sync + interval in milliseconds
-    allow(described_class).to receive(:now).and_return(now + interval)
+    allow(subject).to receive(:now).and_return(now + interval)
     subject.call
     expect(events.size).to be(1)
   end


### PR DESCRIPTION
it seems like `Synchronizer.now` is only needed for testing.  can we de-duplicate this with the instance method?