### PR TITLE
Remove use of Rack::BodyProxy

### DIFF
--- a/lib/flipper/middleware/memoizer.rb
+++ b/lib/flipper/middleware/memoizer.rb
@@ -74,14 +74,9 @@ module Flipper
         when Array then flipper.preload(@opts[:preload])
         end
 
-        response = @app.call(env)
-        response[2] = Rack::BodyProxy.new(response[2]) do
-          flipper.memoize = false
-        end
-        reset_on_body_close = true
-        response
+        @app.call(env)
       ensure
-        flipper.memoize = false if flipper && !reset_on_body_close
+        flipper.memoize = false if flipper
       end
     end
   end

--- a/spec/flipper/middleware/memoizer_spec.rb
+++ b/spec/flipper/middleware/memoizer_spec.rb
@@ -38,26 +38,6 @@ RSpec.describe Flipper::Middleware::Memoizer do
       expect(called).to eq(true)
     end
 
-    it 'disables local cache after body close' do
-      app = ->(_env) { [200, {}, []] }
-      middleware = described_class.new(app)
-      body = middleware.call(env).last
-
-      expect(flipper.memoizing?).to eq(true)
-      body.close
-      expect(flipper.memoizing?).to eq(false)
-    end
-
-    it 'clears local cache after body close' do
-      app = ->(_env) { [200, {}, []] }
-      middleware = described_class.new(app)
-      body = middleware.call(env).last
-
-      flipper.adapter.cache['hello'] = 'world'
-      body.close
-      expect(flipper.adapter.cache).to be_empty
-    end
-
     it 'clears the local cache with a successful request' do
       flipper.adapter.cache['hello'] = 'world'
       get '/', {}, 'flipper' => flipper


### PR DESCRIPTION
Rack::BodyProxy allows deferring execution until after the response has sent to the client. It's intended for expensive cleanup (after the response is rendered, but before it's sent) that could delay delivering the response to the client. Cleaning up memoization is not an expensive operation, and I suspect this use of BodyProxy is the source for warnings in https://github.com/jnunemaker/flipper/issues/604.

I haven't studied it closely, but my guess is that after this middleware returns the rendered response body, puma (or possibly  any threaded web server) delivers the response to the client in another thread, returning execution of the app thread to Rails to start the next request. If the next request starts before the previous one is finished sending, then the next request will produce the warning.

_Updated to added more details._