### PR TITLE
Pretty Up `rails routes` again

### DIFF
--- a/flipper-ui.gemspec
+++ b/flipper-ui.gemspec
@@ -21,7 +21,7 @@ Gem::Specification.new do |gem|
   gem.metadata      = Flipper::METADATA
 
   gem.add_dependency 'rack', '>= 1.4', '< 3'
-  gem.add_dependency 'rack-protection', '>= 1.5.3', '< 2.2.0'
+  gem.add_dependency 'rack-protection', '>= 1.5.3', '<= 2.2.0'
   gem.add_dependency 'flipper', "~> #{Flipper::VERSION}"
   gem.add_dependency 'erubi', '>= 1.0.0', '< 2.0.0'
   gem.add_dependency 'sanitize', '< 7'

--- a/lib/flipper/api.rb
+++ b/lib/flipper/api.rb
@@ -17,8 +17,9 @@ module Flipper
       builder.use Flipper::Api::Middleware, env_key: env_key
       builder.run app
       klass = self
-      builder.define_singleton_method(:inspect) { klass.inspect } # pretty rake routes output
-      builder
+      app = builder.to_app
+      app.define_singleton_method(:inspect) { klass.inspect } # pretty rake routes output
+      app
     end
   end
 end

--- a/lib/flipper/cloud.rb
+++ b/lib/flipper/cloud.rb
@@ -40,8 +40,9 @@ module Flipper
       builder.use Flipper::Cloud::Middleware, env_key: env_key
       builder.run app
       klass = self
-      builder.define_singleton_method(:inspect) { klass.inspect } # pretty rake routes output
-      builder
+      app = builder.to_app
+      app.define_singleton_method(:inspect) { klass.inspect } # pretty rake routes output
+      app
     end
 
     # Private: Configure Flipper to use Cloud by default

--- a/lib/flipper/ui.rb
+++ b/lib/flipper/ui.rb
@@ -49,8 +49,9 @@ module Flipper
       builder.use Flipper::UI::Middleware, flipper: flipper, env_key: env_key
       builder.run app
       klass = self
-      builder.define_singleton_method(:inspect) { klass.inspect } # pretty rake routes output
-      builder.to_app
+      app = builder.to_app
+      app.define_singleton_method(:inspect) { klass.inspect } # pretty rake routes output
+      app
     end
 
     # Public: yields configuration instance for customizing UI text

--- a/spec/flipper/api_spec.rb
+++ b/spec/flipper/api_spec.rb
@@ -107,7 +107,7 @@ RSpec.describe Flipper::Api do
 
   describe 'Inspecting the built Rack app' do
     it 'returns a String' do
-      expect(build_api(flipper).inspect).to be_a(String)
+      expect(build_api(flipper).inspect).to eq("Flipper::Api")
     end
   end
 end

--- a/spec/flipper/cloud/middleware_spec.rb
+++ b/spec/flipper/cloud/middleware_spec.rb
@@ -267,7 +267,7 @@ RSpec.describe Flipper::Cloud::Middleware do
 
   describe 'Inspecting the built Rack app' do
     it 'returns a String' do
-      expect(Flipper::Cloud.app(flipper).inspect).to be_a(String)
+      expect(Flipper::Cloud.app(flipper).inspect).to eq("Flipper::Cloud")
     end
   end
 

--- a/spec/flipper/ui_spec.rb
+++ b/spec/flipper/ui_spec.rb
@@ -32,7 +32,7 @@ RSpec.describe Flipper::UI do
 
   describe 'Inspecting the built Rack app' do
     it 'returns a String' do
-      expect(build_app(flipper).inspect).to be_a(String)
+      expect(build_app(flipper).inspect).to eq("Flipper::UI")
     end
   end
 


### PR DESCRIPTION
`rails routes` use to have pretty output. Then we added `to_app` on the builder call in https://github.com/jnunemaker/flipper/pull/606, which was good but broke the output. 

This fixes the output and changes the spec to ensure we don't break in the future. 

Additionally, I added the performance improvement in https://github.com/jnunemaker/flipper/pull/606 to the API and Cloud apps and ensured there output is correct.

Lastly, I bumped the rack-protection dependency version up to make it so 2.2 works as well. This should fix the problem in #617.

closes #614 
closes #617 