### PR TITLE
Add Ruby 3.0 and 3.1 to the CI matrix

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,13 +15,19 @@ jobs:
           --health-retries 5
     strategy:
       matrix:
-        ruby: ['2.5', '2.6', '2.7']
+        ruby: ['2.5', '2.6', '2.7', '3.0', '3.1']
         rails: ['5.2', '6.0.0', '6.1.0', '7.0.0']
         exclude:
           - ruby: "2.5"
             rails: "7.0.0"
           - ruby: "2.6"
             rails: "7.0.0"
+          - ruby: "3.0"
+            rails: "5.2"
+          - ruby: "3.1"
+            rails: "5.2"
+          - ruby: "3.1"
+            rails: "6.0.0"
     env:
       SQLITE3_VERSION: 1.4.1
       REDIS_URL: redis://localhost:6379/0
@@ -43,7 +49,7 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-gems-${{ matrix.ruby }}-${{ matrix.rails }}-
       - name: Set up Ruby ${{ matrix.ruby }}
-        uses: actions/setup-ruby@v1
+        uses: ruby/setup-ruby@v1
         with:
           ruby-version: ${{ matrix.ruby }}
       - name: Install libpq-dev

--- a/.github/workflows/examples.yml
+++ b/.github/workflows/examples.yml
@@ -16,8 +16,20 @@ jobs:
           --health-retries 5
     strategy:
       matrix:
-        ruby: ['2.5', '2.6', '2.7']
-        rails: ['5.2', '6.0.0', '6.1.0']
+        ruby: ['2.5', '2.6', '2.7', '3.0', '3.1']
+        rails: ['5.2', '6.0.0', '6.1.0', '7.0.0']
+        exclude:
+          - ruby: "2.5"
+            rails: "7.0.0"
+          - ruby: "2.6"
+            rails: "7.0.0"
+          - ruby: "3.0"
+            rails: "5.2"
+          - ruby: "3.1"
+            rails: "5.2"
+          - ruby: "3.1"
+            rails: "6.0.0"
+
     env:
       SQLITE3_VERSION: 1.4.1
       REDIS_URL: redis://localhost:6379/0
@@ -39,7 +51,7 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-gems-${{ matrix.ruby }}-${{ matrix.rails }}-
       - name: Set up Ruby ${{ matrix.ruby }}
-        uses: actions/setup-ruby@v1
+        uses: ruby/setup-ruby@v1
         with:
           ruby-version: ${{ matrix.ruby }}
       - name: Install libpq-dev

--- a/lib/flipper/types/group.rb
+++ b/lib/flipper/types/group.rb
@@ -14,7 +14,7 @@ module Flipper
 
         if block_given?
           @block = block
-          @single_argument = @block.arity.abs == 1
+          @single_argument = call_with_no_context?(@block)
         else
           @block = ->(_thing, _context) { false }
           @single_argument = false
@@ -27,6 +27,13 @@ module Flipper
         else
           @block.call(thing, context)
         end
+      end
+
+      NO_PARAMS_IN_RUBY_3 = [[:req], [:rest]]
+      def call_with_no_context?(block)
+        return true if block.parameters == NO_PARAMS_IN_RUBY_3
+
+        block.arity.abs == 1
       end
     end
   end


### PR DESCRIPTION
This PR adds Ruby 3.0 and 3.1 to the CI matrix.

Aside from the configuration changes in ci.yml it:

1. Changes the setup-ruby action to the currently supported action
2. Updates examples.yml to include Rails 7.0.0 and the necessary matrix exclusions
3. Changes Flipper::Types::Group so that it properly parses parameters for procs in Ruby 3.0 and up

As an aside, even though there's an `if` clause in the `examples.yml` that disables in on forked repos, I did run it and ensure it was green before submitting this PR.