### PR TITLE
noop spec cleanup

### DIFF
--- a/spec/flipper/instrumenters/noop_spec.rb
+++ b/spec/flipper/instrumenters/noop_spec.rb
@@ -4,17 +4,25 @@ RSpec.describe Flipper::Instrumenters::Noop do
   describe '.instrument' do
     context 'with name' do
       it 'yields block' do
-        yielded = false
-        described_class.instrument(:foo) { yielded = true }
-        expect(yielded).to eq(true)
+        expect { |block|
+          described_class.instrument(:foo, &block)
+        }.to yield_control
       end
     end
 
     context 'with name and payload' do
+      let(:payload) { { pay: :load } }
+
       it 'yields block' do
-        yielded = false
-        described_class.instrument(:foo, pay: :load) { yielded = true }
-        expect(yielded).to eq(true)
+        expect { |block|
+          described_class.instrument(:foo, payload, &block)
+        }.to yield_control
+      end
+
+      it 'yields the payload' do
+        described_class.instrument(:foo, payload) do |block_payload|
+          expect(block_payload).to eq payload
+        end
       end
     end
   end


### PR DESCRIPTION
use rspec's `expect {}.to yield_control` syntax to ensure block is being called

https://relishapp.com/rspec/rspec-expectations/docs/built-in-matchers/yield-matchers