### PR TITLE
Upgrade bootstrap js and jquery

### DIFF
--- a/lib/flipper/ui/action.rb
+++ b/lib/flipper/ui/action.rb
@@ -24,7 +24,7 @@ module Flipper
                                              'get'.freeze,
                                              'post'.freeze,
                                              'put'.freeze,
-                                             'delete'.freeze
+                                             'delete'.freeze,
                                            ]).freeze
 
       SOURCES = {

--- a/lib/flipper/ui/action.rb
+++ b/lib/flipper/ui/action.rb
@@ -24,25 +24,25 @@ module Flipper
                                              'get'.freeze,
                                              'post'.freeze,
                                              'put'.freeze,
-                                             'delete'.freeze,
+                                             'delete'.freeze
                                            ]).freeze
 
       SOURCES = {
         bootstrap_css: {
-          src: "https://cdn.jsdelivr.net/npm/bootstrap@4.6.0/dist/css/bootstrap.min.css".freeze,
-          hash: "sha384-B0vP5xmATw1+K9KRQjQERJvTumQW0nPEzvF6L/Z6nronJ3oUOFUFpCjEUQouq2+l".freeze
+          src: 'https://cdn.jsdelivr.net/npm/bootstrap@4.6.0/dist/css/bootstrap.min.css'.freeze,
+          hash: 'sha384-B0vP5xmATw1+K9KRQjQERJvTumQW0nPEzvF6L/Z6nronJ3oUOFUFpCjEUQouq2+l'.freeze
         }.freeze,
         jquery_js: {
-          src: "https://code.jquery.com/jquery-3.5.1.slim.min.js".freeze,
-          hash: "sha384-DfXdz2htPH0lsSSs5nCTpuj/zy4C+OGpamoFVy38MVBnE+IbbVYUew+OrCXaRkfj".freeze
+          src: 'https://code.jquery.com/jquery-3.6.0.slim.js'.freeze,
+          hash: 'sha256-HwWONEZrpuoh951cQD1ov2HUK5zA5DwJ1DNUXaM6FsY='.freeze
         }.freeze,
         popper_js: {
-          src: "https://cdnjs.cloudflare.com/ajax/libs/popper.js/1.12.9/umd/popper.min.js".freeze,
-          hash: "sha384-ApNbgh9B+Y1QKtv3Rn7W3mgPxhU9K/ScQsAP7hUibX39j7fakFPskvXusvfa0b4Q".freeze
+          src: 'https://cdnjs.cloudflare.com/ajax/libs/popper.js/1.12.9/umd/popper.min.js'.freeze,
+          hash: 'sha384-ApNbgh9B+Y1QKtv3Rn7W3mgPxhU9K/ScQsAP7hUibX39j7fakFPskvXusvfa0b4Q'.freeze
         }.freeze,
         bootstrap_js: {
-          src: "https://maxcdn.bootstrapcdn.com/bootstrap/4.0.0/js/bootstrap.min.js".freeze,
-          hash: "sha384-JZR6Spejh4U02d8jOt6vLEHfe/JQGiRRSQQxSfFWpi1MquVdAyjUar5+76PVCmYl".freeze
+          src: 'https://cdn.jsdelivr.net/npm/bootstrap@4.6.0/dist/js/bootstrap.min.js'.freeze,
+          hash: 'sha384-+YQ4JLhjyBLPDQt//I+STsc9iw4uQqACwlvpslubQzn4u2UU2UFM80nGisd026JF'.freeze
         }.freeze
       }.freeze
       SCRIPT_SRCS = SOURCES.values_at(:jquery_js, :popper_js, :bootstrap_js).map { |s| s[:src] }
@@ -239,6 +239,7 @@ module Flipper
       def view(name)
         path = views_path.join("#{name}.erb")
         raise "Template does not exist: #{path}" unless path.exist?
+
         eval(Erubi::Engine.new(path.read, escape: true).src)
       end
 


### PR DESCRIPTION
Signed-off-by: Marcus Heng <marcushwz@gmail.com>

Hi, first of all thank you so much for this gem, I love using it at work! Today, one of my team member report that Flipper UI is taking some time to load. I gave it a look and were able to reproduce it on my local. After diving into it, the problem seems to cause by the `Bootstrap JS CDN`. Attached are images of both Chrome and Firefox refusing to load the `4.0 version`

## Before Upgrade
- Chrome
<img width="725" alt="image" src="https://user-images.githubusercontent.com/40255418/146900202-7e5ae962-083b-4708-9dc9-394433e460b6.png">

- Firefox
<img width="1024" alt="image" src="https://user-images.githubusercontent.com/40255418/146900222-bc863588-b59f-4326-acf3-7a779258ec48.png">

## After Upgrade
- Upgraded Bootstrap JS to v4.6 (Fixed both Chrome and Firefox refusing to load v4.0)
- Upgraded jquery to `jquery-3.6.0` (This isn't causing any problem, but I think it might be good to update to the latest stable)

- Chrome
<img width="495" alt="image" src="https://user-images.githubusercontent.com/40255418/146900989-0ccf378f-90e8-4812-a8d9-4760d1db9872.png">

- Firefox
<img width="629" alt="image" src="https://user-images.githubusercontent.com/40255418/146900950-091a3e15-94fc-4139-a33a-2be022a86f4f.png">


PS: Sorry about the code formatting, let me know if you want to change back the formatting. Those were done by local dev setup with Rubocop.