### PR TITLE
Add kwargs for method_missing using ruby 3.0

### DIFF
--- a/lib/flipper/types/actor.rb
+++ b/lib/flipper/types/actor.rb
@@ -23,8 +23,14 @@ module Flipper
         super || @thing.respond_to?(*args)
       end
 
-      def method_missing(name, *args, &block)
-        @thing.send name, *args, &block
+      if RUBY_VERSION >= '3.0'
+        def method_missing(name, *args, **kwargs, &block)
+          @thing.send name, *args, **kwargs, &block
+        end
+      else
+        def method_missing(name, *args, &block)
+          @thing.send name, *args, &block
+        end
       end
     end
   end


### PR DESCRIPTION
`kwargs` are not supported for ruby 3.0 for `method_missing`

`method_missing` is called in blocks of flippers groups when calling method of `actor`
(https://www.flippercloud.io/docs/features#enablement-group)