### PR TITLE
Add Flipper::Actor#hash

### DIFF
--- a/lib/flipper/actor.rb
+++ b/lib/flipper/actor.rb
@@ -12,5 +12,9 @@ module Flipper
       self.class.eql?(other.class) && @flipper_id == other.flipper_id
     end
     alias_method :==, :eql?
+
+    def hash
+      flipper_id.hash
+    end
   end
 end

--- a/spec/flipper/actor_spec.rb
+++ b/spec/flipper/actor_spec.rb
@@ -43,4 +43,14 @@ RSpec.describe Flipper::Actor do
       expect(actor1.==(actor2)).to be(false)
     end
   end
+
+  describe '#hash' do
+    it 'returns a hash-value based on the flipper id' do
+      h = {
+        described_class.new("User;123") => true
+      }
+      expect(h).to have_key(described_class.new("User;123"))
+      expect(h).not_to have_key(described_class.new("User;456"))
+    end
+  end
 end


### PR DESCRIPTION
This allows them to be used as hash-keys - eg

```ruby
features = {
  Flipper::Actor.new("abc") => [:foo, :bar],
  Flipper::Actor.new("def") => [:baz],
}
features[Flipper::Actor.new("abc")] #=> [:foo, :bar]
```