### PR TITLE
spec cleanup

### DIFF
--- a/.rspec
+++ b/.rspec
@@ -1,0 +1,1 @@
+--require spec_helper

--- a/spec/flipper/actor_spec.rb
+++ b/spec/flipper/actor_spec.rb
@@ -1,5 +1,3 @@
-require 'helper'
-
 RSpec.describe Flipper::Actor do
   it 'initializes with and knows flipper_id' do
     actor = described_class.new("User;235")

--- a/spec/flipper/adapter_spec.rb
+++ b/spec/flipper/adapter_spec.rb
@@ -1,5 +1,3 @@
-require 'helper'
-
 RSpec.describe Flipper::Adapter do
   let(:source_flipper) { build_flipper }
   let(:destination_flipper) { build_flipper }

--- a/spec/flipper/adapters/active_record_spec.rb
+++ b/spec/flipper/adapters/active_record_spec.rb
@@ -1,6 +1,4 @@
-require 'helper'
 require 'flipper/adapters/active_record'
-require 'flipper/spec/shared_adapter_specs'
 
 # Turn off migration logging for specs
 ActiveRecord::Migration.verbose = false

--- a/spec/flipper/adapters/active_support_cache_store_spec.rb
+++ b/spec/flipper/adapters/active_support_cache_store_spec.rb
@@ -1,9 +1,7 @@
-require 'helper'
 require 'active_support/cache'
 require 'active_support/cache/dalli_store'
 require 'flipper/adapters/operation_logger'
 require 'flipper/adapters/active_support_cache_store'
-require 'flipper/spec/shared_adapter_specs'
 
 RSpec.describe Flipper::Adapters::ActiveSupportCacheStore do
   let(:memory_adapter) do

--- a/spec/flipper/adapters/dalli_spec.rb
+++ b/spec/flipper/adapters/dalli_spec.rb
@@ -1,7 +1,5 @@
-require 'helper'
 require 'flipper/adapters/operation_logger'
 require 'flipper/adapters/dalli'
-require 'flipper/spec/shared_adapter_specs'
 require 'logger'
 
 RSpec.describe Flipper::Adapters::Dalli do

--- a/spec/flipper/adapters/dual_write_spec.rb
+++ b/spec/flipper/adapters/dual_write_spec.rb
@@ -1,7 +1,5 @@
-require 'helper'
 require 'flipper/adapters/dual_write'
 require 'flipper/adapters/operation_logger'
-require 'flipper/spec/shared_adapter_specs'
 require 'active_support/notifications'
 
 RSpec.describe Flipper::Adapters::DualWrite do

--- a/spec/flipper/adapters/http_spec.rb
+++ b/spec/flipper/adapters/http_spec.rb
@@ -1,7 +1,5 @@
-require 'helper'
 require 'flipper/adapters/http'
 require 'flipper/adapters/pstore'
-require 'flipper/spec/shared_adapter_specs'
 require 'rack/handler/webrick'
 
 FLIPPER_SPEC_API_PORT = ENV.fetch('FLIPPER_SPEC_API_PORT', 9001).to_i

--- a/spec/flipper/adapters/instrumented_spec.rb
+++ b/spec/flipper/adapters/instrumented_spec.rb
@@ -1,7 +1,5 @@
-require 'helper'
 require 'flipper/adapters/instrumented'
 require 'flipper/instrumenters/memory'
-require 'flipper/spec/shared_adapter_specs'
 
 RSpec.describe Flipper::Adapters::Instrumented do
   let(:instrumenter) { Flipper::Instrumenters::Memory.new }

--- a/spec/flipper/adapters/memoizable_spec.rb
+++ b/spec/flipper/adapters/memoizable_spec.rb
@@ -1,7 +1,5 @@
-require 'helper'
 require 'flipper/adapters/memoizable'
 require 'flipper/adapters/operation_logger'
-require 'flipper/spec/shared_adapter_specs'
 
 RSpec.describe Flipper::Adapters::Memoizable do
   let(:features_key) { described_class::FeaturesKey }

--- a/spec/flipper/adapters/memory_spec.rb
+++ b/spec/flipper/adapters/memory_spec.rb
@@ -1,6 +1,3 @@
-require 'helper'
-require 'flipper/spec/shared_adapter_specs'
-
 RSpec.describe Flipper::Adapters::Memory do
   let(:source) { {} }
   subject { described_class.new(source) }

--- a/spec/flipper/adapters/moneta_spec.rb
+++ b/spec/flipper/adapters/moneta_spec.rb
@@ -1,6 +1,4 @@
-require 'helper'
 require 'flipper/adapters/moneta'
-require 'flipper/spec/shared_adapter_specs'
 
 RSpec.describe Flipper::Adapters::Moneta do
   let(:moneta) { Moneta.new(:Memory) }

--- a/spec/flipper/adapters/mongo_spec.rb
+++ b/spec/flipper/adapters/mongo_spec.rb
@@ -1,6 +1,4 @@
-require 'helper'
 require 'flipper/adapters/mongo'
-require 'flipper/spec/shared_adapter_specs'
 
 Mongo::Logger.logger.level = Logger::INFO
 

--- a/spec/flipper/adapters/operation_logger_spec.rb
+++ b/spec/flipper/adapters/operation_logger_spec.rb
@@ -1,6 +1,4 @@
-require 'helper'
 require 'flipper/adapters/operation_logger'
-require 'flipper/spec/shared_adapter_specs'
 
 RSpec.describe Flipper::Adapters::OperationLogger do
   let(:operations) { [] }

--- a/spec/flipper/adapters/pstore_spec.rb
+++ b/spec/flipper/adapters/pstore_spec.rb
@@ -1,6 +1,4 @@
-require 'helper'
 require 'flipper/adapters/pstore'
-require 'flipper/spec/shared_adapter_specs'
 
 RSpec.describe Flipper::Adapters::PStore do
   subject do

--- a/spec/flipper/adapters/read_only_spec.rb
+++ b/spec/flipper/adapters/read_only_spec.rb
@@ -1,4 +1,3 @@
-require 'helper'
 require 'flipper/adapters/read_only'
 
 RSpec.describe Flipper::Adapters::ReadOnly do

--- a/spec/flipper/adapters/redis_cache_spec.rb
+++ b/spec/flipper/adapters/redis_cache_spec.rb
@@ -1,7 +1,5 @@
-require 'helper'
 require 'flipper/adapters/operation_logger'
 require 'flipper/adapters/redis_cache'
-require 'flipper/spec/shared_adapter_specs'
 
 RSpec.describe Flipper::Adapters::RedisCache do
   let(:client) do

--- a/spec/flipper/adapters/redis_spec.rb
+++ b/spec/flipper/adapters/redis_spec.rb
@@ -1,6 +1,4 @@
-require 'helper'
 require 'flipper/adapters/redis'
-require 'flipper/spec/shared_adapter_specs'
 
 RSpec.describe Flipper::Adapters::Redis do
   let(:client) do

--- a/spec/flipper/adapters/rollout_spec.rb
+++ b/spec/flipper/adapters/rollout_spec.rb
@@ -1,8 +1,6 @@
-require 'helper'
 require 'redis'
 require 'rollout'
 require 'flipper/adapters/rollout'
-require 'flipper/spec/shared_adapter_specs'
 
 RSpec.describe Flipper::Adapters::Rollout do
   let(:redis) { Redis.new }

--- a/spec/flipper/adapters/sequel_spec.rb
+++ b/spec/flipper/adapters/sequel_spec.rb
@@ -1,4 +1,3 @@
-require 'helper'
 require 'sequel'
 
 Sequel::Model.db = Sequel.sqlite(':memory:')
@@ -6,7 +5,6 @@ Sequel.extension :migration, :core_extensions
 
 require 'flipper/adapters/sequel'
 require 'generators/flipper/templates/sequel_migration'
-require 'flipper/spec/shared_adapter_specs'
 
 RSpec.describe Flipper::Adapters::Sequel do
   subject do

--- a/spec/flipper/adapters/sync/feature_synchronizer_spec.rb
+++ b/spec/flipper/adapters/sync/feature_synchronizer_spec.rb
@@ -1,4 +1,3 @@
-require "helper"
 require "flipper/adapters/memory"
 require "flipper/adapters/operation_logger"
 require "flipper/adapters/sync/feature_synchronizer"

--- a/spec/flipper/adapters/sync/interval_synchronizer_spec.rb
+++ b/spec/flipper/adapters/sync/interval_synchronizer_spec.rb
@@ -1,4 +1,3 @@
-require "helper"
 require "flipper/adapters/sync/interval_synchronizer"
 
 RSpec.describe Flipper::Adapters::Sync::IntervalSynchronizer do

--- a/spec/flipper/adapters/sync/synchronizer_spec.rb
+++ b/spec/flipper/adapters/sync/synchronizer_spec.rb
@@ -1,4 +1,3 @@
-require "helper"
 require "flipper/adapters/memory"
 require "flipper/instrumenters/memory"
 require "flipper/adapters/sync/synchronizer"

--- a/spec/flipper/adapters/sync_spec.rb
+++ b/spec/flipper/adapters/sync_spec.rb
@@ -1,7 +1,5 @@
-require 'helper'
 require 'flipper/adapters/sync'
 require 'flipper/adapters/operation_logger'
-require 'flipper/spec/shared_adapter_specs'
 require 'active_support/notifications'
 
 RSpec.describe Flipper::Adapters::Sync do

--- a/spec/flipper/api/action_spec.rb
+++ b/spec/flipper/api/action_spec.rb
@@ -1,5 +1,3 @@
-require 'helper'
-
 RSpec.describe Flipper::Api::Action do
   let(:action_subclass) do
     Class.new(described_class) do

--- a/spec/flipper/api/json_params_spec.rb
+++ b/spec/flipper/api/json_params_spec.rb
@@ -1,5 +1,3 @@
-require 'helper'
-
 RSpec.describe Flipper::Api::JsonParams do
   let(:app) do
     app = lambda do |env|

--- a/spec/flipper/api/v1/actions/actors_gate_spec.rb
+++ b/spec/flipper/api/v1/actions/actors_gate_spec.rb
@@ -1,5 +1,3 @@
-require 'helper'
-
 RSpec.describe Flipper::Api::V1::Actions::ActorsGate do
   let(:app) { build_api(flipper) }
   let(:actor) { Flipper::Actor.new('1') }

--- a/spec/flipper/api/v1/actions/actors_spec.rb
+++ b/spec/flipper/api/v1/actions/actors_spec.rb
@@ -1,5 +1,3 @@
-require 'helper'
-
 RSpec.describe Flipper::Api::V1::Actions::Actors do
   let(:app) { build_api(flipper) }
   let(:actor) { Flipper::Actor.new('User123') }

--- a/spec/flipper/api/v1/actions/boolean_gate_spec.rb
+++ b/spec/flipper/api/v1/actions/boolean_gate_spec.rb
@@ -1,5 +1,3 @@
-require 'helper'
-
 RSpec.describe Flipper::Api::V1::Actions::BooleanGate do
   let(:app) { build_api(flipper) }
 

--- a/spec/flipper/api/v1/actions/clear_feature_spec.rb
+++ b/spec/flipper/api/v1/actions/clear_feature_spec.rb
@@ -1,5 +1,3 @@
-require 'helper'
-
 RSpec.describe Flipper::Api::V1::Actions::ClearFeature do
   let(:app) { build_api(flipper) }
 

--- a/spec/flipper/api/v1/actions/feature_spec.rb
+++ b/spec/flipper/api/v1/actions/feature_spec.rb
@@ -1,5 +1,3 @@
-require 'helper'
-
 RSpec.describe Flipper::Api::V1::Actions::Feature do
   let(:app) { build_api(flipper) }
   let(:feature) { build_feature }

--- a/spec/flipper/api/v1/actions/features_spec.rb
+++ b/spec/flipper/api/v1/actions/features_spec.rb
@@ -1,5 +1,3 @@
-require 'helper'
-
 RSpec.describe Flipper::Api::V1::Actions::Features do
   let(:app) { build_api(flipper) }
   let(:feature) { build_feature }

--- a/spec/flipper/api/v1/actions/groups_gate_spec.rb
+++ b/spec/flipper/api/v1/actions/groups_gate_spec.rb
@@ -1,5 +1,3 @@
-require 'helper'
-
 RSpec.describe Flipper::Api::V1::Actions::GroupsGate do
   let(:app) { build_api(flipper) }
 

--- a/spec/flipper/api/v1/actions/percentage_of_actors_gate_spec.rb
+++ b/spec/flipper/api/v1/actions/percentage_of_actors_gate_spec.rb
@@ -1,5 +1,3 @@
-require 'helper'
-
 RSpec.describe Flipper::Api::V1::Actions::PercentageOfActorsGate do
   let(:app) { build_api(flipper) }
 

--- a/spec/flipper/api/v1/actions/percentage_of_time_gate_spec.rb
+++ b/spec/flipper/api/v1/actions/percentage_of_time_gate_spec.rb
@@ -1,5 +1,3 @@
-require 'helper'
-
 RSpec.describe Flipper::Api::V1::Actions::PercentageOfTimeGate do
   let(:app) { build_api(flipper) }
 

--- a/spec/flipper/api_spec.rb
+++ b/spec/flipper/api_spec.rb
@@ -1,5 +1,3 @@
-require 'helper'
-
 RSpec.describe Flipper::Api do
   describe 'Initializing middleware with flipper instance' do
     let(:app) { build_api(flipper) }

--- a/spec/flipper/cloud/configuration_spec.rb
+++ b/spec/flipper/cloud/configuration_spec.rb
@@ -1,4 +1,3 @@
-require 'helper'
 require 'flipper/cloud/configuration'
 require 'flipper/adapters/instrumented'
 

--- a/spec/flipper/cloud/dsl_spec.rb
+++ b/spec/flipper/cloud/dsl_spec.rb
@@ -1,4 +1,3 @@
-require 'helper'
 require 'flipper/cloud/configuration'
 require 'flipper/cloud/dsl'
 require 'flipper/adapters/operation_logger'

--- a/spec/flipper/cloud/engine_spec.rb
+++ b/spec/flipper/cloud/engine_spec.rb
@@ -1,4 +1,3 @@
-require 'helper'
 require 'rails'
 require 'flipper/cloud'
 

--- a/spec/flipper/cloud/message_verifier_spec.rb
+++ b/spec/flipper/cloud/message_verifier_spec.rb
@@ -1,4 +1,3 @@
-require 'helper'
 require 'flipper/cloud/message_verifier'
 
 RSpec.describe Flipper::Cloud::MessageVerifier do

--- a/spec/flipper/cloud/middleware_spec.rb
+++ b/spec/flipper/cloud/middleware_spec.rb
@@ -1,5 +1,4 @@
 require 'securerandom'
-require 'helper'
 require 'flipper/cloud'
 require 'flipper/cloud/middleware'
 require 'flipper/adapters/operation_logger'

--- a/spec/flipper/cloud_spec.rb
+++ b/spec/flipper/cloud_spec.rb
@@ -1,4 +1,3 @@
-require 'helper'
 require 'flipper/cloud'
 require 'flipper/adapters/instrumented'
 require 'flipper/instrumenters/memory'

--- a/spec/flipper/configuration_spec.rb
+++ b/spec/flipper/configuration_spec.rb
@@ -1,4 +1,3 @@
-require 'helper'
 require 'flipper/configuration'
 
 RSpec.describe Flipper::Configuration do

--- a/spec/flipper/dsl_spec.rb
+++ b/spec/flipper/dsl_spec.rb
@@ -1,4 +1,3 @@
-require 'helper'
 require 'flipper/dsl'
 
 RSpec.describe Flipper::DSL do

--- a/spec/flipper/feature_check_context_spec.rb
+++ b/spec/flipper/feature_check_context_spec.rb
@@ -1,5 +1,3 @@
-require 'helper'
-
 RSpec.describe Flipper::FeatureCheckContext do
   let(:feature_name) { :new_profiles }
   let(:values) { Flipper::GateValues.new({}) }

--- a/spec/flipper/feature_spec.rb
+++ b/spec/flipper/feature_spec.rb
@@ -1,4 +1,3 @@
-require 'helper'
 require 'flipper/feature'
 require 'flipper/instrumenters/memory'
 

--- a/spec/flipper/gate_spec.rb
+++ b/spec/flipper/gate_spec.rb
@@ -1,5 +1,3 @@
-require 'helper'
-
 RSpec.describe Flipper::Gate do
   let(:feature_name) { :stats }
 

--- a/spec/flipper/gate_values_spec.rb
+++ b/spec/flipper/gate_values_spec.rb
@@ -1,4 +1,3 @@
-require 'helper'
 require 'flipper/gate_values'
 
 RSpec.describe Flipper::GateValues do

--- a/spec/flipper/gates/actor_spec.rb
+++ b/spec/flipper/gates/actor_spec.rb
@@ -1,5 +1,3 @@
-require 'helper'
-
 RSpec.describe Flipper::Gates::Actor do
   let(:feature_name) { :search }
 

--- a/spec/flipper/gates/boolean_spec.rb
+++ b/spec/flipper/gates/boolean_spec.rb
@@ -1,5 +1,3 @@
-require 'helper'
-
 RSpec.describe Flipper::Gates::Boolean do
   let(:feature_name) { :search }
 

--- a/spec/flipper/gates/group_spec.rb
+++ b/spec/flipper/gates/group_spec.rb
@@ -1,5 +1,3 @@
-require 'helper'
-
 RSpec.describe Flipper::Gates::Group do
   let(:feature_name) { :search }
 

--- a/spec/flipper/gates/percentage_of_actors_spec.rb
+++ b/spec/flipper/gates/percentage_of_actors_spec.rb
@@ -1,5 +1,3 @@
-require 'helper'
-
 RSpec.describe Flipper::Gates::PercentageOfActors do
   let(:feature_name) { :search }
 

--- a/spec/flipper/gates/percentage_of_time_spec.rb
+++ b/spec/flipper/gates/percentage_of_time_spec.rb
@@ -1,5 +1,3 @@
-require 'helper'
-
 RSpec.describe Flipper::Gates::PercentageOfTime do
   let(:feature_name) { :search }
 

--- a/spec/flipper/identifier_spec.rb
+++ b/spec/flipper/identifier_spec.rb
@@ -1,4 +1,3 @@
-require 'helper'
 require 'flipper/identifier'
 
 RSpec.describe Flipper::Identifier do

--- a/spec/flipper/instrumentation/log_subscriber_spec.rb
+++ b/spec/flipper/instrumentation/log_subscriber_spec.rb
@@ -1,5 +1,4 @@
 require 'logger'
-require 'helper'
 require 'flipper/adapters/instrumented'
 require 'flipper/instrumentation/log_subscriber'
 

--- a/spec/flipper/instrumentation/statsd_subscriber_spec.rb
+++ b/spec/flipper/instrumentation/statsd_subscriber_spec.rb
@@ -1,4 +1,3 @@
-require 'helper'
 require 'flipper/adapters/instrumented'
 require 'flipper/instrumentation/statsd'
 require 'statsd'

--- a/spec/flipper/instrumenters/memory_spec.rb
+++ b/spec/flipper/instrumenters/memory_spec.rb
@@ -1,4 +1,3 @@
-require 'helper'
 require 'flipper/instrumenters/memory'
 
 RSpec.describe Flipper::Instrumenters::Memory do

--- a/spec/flipper/instrumenters/noop_spec.rb
+++ b/spec/flipper/instrumenters/noop_spec.rb
@@ -1,5 +1,3 @@
-require 'helper'
-
 RSpec.describe Flipper::Instrumenters::Noop do
   describe '.instrument' do
     context 'with name' do

--- a/spec/flipper/middleware/memoizer_spec.rb
+++ b/spec/flipper/middleware/memoizer_spec.rb
@@ -1,4 +1,3 @@
-require 'helper'
 require 'rack/test'
 require 'active_support/cache'
 require 'active_support/cache/dalli_store'
@@ -361,7 +360,6 @@ RSpec.describe Flipper::Middleware::Memoizer do
         end
       end.to_app
     end
-
 
     context 'and unless option' do
       before do

--- a/spec/flipper/middleware/setup_env_spec.rb
+++ b/spec/flipper/middleware/setup_env_spec.rb
@@ -1,5 +1,3 @@
-require 'helper'
-
 RSpec.describe Flipper::Middleware::SetupEnv do
   context 'with flipper instance' do
     let(:app) do

--- a/spec/flipper/railtie_spec.rb
+++ b/spec/flipper/railtie_spec.rb
@@ -1,4 +1,3 @@
-require 'helper'
 require 'rails'
 require 'flipper/railtie'
 

--- a/spec/flipper/registry_spec.rb
+++ b/spec/flipper/registry_spec.rb
@@ -1,4 +1,3 @@
-require 'helper'
 require 'flipper/registry'
 
 RSpec.describe Flipper::Registry do

--- a/spec/flipper/typecast_spec.rb
+++ b/spec/flipper/typecast_spec.rb
@@ -1,4 +1,3 @@
-require 'helper'
 require 'flipper/typecast'
 
 RSpec.describe Flipper::Typecast do

--- a/spec/flipper/types/actor_spec.rb
+++ b/spec/flipper/types/actor_spec.rb
@@ -1,4 +1,3 @@
-require 'helper'
 require 'flipper/types/actor'
 
 RSpec.describe Flipper::Types::Actor do

--- a/spec/flipper/types/boolean_spec.rb
+++ b/spec/flipper/types/boolean_spec.rb
@@ -1,4 +1,3 @@
-require 'helper'
 require 'flipper/types/boolean'
 
 RSpec.describe Flipper::Types::Boolean do

--- a/spec/flipper/types/group_spec.rb
+++ b/spec/flipper/types/group_spec.rb
@@ -1,4 +1,3 @@
-require 'helper'
 require 'flipper/types/group'
 
 RSpec.describe Flipper::Types::Group do

--- a/spec/flipper/types/percentage_of_actors_spec.rb
+++ b/spec/flipper/types/percentage_of_actors_spec.rb
@@ -1,4 +1,3 @@
-require 'helper'
 require 'flipper/types/percentage_of_actors'
 
 RSpec.describe Flipper::Types::PercentageOfActors do

--- a/spec/flipper/types/percentage_of_time_spec.rb
+++ b/spec/flipper/types/percentage_of_time_spec.rb
@@ -1,4 +1,3 @@
-require 'helper'
 require 'flipper/types/percentage_of_time'
 
 RSpec.describe Flipper::Types::PercentageOfTime do

--- a/spec/flipper/types/percentage_spec.rb
+++ b/spec/flipper/types/percentage_spec.rb
@@ -1,4 +1,3 @@
-require 'helper'
 require 'flipper/types/percentage_of_actors'
 
 RSpec.describe Flipper::Types::Percentage do

--- a/spec/flipper/ui/action_spec.rb
+++ b/spec/flipper/ui/action_spec.rb
@@ -1,5 +1,3 @@
-require 'helper'
-
 RSpec.describe Flipper::UI::Action do
   describe 'request methods' do
     let(:action_subclass) do

--- a/spec/flipper/ui/actions/actors_gate_spec.rb
+++ b/spec/flipper/ui/actions/actors_gate_spec.rb
@@ -1,5 +1,3 @@
-require 'helper'
-
 RSpec.describe Flipper::UI::Actions::ActorsGate do
   let(:token) do
     if Rack::Protection::AuthenticityToken.respond_to?(:random_token)

--- a/spec/flipper/ui/actions/add_feature_spec.rb
+++ b/spec/flipper/ui/actions/add_feature_spec.rb
@@ -1,5 +1,3 @@
-require 'helper'
-
 RSpec.describe Flipper::UI::Actions::AddFeature do
   describe 'GET /features/new with feature_creation_enabled set to true' do
     before do

--- a/spec/flipper/ui/actions/boolean_gate_spec.rb
+++ b/spec/flipper/ui/actions/boolean_gate_spec.rb
@@ -1,5 +1,3 @@
-require 'helper'
-
 RSpec.describe Flipper::UI::Actions::BooleanGate do
   let(:token) do
     if Rack::Protection::AuthenticityToken.respond_to?(:random_token)

--- a/spec/flipper/ui/actions/feature_spec.rb
+++ b/spec/flipper/ui/actions/feature_spec.rb
@@ -1,5 +1,3 @@
-require 'helper'
-
 RSpec.describe Flipper::UI::Actions::Feature do
   let(:token) do
     if Rack::Protection::AuthenticityToken.respond_to?(:random_token)

--- a/spec/flipper/ui/actions/features_spec.rb
+++ b/spec/flipper/ui/actions/features_spec.rb
@@ -1,5 +1,3 @@
-require 'helper'
-
 RSpec.describe Flipper::UI::Actions::Features do
   let(:token) do
     if Rack::Protection::AuthenticityToken.respond_to?(:random_token)

--- a/spec/flipper/ui/actions/file_spec.rb
+++ b/spec/flipper/ui/actions/file_spec.rb
@@ -1,5 +1,3 @@
-require 'helper'
-
 RSpec.describe Flipper::UI::Actions::File do
   describe 'GET /images/logo.png' do
     before do

--- a/spec/flipper/ui/actions/groups_gate_spec.rb
+++ b/spec/flipper/ui/actions/groups_gate_spec.rb
@@ -1,5 +1,3 @@
-require 'helper'
-
 RSpec.describe Flipper::UI::Actions::GroupsGate do
   let(:token) do
     if Rack::Protection::AuthenticityToken.respond_to?(:random_token)

--- a/spec/flipper/ui/actions/home_spec.rb
+++ b/spec/flipper/ui/actions/home_spec.rb
@@ -1,5 +1,3 @@
-require 'helper'
-
 RSpec.describe Flipper::UI::Actions::Home do
   describe 'GET /' do
     before do

--- a/spec/flipper/ui/actions/percentage_of_actors_gate_spec.rb
+++ b/spec/flipper/ui/actions/percentage_of_actors_gate_spec.rb
@@ -1,5 +1,3 @@
-require 'helper'
-
 RSpec.describe Flipper::UI::Actions::PercentageOfActorsGate do
   let(:token) do
     if Rack::Protection::AuthenticityToken.respond_to?(:random_token)

--- a/spec/flipper/ui/actions/percentage_of_time_gate_spec.rb
+++ b/spec/flipper/ui/actions/percentage_of_time_gate_spec.rb
@@ -1,5 +1,3 @@
-require 'helper'
-
 RSpec.describe Flipper::UI::Actions::PercentageOfTimeGate do
   let(:token) do
     if Rack::Protection::AuthenticityToken.respond_to?(:random_token)

--- a/spec/flipper/ui/configuration_spec.rb
+++ b/spec/flipper/ui/configuration_spec.rb
@@ -1,5 +1,3 @@
-require 'helper'
-
 RSpec.describe Flipper::UI::Configuration do
   let(:configuration) { described_class.new }
 

--- a/spec/flipper/ui/decorators/feature_spec.rb
+++ b/spec/flipper/ui/decorators/feature_spec.rb
@@ -1,5 +1,3 @@
-require 'helper'
-
 RSpec.describe Flipper::UI::Decorators::Feature do
   let(:source)  { {} }
   let(:adapter) { Flipper::Adapters::Memory.new(source) }

--- a/spec/flipper/ui/decorators/gate_spec.rb
+++ b/spec/flipper/ui/decorators/gate_spec.rb
@@ -1,4 +1,3 @@
-require 'helper'
 require 'flipper/ui/decorators/gate'
 
 RSpec.describe Flipper::UI::Decorators::Gate do

--- a/spec/flipper/ui/util_spec.rb
+++ b/spec/flipper/ui/util_spec.rb
@@ -1,4 +1,3 @@
-require 'helper'
 require 'flipper/ui/util'
 
 RSpec.describe Flipper::UI::Util do

--- a/spec/flipper/ui_spec.rb
+++ b/spec/flipper/ui_spec.rb
@@ -1,5 +1,3 @@
-require 'helper'
-
 RSpec.describe Flipper::UI do
   let(:token) do
     if Rack::Protection::AuthenticityToken.respond_to?(:random_token)

--- a/spec/flipper_integration_spec.rb
+++ b/spec/flipper_integration_spec.rb
@@ -1,4 +1,3 @@
-require 'helper'
 require 'flipper/feature'
 
 RSpec.describe Flipper do

--- a/spec/flipper_spec.rb
+++ b/spec/flipper_spec.rb
@@ -1,4 +1,3 @@
-require 'helper'
 require 'flipper/cloud'
 
 RSpec.describe Flipper do

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -14,8 +14,9 @@ require 'webmock/rspec'
 WebMock.disable_net_connect!(allow_localhost: true)
 
 require 'flipper'
-require 'flipper/ui'
 require 'flipper/api'
+require 'flipper/spec/shared_adapter_specs'
+require 'flipper/ui'
 
 Dir[FlipperRoot.join('spec/support/**/*.rb')].sort.each { |f| require f }
 


### PR DESCRIPTION
lean on some rspec conventions / helpers to simplify our specs.  this `.rspec` automatically loads `spec_helper.rb` before any test is run, so we no longer need to explicitly require it everywhere