### PR TITLE
Improve http error message

### DIFF
--- a/lib/flipper/adapters/http/error.rb
+++ b/lib/flipper/adapters/http/error.rb
@@ -1,3 +1,5 @@
+require "json"
+
 module Flipper
   module Adapters
     class Http
@@ -6,7 +8,23 @@ module Flipper
 
         def initialize(response)
           @response = response
-          super("Failed with status: #{response.code}")
+          message = "Failed with status: #{response.code}"
+
+          begin
+            data = JSON.parse(response.body)
+
+            if error_message = data["message"]
+              message << "\n\n#{data["message"]}"
+            end
+
+            if more_info = data["more_info"]
+              message << "\n#{data["more_info"]}"
+            end
+          rescue => exception
+            # welp we tried
+          end
+
+          super(message)
         end
       end
     end

--- a/spec/flipper/adapters/http_spec.rb
+++ b/spec/flipper/adapters/http_spec.rb
@@ -165,7 +165,44 @@ RSpec.describe Flipper::Adapters::Http do
       thing = gate.wrap(true)
       expect {
         adapter.enable(feature, gate, thing)
+      }.to raise_error(Flipper::Adapters::Http::Error, "Failed with status: 503")
+    end
+
+    it "doesn't raise json error if body cannot be parsed" do
+      stub_request(:post, /app.com/)
+        .to_return(status: 503, body: "barf", headers: {})
+
+      adapter = described_class.new(url: 'http://app.com/flipper')
+      feature = Flipper::Feature.new(:search, adapter)
+      gate = feature.gate(:boolean)
+      thing = gate.wrap(true)
+      expect {
+        adapter.enable(feature, gate, thing)
       }.to raise_error(Flipper::Adapters::Http::Error)
+    end
+
+    it "includes response information if available when raising error" do
+      api_response = {
+        "code" => "error",
+        "message" => "This feature has reached the limit to the number of " +
+                     "actors per feature. Check out groups as a more flexible " +
+                     "way to enable many actors.",
+        "more_info" => "https://www.flippercloud.io/docs",
+      }
+      stub_request(:post, /app.com/)
+        .to_return(status: 503, body: JSON.dump(api_response), headers: {})
+
+      adapter = described_class.new(url: 'http://app.com/flipper')
+      feature = Flipper::Feature.new(:search, adapter)
+      gate = feature.gate(:boolean)
+      thing = gate.wrap(true)
+      error_message = "Failed with status: 503\n\nThis feature has reached the " +
+                      "limit to the number of actors per feature. Check out " +
+                      "groups as a more flexible way to enable many actors.\n" +
+                      "https://www.flippercloud.io/docs"
+      expect {
+        adapter.enable(feature, gate, thing)
+      }.to raise_error(Flipper::Adapters::Http::Error, error_message)
     end
   end
 
@@ -202,7 +239,8 @@ RSpec.describe Flipper::Adapters::Http do
     let(:feature) { flipper[:feature_panel] }
 
     before do
-      stub_request(:get, %r{\Ahttp://app.com*}).to_return(body: fixture_file('feature.json'))
+      stub_request(:get, %r{\Ahttp://app.com*}).
+        to_return(body: fixture_file('feature.json'))
     end
 
     it 'allows client to set request headers' do


### PR DESCRIPTION
The API returns nice error messages but our errors weren't showing them.

Now we are showing them. Much easier to figure out what went wrong and fix it on your own.