### PR TITLE
Call to_app before returning the rack app

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -6,6 +6,7 @@
 * Removed support for Ruby 2.5 (which was end of line 9 months ago)
 * Add (alpha) client side instrumentation of events to cloud (https://github.com/jnunemaker/flipper/pull/602)
 * Fix deprecated uses of Redis#pipelined (https://github.com/jnunemaker/flipper/pull/603). redis-rb >= 3 now required.
+* Fix Flipper UI Rack application when `Rack::Session::Pool` is used to build it.
 
 ## 0.23.1
 

--- a/lib/flipper/ui.rb
+++ b/lib/flipper/ui.rb
@@ -50,7 +50,7 @@ module Flipper
       builder.run app
       klass = self
       builder.define_singleton_method(:inspect) { klass.inspect } # pretty rake routes output
-      builder
+      builder.to_app
     end
 
     # Public: yields configuration instance for customizing UI text


### PR DESCRIPTION
If we return a `Rack::Builder` instance, it will call `to_app` for every request. That's not performant, but more importantly, it makes apps that want to use `Rack::Session::Pool` not work. `Rack::Session::Pool` uses `@pool` to store the sessions; if we rebuild the Rack application for every request, it can't keep track of sessions because it resets the variable.

The following application wouldn't work without this change:

```ruby
require "rack"
require "flipper"
require "flipper-ui"

flipper = Flipper.new(Flipper::Adapters::Memory.new)

run Rack::URLMap.new({
  "/flipper" => Flipper::UI.app(flipper) do |builder|
    builder.use Rack::Session::Pool
  end
})
```