### PR TITLE
Fix railtie initialization to mount middleware after config/intializers/*

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -1,9 +1,12 @@
-## Unreleased 
+## Unreleased
 
 ### Additions/Changes
 
 * Relax dalli version constraint (https://github.com/jnunemaker/flipper/pull/596)
 
+### Bug Fixes
+
+* Fix railtie initialization to mount middleware after config/intializers/* (https://github.com/jnunemaker/flipper/pull/586)
 
 ## 0.23.0
 

--- a/lib/flipper/railtie.rb
+++ b/lib/flipper/railtie.rb
@@ -18,7 +18,7 @@ module Flipper
       end
     end
 
-    initializer "flipper.memoizer" do |app|
+    initializer "flipper.memoizer", after: :load_config_initializers do |app|
       config = app.config.flipper
 
       if config.memoize
@@ -30,8 +30,9 @@ module Flipper
       end
     end
 
-    initializer "flipper.log" do |app|
+    initializer "flipper.log", after: :load_config_initializers do |app|
       config = app.config.flipper
+
       if config.log && config.instrumenter == ActiveSupport::Notifications
         require "flipper/instrumentation/log_subscriber"
       end

--- a/spec/flipper/railtie_spec.rb
+++ b/spec/flipper/railtie_spec.rb
@@ -17,46 +17,55 @@ RSpec.describe Flipper::Railtie do
 
   describe 'initializers' do
     it 'sets defaults' do
+      subject # initialize
       expect(config.env_key).to eq("flipper")
       expect(config.memoize).to be(true)
       expect(config.preload).to be(true)
     end
 
     it "configures instrumentor on default instance" do
-      subject
-
+      subject # initialize
       expect(Flipper.instance.instrumenter).to eq(ActiveSupport::Notifications)
     end
 
     it 'uses Memoizer middleware if config.memoize = true' do
+      initializer { config.memoize = true }
       expect(subject.middleware).to include(Flipper::Middleware::Memoizer)
     end
 
     it 'does not use Memoizer middleware if config.memoize = false' do
-      # load but don't initialize
-      config.memoize = false
-
+      initializer { config.memoize = false }
       expect(subject.middleware).not_to include(Flipper::Middleware::Memoizer)
     end
 
     it 'passes config to memoizer' do
-      # load but don't initialize
-      config.update(
-        env_key: 'my_flipper',
-        preload: [:stats, :search]
-      )
+      initializer do
+        config.update(
+          env_key: 'my_flipper',
+          preload: [:stats, :search]
+        )
+      end
 
-      expect(Flipper::Middleware::Memoizer).to receive(:new).with(application.routes,
-        env_key: 'my_flipper', preload: [:stats, :search], if: nil
-      )
-
-      subject # initialize
+      expect(subject.middleware).to include(Flipper::Middleware::Memoizer)
+      middleware = subject.middleware.detect { |m| m.klass == Flipper::Middleware::Memoizer }
+      expect(middleware.args[0]).to eq({
+        env_key: config.env_key,
+        preload: config.preload,
+        if: nil
+      })
     end
 
     it "defines #flipper_id on AR::Base" do
       subject
       require 'active_record'
       expect(ActiveRecord::Base.ancestors).to include(Flipper::Identifier)
+    end
+  end
+
+  # Add app initializer in the same order as config/initializers/*
+  def initializer(&block)
+    application.initializer 'spec', before: :load_config_initializers do
+      block.call
     end
   end
 end

--- a/spec/flipper/railtie_spec.rb
+++ b/spec/flipper/railtie_spec.rb
@@ -3,11 +3,8 @@ require 'flipper/railtie'
 
 RSpec.describe Flipper::Railtie do
   let(:application) do
-    Class.new(Rails::Application).new(
-      railties: [Flipper::Railtie],
-    ).tap do |app|
-      app.config.eager_load = false
-      app.run_load_hooks!
+    Class.new(Rails::Application).create(railties: [Flipper::Railtie]) do
+      config.eager_load = false
     end
   end
 


### PR DESCRIPTION
After #563, Flipper configuration in `config/initializers/*` is ignored because the Memoization middleware gets mounted before initializers are run. This reverts 713e9d1 and fixes the specs to expose this issue.

The tests pass here, but it's going to cause issues that #563 was meant to fix, so I need some help.

I've been spelunking on Rails initialization process all day, and I can't quite figure out the order of initializers. Some initializers run after `load_config_initializers` without declaring a `before`/`after` dependency (see all of `action_view` below), while most run earlier in the process.

### What else I tried

* Running `flipper.memoizer` before `build_middleware_stack` initializer, but that appears to be defined on a `Finalizer` module outside of the app's initializers, so you can't order anything before/after it.
* Removing all `before`/`after` dependencies to see if it would just run in the right order automagically 🤷 

### Intializer order

Here's the order for a few different examples:

<details>
<summary>Initializers for new Rails 6.1.4.1 app</summary>
<pre>
>> puts Rails.application.initializers.tsort.map(&:name).uniq
load_environment_config
load_environment_hook
load_active_support
set_eager_load
initialize_logger
initialize_cache
initialize_dependency_mechanism
set_load_path
set_autoload_paths
set_eager_load_paths
bootstrap_hook
set_secrets_root
active_support.set_authenticated_message_encryption
active_support.reset_all_current_attributes_instances
active_support.deprecation_behavior
active_support.initialize_time_zone
active_support.initialize_beginning_of_week
active_support.require_master_key
active_support.set_configs
active_support.set_hash_digest_class
action_dispatch.configure
active_model.secure_password
active_model.i18n_customize_full_message
action_controller.assets_config
action_controller.set_helpers_path
action_controller.parameters_config
action_controller.set_configs
action_controller.compile_config_methods
action_controller.request_forgery_protection
action_controller.eager_load_actions
active_record.initialize_timezone
active_record.logger
active_record.backtrace_cleaner
active_record.migration_error
active_record.database_selector
Check for cache versioning support
active_record.check_schema_cache_dump
active_record.define_attribute_methods
active_record.warn_on_records_fetched_greater_than
active_record.set_configs
active_record.initialize_database
active_record.log_runtime
active_record.set_reloader_hooks
active_record.set_executor_hooks
active_record.add_watchable_files
active_record.clear_active_connections
active_record.set_filter_attributes
active_record.set_signed_id_verifier_secret
global_id
active_job.logger
active_job.custom_serializers
active_job.set_configs
active_job.set_reloader_hook
action_mailer.logger
action_mailer.set_configs
action_mailer.set_autoload_paths
action_mailer.compile_config_methods
action_mailer.eager_load_actions
test_unit.line_filtering
set_default_precompile
quiet_assets
asset_url_processor
asset_sourcemap_url_processor
setup_sass
setup_compression
jbuilder
web_console.initialize
web_console.development_only
web_console.insert_middleware
web_console.mount_point
web_console.template_paths
web_console.permissions
web_console.whiny_requests
i18n.load_path
rack_mini_profiler.configure_rails_initialization
add_routing_paths
add_locales
add_view_paths
prepend_helpers_path
load_config_initializers
wrap_executor_around_load_seed
engines_blank_point
append_assets_path
action_view.logger
action_view.caching
action_view.setup_action_pack
action_view.collection_caching
active_storage.configs
active_storage.attached
active_storage.verifier
active_storage.services
active_storage.queues
active_storage.reflection
action_cable.helpers
action_cable.logger
action_cable.set_configs
action_cable.routes
action_cable.set_work_hooks
action_mailbox.config
action_text.attribute
action_text.attachable
action_text.helper
action_text.renderer
action_text.system_test_helper
webpacker.proxy
webpacker.helper
webpacker.logger
webpacker.bootstrap
webpacker.set_source
turbolinks
add_generator_templates
ensure_autoload_once_paths_as_subset
warn_if_autoloaded
let_zeitwerk_take_over
add_builtin_route
setup_default_session_store
build_middleware_stack
define_main_app_helper
add_to_prepare_blocks
run_prepare_callbacks
eager_load!
finisher_hook
configure_executor_for_concurrency
set_routes_reloader_hook
set_clear_dependencies_hook
disable_dependency_loading
</pre>
</details>
<details>
<summary>Initializers for new Rails 6.1.4.1 app + Flipper 0.22.2</summary>
<pre>
>> puts Rails.application.initializers.tsort.map(&:name).uniq
load_environment_config
load_environment_hook
load_active_support
set_eager_load
initialize_logger
initialize_cache
initialize_dependency_mechanism
set_load_path
set_autoload_paths
set_eager_load_paths
bootstrap_hook
set_secrets_root
active_support.set_authenticated_message_encryption
active_support.reset_all_current_attributes_instances
active_support.deprecation_behavior
active_support.initialize_time_zone
active_support.initialize_beginning_of_week
active_support.require_master_key
active_support.set_configs
active_support.set_hash_digest_class
action_dispatch.configure
active_model.secure_password
active_model.i18n_customize_full_message
action_controller.assets_config
action_controller.set_helpers_path
action_controller.parameters_config
action_controller.set_configs
action_controller.compile_config_methods
action_controller.request_forgery_protection
action_controller.eager_load_actions
active_record.initialize_timezone
active_record.logger
active_record.backtrace_cleaner
active_record.migration_error
active_record.database_selector
Check for cache versioning support
active_record.check_schema_cache_dump
active_record.define_attribute_methods
active_record.warn_on_records_fetched_greater_than
active_record.set_configs
active_record.initialize_database
active_record.log_runtime
active_record.set_reloader_hooks
active_record.set_executor_hooks
active_record.add_watchable_files
active_record.clear_active_connections
active_record.set_filter_attributes
active_record.set_signed_id_verifier_secret
global_id
active_job.logger
active_job.custom_serializers
active_job.set_configs
active_job.set_reloader_hook
action_mailer.logger
action_mailer.set_configs
action_mailer.set_autoload_paths
action_mailer.compile_config_methods
action_mailer.eager_load_actions
test_unit.line_filtering
set_default_precompile
quiet_assets
asset_url_processor
asset_sourcemap_url_processor
setup_sass
setup_compression
jbuilder
flipper.default
flipper.memoizer
flipper.log
flipper.identifier
web_console.initialize
web_console.development_only
web_console.insert_middleware
web_console.mount_point
web_console.template_paths
web_console.permissions
web_console.whiny_requests
i18n.load_path
rack_mini_profiler.configure_rails_initialization
add_routing_paths
add_locales
add_view_paths
prepend_helpers_path
load_config_initializers
wrap_executor_around_load_seed
engines_blank_point
append_assets_path
action_view.logger
action_view.caching
action_view.setup_action_pack
action_view.collection_caching
active_storage.configs
active_storage.attached
active_storage.verifier
active_storage.services
active_storage.queues
active_storage.reflection
action_cable.helpers
action_cable.logger
action_cable.set_configs
action_cable.routes
action_cable.set_work_hooks
action_mailbox.config
action_text.attribute
action_text.attachable
action_text.helper
action_text.renderer
action_text.system_test_helper
webpacker.proxy
webpacker.helper
webpacker.logger
webpacker.bootstrap
webpacker.set_source
turbolinks
add_generator_templates
ensure_autoload_once_paths_as_subset
warn_if_autoloaded
let_zeitwerk_take_over
add_builtin_route
setup_default_session_store
build_middleware_stack
define_main_app_helper
add_to_prepare_blocks
run_prepare_callbacks
eager_load!
finisher_hook
configure_executor_for_concurrency
set_routes_reloader_hook
set_clear_dependencies_hook
disable_dependency_loading
</details>
<details>
<summary>Initializers for new Rails 6.1.4.1 app + this flipper branch</summary>
<pre>
> puts Rails.application.initializers.tsort.map(&:name).uniq
load_environment_config
load_environment_hook
load_active_support
set_eager_load
initialize_logger
initialize_cache
initialize_dependency_mechanism
set_load_path
set_autoload_paths
set_eager_load_paths
bootstrap_hook
set_secrets_root
active_support.set_authenticated_message_encryption
active_support.reset_all_current_attributes_instances
active_support.deprecation_behavior
active_support.initialize_time_zone
active_support.initialize_beginning_of_week
active_support.require_master_key
active_support.set_configs
active_support.set_hash_digest_class
action_dispatch.configure
active_model.secure_password
active_model.i18n_customize_full_message
action_controller.assets_config
action_controller.set_helpers_path
action_controller.parameters_config
action_controller.set_configs
action_controller.compile_config_methods
action_controller.request_forgery_protection
action_controller.eager_load_actions
active_record.initialize_timezone
active_record.logger
active_record.backtrace_cleaner
active_record.migration_error
active_record.database_selector
Check for cache versioning support
active_record.check_schema_cache_dump
active_record.define_attribute_methods
active_record.warn_on_records_fetched_greater_than
active_record.set_configs
active_record.initialize_database
active_record.log_runtime
active_record.set_reloader_hooks
active_record.set_executor_hooks
active_record.add_watchable_files
active_record.clear_active_connections
active_record.set_filter_attributes
active_record.set_signed_id_verifier_secret
global_id
active_job.logger
active_job.custom_serializers
active_job.set_configs
active_job.set_reloader_hook
action_mailer.logger
action_mailer.set_configs
action_mailer.set_autoload_paths
action_mailer.compile_config_methods
action_mailer.eager_load_actions
test_unit.line_filtering
set_default_precompile
quiet_assets
asset_url_processor
asset_sourcemap_url_processor
setup_sass
setup_compression
jbuilder
flipper.default
flipper.memoizer
add_routing_paths
add_locales
add_view_paths
prepend_helpers_path
load_config_initializers
flipper.log
flipper.identifier
web_console.initialize
web_console.development_only
web_console.insert_middleware
web_console.mount_point
web_console.template_paths
web_console.permissions
web_console.whiny_requests
i18n.load_path
rack_mini_profiler.configure_rails_initialization
wrap_executor_around_load_seed
engines_blank_point
append_assets_path
action_view.logger
action_view.caching
action_view.setup_action_pack
action_view.collection_caching
active_storage.configs
active_storage.attached
active_storage.verifier
active_storage.services
active_storage.queues
active_storage.reflection
action_cable.helpers
action_cable.logger
action_cable.set_configs
action_cable.routes
action_cable.set_work_hooks
action_mailbox.config
action_text.attribute
action_text.attachable
action_text.helper
action_text.renderer
action_text.system_test_helper
webpacker.proxy
webpacker.helper
webpacker.logger
webpacker.bootstrap
webpacker.set_source
turbolinks
add_generator_templates
ensure_autoload_once_paths_as_subset
warn_if_autoloaded
let_zeitwerk_take_over
add_builtin_route
setup_default_session_store
build_middleware_stack
define_main_app_helper
add_to_prepare_blocks
run_prepare_callbacks
eager_load!
finisher_hook
configure_executor_for_concurrency
set_routes_reloader_hook
set_clear_dependencies_hook
disable_dependency_loading
</pre>
</details>
<details>
<summary>Initializers in specs for this flipper branch</summary>
<pre>
load_environment_config
load_environment_hook
load_active_support
set_eager_load
initialize_logger
initialize_cache
initialize_dependency_mechanism
set_load_path
set_autoload_paths
set_eager_load_paths
bootstrap_hook
set_secrets_root
flipper.identifier
flipper.default
add_routing_paths
add_locales
add_view_paths
prepend_helpers_path
spec
load_config_initializers
flipper.log
flipper.memoizer
wrap_executor_around_load_seed
engines_blank_point
add_generator_templates
ensure_autoload_once_paths_as_subset
warn_if_autoloaded
let_zeitwerk_take_over
add_builtin_route
setup_default_session_store
build_middleware_stack
define_main_app_helper
add_to_prepare_blocks
run_prepare_callbacks
eager_load!
finisher_hook
configure_executor_for_concurrency
set_routes_reloader_hook
set_clear_dependencies_hook
disable_dependency_loading
</pre>
</details>

### Further Reading:
* [Rails::Railtie API docs on initializers](https://api.rubyonrails.org/classes/Rails/Railtie.html#class-Rails::Railtie-label-Initializers)
* [Rails::Application API docs on boot process](https://api.rubyonrails.org/classes/Rails/Application.html#class-Rails::Application-label-Booting+process)
* [Rails guide on configuring](https://guides.rubyonrails.org/configuring.html#initializers)

cc @jdelStrother