### PR TITLE
memory instrumenter

### DIFF
--- a/lib/flipper/instrumenters/memory.rb
+++ b/lib/flipper/instrumenters/memory.rb
@@ -17,9 +17,13 @@ module Flipper
         # block rather than the one passed to #instrument.
         payload = payload.dup
 
-        result = (yield payload if block_given?)
+        result = yield payload if block_given?
+      rescue Exception => e
+        payload[:exception] = [e.class.name, e.message]
+        payload[:exception_object] = e
+        raise e
+      ensure
         @events << Event.new(name, payload, result)
-        result
       end
 
       def events_by_name(name)

--- a/spec/flipper/instrumenters/memory_spec.rb
+++ b/spec/flipper/instrumenters/memory_spec.rb
@@ -22,5 +22,23 @@ RSpec.describe Flipper::Instrumenters::Memory do
       event = described_class::Event.new(name, payload, block_result)
       expect(instrumenter.events).to eq([event])
     end
+
+    context 'when an error is raised' do
+      subject do
+        instrumenter.instrument(:name) { raise IOError }
+      end
+
+      let(:instrumenter) { described_class.new }
+
+      it 'captures and propagates the error' do
+        expect { subject }.to raise_error(IOError)
+
+        expect(instrumenter.events.count).to be 1
+
+        payload = instrumenter.events[0].payload
+        expect(payload.keys).to include(:exception, :exception_object)
+        expect(payload[:exception_object]).to be_a IOError
+      end
+    end
   end
 end


### PR DESCRIPTION
upgrade memory instrumentor to capture exceptions raised, similar to `ActiveSupport::Notifications`: https://github.com/rails/rails/blob/83217025a171593547d1268651b446d3533e2019/activesupport/lib/active_support/notifications/instrumenter.rb#L25