### PR TITLE
Remove deprecations

### DIFF
--- a/lib/flipper/cloud.rb
+++ b/lib/flipper/cloud.rb
@@ -15,14 +15,7 @@ module Flipper
     # options - The Hash of options. See Flipper::Cloud::Configuration.
     # block - The block that configuration will be yielded to allowing you to
     #         customize this cloud instance and its adapter.
-    def self.new(options = {}, deprecated_options = {})
-      if options.is_a?(String)
-        warn "`Flipper::Cloud.new(token)` is deprecated. Use `Flipper::Cloud.new(token: token)` " +
-          "or set the `FLIPPER_CLOUD_TOKEN` environment variable.\n" +
-          caller[0]
-        options = deprecated_options.merge(token: options)
-      end
-
+    def self.new(options = {})
       configuration = Configuration.new(options)
       yield configuration if block_given?
       DSL.new(configuration)

--- a/lib/flipper/cloud/configuration.rb
+++ b/lib/flipper/cloud/configuration.rb
@@ -73,11 +73,6 @@ module Flipper
           raise ArgumentError, "Flipper::Cloud token is missing. Please set FLIPPER_CLOUD_TOKEN or provide the token (e.g. Flipper::Cloud.new(token: 'token'))."
         end
 
-        if ENV["FLIPPER_CLOUD_SYNC_METHOD"]
-          warn "FLIPPER_CLOUD_SYNC_METHOD is deprecated and has no effect."
-        end
-        self.sync_method = options[:sync_method] if options[:sync_method]
-
         @read_timeout = options.fetch(:read_timeout) { ENV.fetch("FLIPPER_CLOUD_READ_TIMEOUT", 5).to_f }
         @open_timeout = options.fetch(:open_timeout) { ENV.fetch("FLIPPER_CLOUD_OPEN_TIMEOUT", 5).to_f }
         @write_timeout = options.fetch(:write_timeout) { ENV.fetch("FLIPPER_CLOUD_WRITE_TIMEOUT", 5).to_f }
@@ -150,10 +145,6 @@ module Flipper
       # cloud. (default: :poll, will be :webhook if sync_secret is set).
       def sync_method
         sync_secret ? :webhook : :poll
-      end
-
-      def sync_method=(_)
-        warn "Flipper::Cloud: sync_method is deprecated and has no effect."
       end
 
       private

--- a/lib/flipper/errors.rb
+++ b/lib/flipper/errors.rb
@@ -12,27 +12,10 @@ module Flipper
   # Raised when attempting to declare a group name that has already been used.
   class DuplicateGroup < Error; end
 
-  # Raised when default instance not configured but there is an attempt to
-  # use it.
-  class DefaultNotSet < Flipper::Error
-    def initialize(message = nil)
-      warn "Flipper::DefaultNotSet is deprecated and will be removed in 1.0"
-      super
-    end
-  end
-
   # Raised when an invalid value is set to a configuration property
   class InvalidConfigurationValue < Flipper::Error
     def initialize(message = nil)
       default = "Configuration value is not valid."
-      super(message || default)
-    end
-  end
-
-  # Raised when accessing a configuration property that has been deprecated
-  class ConfigurationDeprecated < Flipper::Error
-    def initialize(message = nil)
-      default = "The configuration property has been deprecated"
       super(message || default)
     end
   end

--- a/lib/flipper/middleware/memoizer.rb
+++ b/lib/flipper/middleware/memoizer.rb
@@ -25,11 +25,6 @@ module Flipper
           raise 'Flipper::Middleware::Memoizer no longer initializes with a flipper instance or block. Read more at: https://git.io/vSo31.'
         end
 
-        if opts[:preload_all]
-          warn "Flipper::Middleware::Memoizer: `preload_all` is deprecated, use `preload: true`"
-          opts[:preload] = true
-        end
-
         @app = app
         @opts = opts
         @env_key = opts.fetch(:env_key, 'flipper')

--- a/lib/flipper/ui.rb
+++ b/lib/flipper/ui.rb
@@ -14,24 +14,6 @@ require 'flipper/ui/configuration'
 
 module Flipper
   module UI
-    class << self
-      # These three configuration options have been moved to Flipper::UI::Configuration
-      deprecated_configuration_options = %w(application_breadcrumb_href
-                                            feature_creation_enabled
-                                            feature_removal_enabled)
-      deprecated_configuration_options.each do |attribute_name|
-        send(:define_method, "#{attribute_name}=".to_sym) do
-          raise ConfigurationDeprecated, "The UI configuration for #{attribute_name} has " \
-            "deprecated. This configuration option has moved to Flipper::UI::Configuration"
-        end
-
-        send(:define_method, attribute_name.to_sym) do
-          raise ConfigurationDeprecated, "The UI configuration for #{attribute_name} has " \
-            "deprecated. This configuration option has moved to Flipper::UI::Configuration"
-        end
-      end
-    end
-
     def self.root
       @root ||= Pathname(__FILE__).dirname.expand_path.join('ui')
     end

--- a/spec/flipper/ui_spec.rb
+++ b/spec/flipper/ui_spec.rb
@@ -45,27 +45,6 @@ RSpec.describe Flipper::UI do
     expect(last_response.headers['Location']).to eq('/features/refactor-images')
   end
 
-  describe "application_breadcrumb_href" do
-    it "raises an exception since it is deprecated" do
-      expect { described_class.application_breadcrumb_href }
-        .to raise_error(Flipper::ConfigurationDeprecated)
-    end
-  end
-
-  describe "feature_creation_enabled" do
-    it "raises an exception since it is deprecated" do
-      expect { described_class.feature_creation_enabled }
-        .to raise_error(Flipper::ConfigurationDeprecated)
-    end
-  end
-
-  describe "feature_removal_enabled" do
-    it "raises an exception since it is deprecated" do
-      expect { described_class.feature_removal_enabled }
-        .to raise_error(Flipper::ConfigurationDeprecated)
-    end
-  end
-
   describe 'configure' do
     it 'yields configuration instance' do
       described_class.configure do |config|


### PR DESCRIPTION
This removes existing deprecations and warnings. All of these have been around for at least a year (since 0.21), if not longer.