### PR TITLE
ActiveRecord: base class for internal models

### DIFF
--- a/lib/flipper/adapters/active_record.rb
+++ b/lib/flipper/adapters/active_record.rb
@@ -7,6 +7,7 @@ module Flipper
     class ActiveRecord
       include ::Flipper::Adapter
 
+      # Abstract base class for internal models
       class Model < ::ActiveRecord::Base
         self.abstract_class = true
       end
@@ -110,7 +111,7 @@ module Flipper
         rows_query = features.join(gates, Arel::Nodes::OuterJoin)
           .on(features[:key].eq(gates[:feature_key]))
           .project(features[:key].as('feature_key'), gates[:key], gates[:value])
-        rows = Model.connection.select_all rows_query
+        rows = @feature_class.connection.select_all rows_query
         db_gates = rows.map { |row| Gate.new(row) }
         grouped_db_gates = db_gates.group_by(&:feature_key)
         result = Hash.new { |hash, key| hash[key] = default_config }

--- a/lib/flipper/adapters/active_record.rb
+++ b/lib/flipper/adapters/active_record.rb
@@ -7,21 +7,25 @@ module Flipper
     class ActiveRecord
       include ::Flipper::Adapter
 
+      class Model < ::ActiveRecord::Base
+        self.abstract_class = true
+      end
+
       # Private: Do not use outside of this adapter.
-      class Feature < ::ActiveRecord::Base
+      class Feature < Model
         self.table_name = [
-          ::ActiveRecord::Base.table_name_prefix,
+          Model.table_name_prefix,
           "flipper_features",
-          ::ActiveRecord::Base.table_name_suffix,
+          Model.table_name_suffix,
         ].join
       end
 
       # Private: Do not use outside of this adapter.
-      class Gate < ::ActiveRecord::Base
+      class Gate < Model
         self.table_name = [
-          ::ActiveRecord::Base.table_name_prefix,
+          Model.table_name_prefix,
           "flipper_gates",
-          ::ActiveRecord::Base.table_name_suffix,
+          Model.table_name_suffix,
         ].join
       end
 
@@ -106,7 +110,7 @@ module Flipper
         rows_query = features.join(gates, Arel::Nodes::OuterJoin)
           .on(features[:key].eq(gates[:feature_key]))
           .project(features[:key].as('feature_key'), gates[:key], gates[:value])
-        rows = ::ActiveRecord::Base.connection.select_all rows_query
+        rows = Model.connection.select_all rows_query
         db_gates = rows.map { |row| Gate.new(row) }
         grouped_db_gates = db_gates.group_by(&:feature_key)
         result = Hash.new { |hash, key| hash[key] = default_config }


### PR DESCRIPTION
Alternative approach to #628 to ease connecting to alternate database. This defines an abstract base class for Flipper's internal ActiveRecord models, which can be used to configure connection handling and probably other options. It also switches from using `ActiveRecord::Base` to the internal `Feature` class (or the `feature_class` option passed when the adapter is initialized) to get a new connection.

This allows configuring connection options:

```ruby
# config/initializers/flipper.rb

Flipper::Adapters::ActiveRecord::Model.connects_to database: {
  writing: :flipper, reading: :flipper_replica
}
```

cc @ceritium