### PR TITLE
Fix deprecated uses of `Redis#pipelined`

### DIFF
--- a/flipper-redis.gemspec
+++ b/flipper-redis.gemspec
@@ -21,5 +21,5 @@ Gem::Specification.new do |gem|
   gem.metadata      = Flipper::METADATA
 
   gem.add_dependency 'flipper', "~> #{Flipper::VERSION}"
-  gem.add_dependency 'redis', '>= 2.2', '< 5'
+  gem.add_dependency 'redis', '>= 3.0', '< 5'
 end

--- a/lib/flipper/adapters/redis.rb
+++ b/lib/flipper/adapters/redis.rb
@@ -125,14 +125,14 @@ module Flipper
       # Private: Gets a hash of fields => values for the given feature.
       #
       # Returns a Hash of fields => values.
-      def doc_for(feature)
-        @client.hgetall(feature.key)
+      def doc_for(feature, pipeline: @client)
+        pipeline.hgetall(feature.key)
       end
 
       def docs_for(features)
-        @client.pipelined do
+        @client.pipelined do |pipeline|
           features.each do |feature|
-            doc_for(feature)
+            doc_for(feature, pipeline: pipeline)
           end
         end
       end


### PR DESCRIPTION
Context: https://github.com/redis/redis-rb/pull/1059

The following is deprecated
```ruby
redis.pipelined do
  redis.get(key)
end
```

And should be rewritten as:
```ruby
redis.pipelined do |pipeline|
  pipeline.get(key)
end
```

Functionally it makes no difference.
This API is available since Redis 3.0.