### PR TITLE
Support ActiveRecord 7.0

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,7 +16,7 @@ jobs:
     strategy:
       matrix:
         ruby: ['2.5', '2.6', '2.7']
-        rails: ['5.2', '6.0.0', '6.1.0']
+        rails: ['5.2', '6.0.0', '6.1.0', '7.0.0']
     env:
       SQLITE3_VERSION: 1.4.1
       REDIS_URL: redis://localhost:6379/0

--- a/flipper-active_record.gemspec
+++ b/flipper-active_record.gemspec
@@ -25,5 +25,5 @@ Gem::Specification.new do |gem|
   gem.metadata      = Flipper::METADATA
 
   gem.add_dependency 'flipper', "~> #{Flipper::VERSION}"
-  gem.add_dependency 'activerecord', '>= 4.2', '< 7'
+  gem.add_dependency 'activerecord', '>= 4.2', '< 8'
 end


### PR DESCRIPTION
Rails 7.0 was just released and having the dependency `< 7` prevents us from installing flipper with a new rails app.

I'm not sure _what_ needs to change or why the restriction on `< 7` so opening the easiest PR for this, but let me know if there are things that worry you and I'll work on them!

One thing that might hold this back is that Rails 7 requires Ruby 2.7.0+ and I see tests with ruby 2.5 and 2.6.