### PR TITLE
failsafe adapter

### DIFF
--- a/lib/flipper/adapters/failsafe.rb
+++ b/lib/flipper/adapters/failsafe.rb
@@ -1,0 +1,76 @@
+module Flipper
+  module Adapters
+    class Failsafe
+      include ::Flipper::Adapter
+
+      # Public: The name of the adapter.
+      attr_reader :name
+
+      # Public: Build a new Failsafe instance.
+      #
+      # adapter   - Flipper adapter to guard.
+      # options   - Hash of options:
+      #             :errors - Array of exception types for which to fail safe
+
+      def initialize(adapter, options = {})
+        @adapter = adapter
+        @errors = options.fetch(:errors, [StandardError])
+        @name = :failsafe
+      end
+
+      def features
+        @adapter.features
+      rescue *@errors
+        Set.new
+      end
+
+      def add(feature)
+        @adapter.add(feature)
+      rescue *@errors
+        false
+      end
+
+      def remove(feature)
+        @adapter.remove(feature)
+      rescue *@errors
+        false
+      end
+
+      def clear(feature)
+        @adapter.clear(feature)
+      rescue *@errors
+        false
+      end
+
+      def get(feature)
+        @adapter.get(feature)
+      rescue *@errors
+        {}
+      end
+
+      def get_multi(features)
+        @adapter.get_multi(features)
+      rescue *@errors
+        {}
+      end
+
+      def get_all
+        @adapter.get_all
+      rescue *@errors
+        {}
+      end
+
+      def enable(feature, gate, thing)
+        @adapter.enable(feature, gate, thing)
+      rescue *@errors
+        false
+      end
+
+      def disable(feature, gate, thing)
+        @adapter.disable(feature, gate, thing)
+      rescue *@errors
+        false
+      end
+    end
+  end
+end

--- a/spec/flipper/adapters/failsafe_spec.rb
+++ b/spec/flipper/adapters/failsafe_spec.rb
@@ -1,0 +1,58 @@
+require 'flipper/adapters/failsafe'
+
+RSpec.describe Flipper::Adapters::Failsafe do
+  subject { described_class.new(memory_adapter, options) }
+
+  let(:memory_adapter) { Flipper::Adapters::Memory.new }
+  let(:options) { {} }
+  let(:flipper) { Flipper.new(subject) }
+
+  it_should_behave_like 'a flipper adapter'
+
+  context 'when disaster strikes' do
+    before do
+      expect(flipper[feature.name].enable).to be(true)
+
+      (subject.methods - Object.methods).each do |method_name|
+        allow(memory_adapter).to receive(method_name).and_raise(IOError)
+      end
+    end
+
+    let(:feature) { Flipper::Feature.new(:my_feature, subject) }
+
+    it { expect(subject.features).to eq(Set.new) }
+    it { expect(feature.add).to eq(false) }
+    it { expect(feature.remove).to eq(false) }
+    it { expect(feature.clear).to eq(false) }
+    it { expect(subject.get(feature)).to eq({}) }
+    it { expect(subject.get_multi([feature])).to eq({}) }
+    it { expect(subject.get_all).to eq({}) }
+    it { expect(feature.enable).to eq(false) }
+    it { expect(feature.disable).to eq(false) }
+
+    context 'when used via Flipper' do
+      it { expect(flipper.features).to eq(Set.new) }
+      it { expect(flipper[feature.name].enabled?).to eq(false) }
+      it { expect(flipper[feature.name].enable).to eq(false) }
+      it { expect(flipper[feature.name].disable).to eq(false) }
+    end
+
+    context 'when there is a syntax error' do
+      let(:test) { flipper[feature.name].enabled? }
+
+      before do
+        expect(memory_adapter).to receive(:get).and_raise(SyntaxError)
+      end
+
+      it 'does not catch this type of error' do
+        expect { test }.to raise_error(SyntaxError)
+      end
+
+      context 'when configured to catch SyntaxError' do
+        let(:options) { { errors: [SyntaxError] } }
+
+        it { expect(test).to eq(false) }
+      end
+    end
+  end
+end


### PR DESCRIPTION
Create an adapter that fails safe, ie. closed, when issues arise.  This protects against issues like network hiccups or Redis crashes from taking down an application using Flipper.