### PR TITLE
Global instrumenter configuration

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -3,6 +3,17 @@
 ### Additions/Changes
 
 * Added failsafe adapter (https://github.com/jnunemaker/flipper/pull/626)
+* Deprecate `instrumenter:` option everywhere in favor of global config. If you are manually configuring the instrumenter, you will need to update your configuration:
+    ```diff
+    # config/initializers/flipper.rb
+      Flipper.configure do |config|
+        config.adapter do
+    -     Flipper::Adapters::Instrumented.new(my_adapter, instrumenter: MyInstrumenter)
+    +     Flipper::Adapters::Instrumented.new(my_adapter)
+        end
+    +   config.instrumenter MyInstrumenter
+      end
+    ```
 
 ## 0.24.1
 

--- a/examples/api/custom_memoized.ru
+++ b/examples/api/custom_memoized.ru
@@ -10,15 +10,15 @@
 #
 
 require 'bundler/setup'
-require "active_support/notifications"
+require 'active_support'
+require 'active_support/notifications'
 require "flipper/api"
 require "flipper/adapters/pstore"
 
-adapter = Flipper::Adapters::Instrumented.new(
-  Flipper::Adapters::PStore.new,
-  instrumenter: ActiveSupport::Notifications,
-)
-flipper = Flipper.new(adapter)
+Flipper.configure do |config|
+  config.instrumenter ActiveSupport::Notifications
+  config.adapter { Flipper::Adapters::Instrumented.new(Flipper::Adapters::PStore.new) }
+end
 
 ActiveSupport::Notifications.subscribe(/.*/, ->(*args) {
   name, start, finish, id, data = args
@@ -31,7 +31,6 @@ ActiveSupport::Notifications.subscribe(/.*/, ->(*args) {
 # You can uncomment this to get some default data:
 # flipper[:logging].enable_percentage_of_time 5
 
-run Flipper::Api.app(flipper) { |builder|
-  builder.use Flipper::Middleware::SetupEnv, flipper
+run Flipper::Api.app { |builder|
   builder.use Flipper::Middleware::Memoizer, preload: true
 }

--- a/examples/api/memoized.ru
+++ b/examples/api/memoized.ru
@@ -10,16 +10,15 @@
 #
 
 require 'bundler/setup'
+require 'active_support'
 require "active_support/notifications"
 require "flipper/api"
 require "flipper/adapters/pstore"
 
 Flipper.configure do |config|
+  config.instrumenter ActiveSupport::Notifications
   config.adapter {
-    Flipper::Adapters::Instrumented.new(
-      Flipper::Adapters::PStore.new,
-      instrumenter: ActiveSupport::Notifications,
-    )
+    Flipper::Adapters::Instrumented.new(Flipper::Adapters::PStore.new)
   }
 end
 

--- a/examples/instrumentation.rb
+++ b/examples/instrumentation.rb
@@ -1,5 +1,6 @@
 require 'bundler/setup'
 require 'securerandom'
+require 'active_support'
 require 'active_support/notifications'
 
 class FlipperSubscriber
@@ -14,17 +15,13 @@ end
 require 'flipper'
 require 'flipper/adapters/instrumented'
 
-# pick an adapter
-adapter = Flipper::Adapters::Memory.new
-
-# instrument it if you want, if not you still get the feature instrumentation
-instrumented = Flipper::Adapters::Instrumented.new(adapter, :instrumenter => ActiveSupport::Notifications)
-
-# get a handy dsl instance
-flipper = Flipper.new(instrumented, :instrumenter => ActiveSupport::Notifications)
+Flipper.configure do |config|
+  config.instrumenter ActiveSupport::Notifications
+  config.adapter { Flipper::Adapters::Instrumented.new(Flipper::Adapters::Memory.new) }
+end
 
 # grab a feature
-search = flipper[:search]
+search = Flipper[:search]
 
 perform = lambda do
   # check if that feature is enabled

--- a/examples/instrumentation_last_accessed_at.rb
+++ b/examples/instrumentation_last_accessed_at.rb
@@ -1,6 +1,7 @@
 # Quick example of how to keep track of when a feature was last checked.
 require 'bundler/setup'
 require 'securerandom'
+require 'active_support'
 require 'active_support/notifications'
 require 'flipper'
 
@@ -20,9 +21,7 @@ class FlipperSubscriber
 end
 
 Flipper.configure do |config|
-  config.default {
-    Flipper.new(config.adapter, instrumenter: ActiveSupport::Notifications)
-  }
+  config.instrumenter ActiveSupport::Notifications
 end
 
 Flipper.enabled?(:search)

--- a/lib/flipper.rb
+++ b/lib/flipper.rb
@@ -68,7 +68,15 @@ module Flipper
                  :memoize=, :memoizing?,
                  :sync, :sync_secret # For Flipper::Cloud. Will error for OSS Flipper.
 
+  # Public: Get or set the configured instrumenter.
   def_delegators :configuration, :instrumenter, :instrumenter=
+
+  # Public: Instrument a call using the configured instrumenter.
+  #
+  #   Flipper.instrument(name, payload) do |payload|
+  #     payload[:result] = something
+  #   end
+  #
   def_delegators :instrumenter, :instrument
 
   # Public: Use this to register a group by name.
@@ -143,6 +151,7 @@ module Flipper
   end
 end
 
+require 'flipper/deprecated_instrumenter'
 require 'flipper/actor'
 require 'flipper/adapter'
 require 'flipper/adapters/memoizable'

--- a/lib/flipper.rb
+++ b/lib/flipper.rb
@@ -68,6 +68,9 @@ module Flipper
                  :memoize=, :memoizing?,
                  :sync, :sync_secret # For Flipper::Cloud. Will error for OSS Flipper.
 
+  def_delegators :configuration, :instrumenter, :instrumenter=
+  def_delegators :instrumenter, :instrument
+
   # Public: Use this to register a group by name.
   #
   # name - The Symbol name of the group.

--- a/lib/flipper/adapters/instrumented.rb
+++ b/lib/flipper/adapters/instrumented.rb
@@ -6,6 +6,7 @@ module Flipper
     # operations.
     class Instrumented < SimpleDelegator
       include ::Flipper::Adapter
+      include DeprecatedInstrumenter
 
       # Private: The name of instrumentation events.
       InstrumentationName = "adapter_operation.#{InstrumentationNamespace}".freeze
@@ -17,8 +18,9 @@ module Flipper
       #
       # adapter - Vanilla adapter instance to wrap.
       #
-      def initialize(adapter)
+      def initialize(adapter, options = {})
         super(adapter)
+        deprecated_instrumenter_option options
         @adapter = adapter
         @name = :instrumented
       end

--- a/lib/flipper/adapters/instrumented.rb
+++ b/lib/flipper/adapters/instrumented.rb
@@ -10,9 +10,6 @@ module Flipper
       # Private: The name of instrumentation events.
       InstrumentationName = "adapter_operation.#{InstrumentationNamespace}".freeze
 
-      # Private: What is used to instrument all the things.
-      attr_reader :instrumenter
-
       # Public: The name of the adapter.
       attr_reader :name
 
@@ -20,14 +17,10 @@ module Flipper
       #
       # adapter - Vanilla adapter instance to wrap.
       #
-      # options - The Hash of options.
-      #           :instrumenter - What to use to instrument all the things.
-      #
-      def initialize(adapter, options = {})
+      def initialize(adapter)
         super(adapter)
         @adapter = adapter
         @name = :instrumented
-        @instrumenter = options.fetch(:instrumenter, Instrumenters::Noop)
       end
 
       # Public
@@ -37,7 +30,7 @@ module Flipper
           adapter_name: @adapter.name,
         }
 
-        @instrumenter.instrument(InstrumentationName, default_payload) do |payload|
+        Flipper.instrument(InstrumentationName, default_payload) do |payload|
           payload[:result] = @adapter.features
         end
       end
@@ -50,7 +43,7 @@ module Flipper
           feature_name: feature.name,
         }
 
-        @instrumenter.instrument(InstrumentationName, default_payload) do |payload|
+        Flipper.instrument(InstrumentationName, default_payload) do |payload|
           payload[:result] = @adapter.add(feature)
         end
       end
@@ -63,7 +56,7 @@ module Flipper
           feature_name: feature.name,
         }
 
-        @instrumenter.instrument(InstrumentationName, default_payload) do |payload|
+        Flipper.instrument(InstrumentationName, default_payload) do |payload|
           payload[:result] = @adapter.remove(feature)
         end
       end
@@ -76,7 +69,7 @@ module Flipper
           feature_name: feature.name,
         }
 
-        @instrumenter.instrument(InstrumentationName, default_payload) do |payload|
+        Flipper.instrument(InstrumentationName, default_payload) do |payload|
           payload[:result] = @adapter.clear(feature)
         end
       end
@@ -89,7 +82,7 @@ module Flipper
           feature_name: feature.name,
         }
 
-        @instrumenter.instrument(InstrumentationName, default_payload) do |payload|
+        Flipper.instrument(InstrumentationName, default_payload) do |payload|
           payload[:result] = @adapter.get(feature)
         end
       end
@@ -101,7 +94,7 @@ module Flipper
           feature_names: features.map(&:name),
         }
 
-        @instrumenter.instrument(InstrumentationName, default_payload) do |payload|
+        Flipper.instrument(InstrumentationName, default_payload) do |payload|
           payload[:result] = @adapter.get_multi(features)
         end
       end
@@ -112,7 +105,7 @@ module Flipper
           adapter_name: @adapter.name,
         }
 
-        @instrumenter.instrument(InstrumentationName, default_payload) do |payload|
+        Flipper.instrument(InstrumentationName, default_payload) do |payload|
           payload[:result] = @adapter.get_all
         end
       end
@@ -127,7 +120,7 @@ module Flipper
           thing_value: thing.value,
         }
 
-        @instrumenter.instrument(InstrumentationName, default_payload) do |payload|
+        Flipper.instrument(InstrumentationName, default_payload) do |payload|
           payload[:result] = @adapter.enable(feature, gate, thing)
         end
       end
@@ -142,7 +135,7 @@ module Flipper
           thing_value: thing.value,
         }
 
-        @instrumenter.instrument(InstrumentationName, default_payload) do |payload|
+        Flipper.instrument(InstrumentationName, default_payload) do |payload|
           payload[:result] = @adapter.disable(feature, gate, thing)
         end
       end

--- a/lib/flipper/adapters/sync.rb
+++ b/lib/flipper/adapters/sync.rb
@@ -29,8 +29,6 @@ module Flipper
           sync_options = {
             raise: false,
           }
-          instrumenter = options[:instrumenter]
-          sync_options[:instrumenter] = instrumenter if instrumenter
           synchronizer = Synchronizer.new(@local, @remote, sync_options)
           IntervalSynchronizer.new(synchronizer, interval: options[:interval])
         end

--- a/lib/flipper/adapters/sync.rb
+++ b/lib/flipper/adapters/sync.rb
@@ -7,6 +7,7 @@ module Flipper
     # rather than in the main thread only when reads happen.
     class Sync
       include ::Flipper::Adapter
+      include DeprecatedInstrumenter
 
       # Public: The name of the adapter.
       attr_reader :name
@@ -22,6 +23,7 @@ module Flipper
       # interval - The Float or Integer number of seconds between syncs from
       # remote to local. Default value is set in IntervalSynchronizer.
       def initialize(local, remote, options = {})
+        deprecated_instrumenter_option options
         @name = :sync
         @local = local
         @remote = remote

--- a/lib/flipper/adapters/sync/synchronizer.rb
+++ b/lib/flipper/adapters/sync/synchronizer.rb
@@ -8,6 +8,8 @@ module Flipper
       # Public: Given a local and remote adapter, it can update the local to
       # match the remote doing only the necessary enable/disable operations.
       class Synchronizer
+        include DeprecatedInstrumenter
+
         # Public: Initializes a new synchronizer.
         #
         # local - The Flipper adapter to get in sync with the remote.
@@ -16,6 +18,7 @@ module Flipper
         # options - The Hash of options.
         #           :raise - Should errors be raised (default: true).
         def initialize(local, remote, options = {})
+          deprecated_instrumenter_option options
           @local = local
           @remote = remote
           @raise = options.fetch(:raise, true)

--- a/lib/flipper/adapters/sync/synchronizer.rb
+++ b/lib/flipper/adapters/sync/synchronizer.rb
@@ -14,18 +14,16 @@ module Flipper
         # remote - The Flipper adapter that is source of truth that the local
         #          adapter should be brought in line with.
         # options - The Hash of options.
-        #           :instrumenter - The instrumenter used to instrument.
         #           :raise - Should errors be raised (default: true).
         def initialize(local, remote, options = {})
           @local = local
           @remote = remote
-          @instrumenter = options.fetch(:instrumenter, Instrumenters::Noop)
           @raise = options.fetch(:raise, true)
         end
 
         # Public: Forces a sync.
         def call
-          @instrumenter.instrument("synchronizer_call.flipper") { sync }
+          Flipper.instrument("synchronizer_call.flipper") { sync }
         end
 
         private
@@ -54,7 +52,7 @@ module Flipper
 
           nil
         rescue => exception
-          @instrumenter.instrument("synchronizer_exception.flipper", exception: exception)
+          Flipper.instrument("synchronizer_exception.flipper", exception: exception)
           raise if @raise
         end
       end

--- a/lib/flipper/cloud/configuration.rb
+++ b/lib/flipper/cloud/configuration.rb
@@ -41,14 +41,6 @@ module Flipper
       #  configuration.debug_output = STDOUT
       attr_accessor :debug_output
 
-      # Public: Instrumenter to use for the Flipper instance returned by
-      #         Flipper::Cloud.new (default: Flipper::Instrumenters::Noop).
-      #
-      #  # for example, to use active support notifications you could do:
-      #  configuration = Flipper::Cloud::Configuration.new
-      #  configuration.instrumenter = ActiveSupport::Notifications
-      attr_accessor :instrumenter
-
       # Public: Local adapter that all reads should go to in order to ensure
       # latency is low and resiliency is high. This adapter is automatically
       # kept in sync with cloud.
@@ -88,14 +80,11 @@ module Flipper
         @adapter_block = ->(adapter) { adapter }
         self.url = options.fetch(:url) { ENV.fetch("FLIPPER_CLOUD_URL", DEFAULT_URL) }
 
-        instrumenter = options.fetch(:instrumenter, Instrumenters::Noop)
-
         # This is alpha. Don't use this unless you are me. And you are not me.
         cloud_instrument = options.fetch(:cloud_instrument) { ENV["FLIPPER_CLOUD_INSTRUMENT"] == "1" }
-        @instrumenter = if cloud_instrument
-          Instrumenter.new(brow: brow, instrumenter: instrumenter)
-        else
-          instrumenter
+        if cloud_instrument
+          # FIXME: replace with a subscriber to AS::Notifications
+          Flipper.instrumenter Instrumenter.new(brow: brow, instrumenter: Flipper.instrumenter)
         end
       end
 
@@ -123,7 +112,6 @@ module Flipper
 
       def sync
         Flipper::Adapters::Sync::Synchronizer.new(local_adapter, http_adapter, {
-          instrumenter: instrumenter,
           interval: sync_interval,
         }).call
       end
@@ -168,7 +156,6 @@ module Flipper
 
       def sync_adapter
         Flipper::Adapters::Sync.new(local_adapter, http_adapter, {
-          instrumenter: instrumenter,
           interval: sync_interval,
         })
       end

--- a/lib/flipper/cloud/configuration.rb
+++ b/lib/flipper/cloud/configuration.rb
@@ -3,7 +3,6 @@ require "flipper/adapters/http"
 require "flipper/adapters/memory"
 require "flipper/adapters/dual_write"
 require "flipper/adapters/sync"
-require "flipper/cloud/instrumenter"
 require "flipper/cloud/registry"
 require "brow"
 
@@ -83,8 +82,12 @@ module Flipper
         # This is alpha. Don't use this unless you are me. And you are not me.
         cloud_instrument = options.fetch(:cloud_instrument) { ENV["FLIPPER_CLOUD_INSTRUMENT"] == "1" }
         if cloud_instrument
-          # FIXME: replace with a subscriber to AS::Notifications
-          Flipper.instrumenter Instrumenter.new(brow: brow, instrumenter: Flipper.instrumenter)
+          require 'flipper/instrumentation/cloud_subscriber'
+
+          Flipper.instrumenter.subscribe(
+            Flipper::Feature::InstrumentationName,
+            Flipper::Instrumentation::CloudSubscriber.new(brow)
+          )
         end
       end
 

--- a/lib/flipper/cloud/configuration.rb
+++ b/lib/flipper/cloud/configuration.rb
@@ -9,6 +9,8 @@ require "brow"
 module Flipper
   module Cloud
     class Configuration
+      include DeprecatedInstrumenter
+
       # The set of valid ways that syncing can happpen.
       VALID_SYNC_METHODS = Set[
         :poll,
@@ -58,6 +60,7 @@ module Flipper
       attr_accessor :sync_secret
 
       def initialize(options = {})
+        deprecated_instrumenter_option options
         @token = options.fetch(:token) { ENV["FLIPPER_CLOUD_TOKEN"] }
 
         if @token.nil?

--- a/lib/flipper/cloud/dsl.rb
+++ b/lib/flipper/cloud/dsl.rb
@@ -7,7 +7,7 @@ module Flipper
 
       def initialize(cloud_configuration)
         @cloud_configuration = cloud_configuration
-        super Flipper.new(@cloud_configuration.adapter, instrumenter: @cloud_configuration.instrumenter)
+        super Flipper.new(@cloud_configuration.adapter)
       end
 
       def sync

--- a/lib/flipper/cloud/engine.rb
+++ b/lib/flipper/cloud/engine.rb
@@ -13,10 +13,7 @@ module Flipper
         Flipper.configure do |config|
           config.default do
             if ENV["FLIPPER_CLOUD_TOKEN"]
-              Flipper::Cloud.new(
-                local_adapter: config.adapter,
-                instrumenter: app.config.flipper.instrumenter
-              )
+              Flipper::Cloud.new(local_adapter: config.adapter)
             else
               warn "Missing FLIPPER_CLOUD_TOKEN environment variable. Disabling Flipper::Cloud."
               Flipper.new(config.adapter)

--- a/lib/flipper/cloud/instrumenter.rb
+++ b/lib/flipper/cloud/instrumenter.rb
@@ -4,14 +4,13 @@ require "flipper/instrumenters/noop"
 module Flipper
   module Cloud
     class Instrumenter < SimpleDelegator
-      def initialize(options = {})
+      def initialize(instrumenter: Flipper.instrumenter)
         @brow = options.fetch(:brow)
-        @instrumenter = options.fetch(:instrumenter, Instrumenters::Noop)
-        super @instrumenter
+        super instrumenter
       end
 
       def instrument(name, payload = {}, &block)
-        result = @instrumenter.instrument(name, payload, &block)
+        result = Flipper.instrument(name, payload, &block)
         push name, payload
         result
       end

--- a/lib/flipper/configuration.rb
+++ b/lib/flipper/configuration.rb
@@ -1,8 +1,11 @@
 module Flipper
   class Configuration
+    attr_accessor :instrumenter
+
     def initialize(options = {})
-      @default = -> { Flipper.new(adapter) }
-      @adapter = -> { Flipper::Adapters::Memory.new }
+      adapter { Flipper::Adapters::Memory.new }
+      default { Flipper.new(adapter) }
+      instrumenter Flipper::Instrumenters::Noop
     end
 
     # The default adapter to use.
@@ -54,5 +57,15 @@ module Flipper
         @default.call
       end
     end
+
+    # Configure or fetch the current instrumenter
+    #
+    #   Flipper.configure do |config|
+    #     config.instrumenter ActiveSupport::Notifications
+    #   end
+    def instrumenter(new_value = @instrumenter)
+      @instrumenter = new_value
+    end
+    alias :instrumenter= :instrumenter
   end
 end

--- a/lib/flipper/configuration.rb
+++ b/lib/flipper/configuration.rb
@@ -1,7 +1,5 @@
 module Flipper
   class Configuration
-    attr_accessor :instrumenter
-
     def initialize(options = {})
       adapter { Flipper::Adapters::Memory.new }
       default { Flipper.new(adapter) }

--- a/lib/flipper/deprecated_instrumenter.rb
+++ b/lib/flipper/deprecated_instrumenter.rb
@@ -1,0 +1,18 @@
+module Flipper
+  # Private: Deprecation warnings for instrumenter option
+  module DeprecatedInstrumenter
+    def deprecated_instrumenter_option options
+      if options.has_key?(:instrumenter)
+        warn "The `:instrumenter` option is deprecated and has no effect. Set `Flipper.instrumenter` globally."
+        warn caller[1]
+      end
+    end
+
+    def instrumenter
+      warn "`#instrumenter` is deprecated. Use `Flipper.instrument` or `Flipper.instrumenter` instead."
+      warn caller[0]
+
+      Flipper.instrumenter
+    end
+  end
+end

--- a/lib/flipper/dsl.rb
+++ b/lib/flipper/dsl.rb
@@ -3,6 +3,7 @@ require 'forwardable'
 module Flipper
   class DSL
     extend Forwardable
+    include DeprecatedInstrumenter
 
     # Private
     attr_reader :adapter
@@ -15,6 +16,7 @@ module Flipper
     # options - The Hash of options.
     #           :memoize - Should adapter be wrapped by memoize adapter or not.
     def initialize(adapter, options = {})
+      deprecated_instrumenter_option options
       memoize = options.fetch(:memoize, true)
       adapter = Adapters::Memoizable.new(adapter) if memoize
       @adapter = adapter

--- a/lib/flipper/dsl.rb
+++ b/lib/flipper/dsl.rb
@@ -7,19 +7,14 @@ module Flipper
     # Private
     attr_reader :adapter
 
-    # Private: What is being used to instrument all the things.
-    attr_reader :instrumenter
-
     def_delegators :@adapter, :memoize=, :memoizing?
 
     # Public: Returns a new instance of the DSL.
     #
     # adapter - The adapter that this DSL instance should use.
     # options - The Hash of options.
-    #           :instrumenter - What should be used to instrument all the things.
     #           :memoize - Should adapter be wrapped by memoize adapter or not.
     def initialize(adapter, options = {})
-      @instrumenter = options.fetch(:instrumenter, Instrumenters::Noop)
       memoize = options.fetch(:memoize, true)
       adapter = Adapters::Memoizable.new(adapter) if memoize
       @adapter = adapter
@@ -181,7 +176,7 @@ module Flipper
         raise ArgumentError, "#{name} must be a String or Symbol"
       end
 
-      @memoized_features[name.to_sym] ||= Feature.new(name, @adapter, instrumenter: instrumenter)
+      @memoized_features[name.to_sym] ||= Feature.new(name, @adapter)
     end
 
     # Public: Preload the features with the given names.

--- a/lib/flipper/feature.rb
+++ b/lib/flipper/feature.rb
@@ -18,21 +18,14 @@ module Flipper
     # Private: The adapter this feature should use.
     attr_reader :adapter
 
-    # Private: What is being used to instrument all the things.
-    attr_reader :instrumenter
-
     # Internal: Initializes a new feature instance.
     #
     # name - The Symbol or String name of the feature.
     # adapter - The adapter that will be used to store details about this feature.
     #
-    # options - The Hash of options.
-    #           :instrumenter - What to use to instrument all the things.
-    #
-    def initialize(name, adapter, options = {})
+    def initialize(name, adapter)
       @name = name
       @key = name.to_s
-      @instrumenter = options.fetch(:instrumenter, Instrumenters::Noop)
       @adapter = adapter
     end
 
@@ -369,7 +362,7 @@ module Flipper
 
     # Private: Instrument a feature operation.
     def instrument(operation)
-      @instrumenter.instrument(InstrumentationName) do |payload|
+      Flipper.instrument(InstrumentationName) do |payload|
         payload[:feature_name] = name
         payload[:operation] = operation
         payload[:result] = yield(payload) if block_given?

--- a/lib/flipper/feature.rb
+++ b/lib/flipper/feature.rb
@@ -6,6 +6,8 @@ require 'flipper/gate_values'
 
 module Flipper
   class Feature
+    include DeprecatedInstrumenter
+
     # Private: The name of feature instrumentation events.
     InstrumentationName = "feature_operation.#{InstrumentationNamespace}".freeze
 
@@ -23,7 +25,8 @@ module Flipper
     # name - The Symbol or String name of the feature.
     # adapter - The adapter that will be used to store details about this feature.
     #
-    def initialize(name, adapter)
+    def initialize(name, adapter, options = {})
+      deprecated_instrumenter_option options
       @name = name
       @key = name.to_s
       @adapter = adapter

--- a/lib/flipper/instrumentation/cloud_subscriber.rb
+++ b/lib/flipper/instrumentation/cloud_subscriber.rb
@@ -1,18 +1,13 @@
-require "delegate"
-require "flipper/instrumenters/noop"
-
 module Flipper
-  module Cloud
-    class Instrumenter < SimpleDelegator
-      def initialize(instrumenter: Flipper.instrumenter)
-        @brow = options.fetch(:brow)
-        super instrumenter
+  module Instrumentation
+    # Report the result of feature checks to Flipper Cloud.
+    class CloudSubscriber
+      def initialize(brow)
+        @brow = brow
       end
 
-      def instrument(name, payload = {}, &block)
-        result = Flipper.instrument(name, payload, &block)
+      def call(name, start, finish, id, payload)
         push name, payload
-        result
       end
 
       private

--- a/lib/flipper/instrumentation/log_subscriber.rb
+++ b/lib/flipper/instrumentation/log_subscriber.rb
@@ -1,4 +1,5 @@
 require 'securerandom'
+require 'active_support'
 require 'active_support/notifications'
 require 'active_support/log_subscriber'
 

--- a/lib/flipper/instrumentation/statsd.rb
+++ b/lib/flipper/instrumentation/statsd.rb
@@ -1,4 +1,5 @@
 require 'securerandom'
+require 'active_support'
 require 'active_support/notifications'
 require 'flipper/instrumentation/statsd_subscriber'
 

--- a/lib/flipper/instrumenters/memory.rb
+++ b/lib/flipper/instrumenters/memory.rb
@@ -26,6 +26,11 @@ module Flipper
         @events << Event.new(name, payload, result)
       end
 
+      def self.subscribe(_name, _subscriber)
+        # noop
+      end
+
+
       def events_by_name(name)
         @events.select { |event| event.name == name }
       end

--- a/lib/flipper/instrumenters/memory.rb
+++ b/lib/flipper/instrumenters/memory.rb
@@ -26,10 +26,9 @@ module Flipper
         @events << Event.new(name, payload, result)
       end
 
-      def self.subscribe(_name, _subscriber)
+      def self.subscribe(_name, _callback = nil, &_block)
         # noop
       end
-
 
       def events_by_name(name)
         @events.select { |event| event.name == name }

--- a/lib/flipper/instrumenters/noop.rb
+++ b/lib/flipper/instrumenters/noop.rb
@@ -5,7 +5,7 @@ module Flipper
         yield payload if block_given?
       end
 
-      def self.subscribe(_name, _subscriber)
+      def self.subscribe(_name, _callback = nil, &_block)
         # noop
       end
     end

--- a/lib/flipper/instrumenters/noop.rb
+++ b/lib/flipper/instrumenters/noop.rb
@@ -4,6 +4,10 @@ module Flipper
       def self.instrument(_name, payload = {})
         yield payload if block_given?
       end
+
+      def self.subscribe(_name, _subscriber)
+        # noop
+      end
     end
   end
 end

--- a/lib/flipper/railtie.rb
+++ b/lib/flipper/railtie.rb
@@ -18,8 +18,9 @@ module Flipper
 
     initializer "flipper.default", before: :load_config_initializers do |app|
       Flipper.configure do |config|
+        config.instrumenter app.config.flipper.instrumenter
         config.default do
-          Flipper.new(config.adapter, instrumenter: app.config.flipper.instrumenter)
+          Flipper.new(config.adapter)
         end
       end
     end

--- a/spec/flipper/adapters/dual_write_spec.rb
+++ b/spec/flipper/adapters/dual_write_spec.rb
@@ -1,5 +1,6 @@
 require 'flipper/adapters/dual_write'
 require 'flipper/adapters/operation_logger'
+require 'active_support'
 require 'active_support/notifications'
 
 RSpec.describe Flipper::Adapters::DualWrite do

--- a/spec/flipper/adapters/failover_spec.rb
+++ b/spec/flipper/adapters/failover_spec.rb
@@ -84,21 +84,19 @@ RSpec.describe Flipper::Adapters::Failover do
   context 'when primary is instrumented and fails' do
     before do
       allow(memory_adapter).to receive(:get).and_raise(Net::ReadTimeout)
+      Flipper.instrumenter = instrumenter
     end
 
     let(:memory_adapter) { Flipper::Adapters::Memory.new }
     let(:primary) do
-      Flipper::Adapters::Instrumented.new(
-        memory_adapter,
-        instrumenter: instrumenter,
-      )
+      Flipper::Adapters::Instrumented.new(memory_adapter)
     end
     let(:instrumenter) { Flipper::Instrumenters::Memory.new }
 
     it 'logs the raised exception' do
       flipper[:flag].enabled?
 
-      expect(instrumenter.events.count).to be 1
+      expect(instrumenter.events.count).to be(2)
 
       payload = instrumenter.events[0].payload
       expect(payload.keys).to include(:exception, :exception_object)

--- a/spec/flipper/adapters/instrumented_spec.rb
+++ b/spec/flipper/adapters/instrumented_spec.rb
@@ -10,8 +10,12 @@ RSpec.describe Flipper::Adapters::Instrumented do
   let(:gate) { feature.gate(:percentage_of_actors) }
   let(:thing) { flipper.actors(22) }
 
+  before do
+    Flipper.instrumenter = instrumenter
+  end
+
   subject do
-    described_class.new(adapter, instrumenter: instrumenter)
+    described_class.new(adapter)
   end
 
   it_should_behave_like 'a flipper adapter'

--- a/spec/flipper/adapters/sync/synchronizer_spec.rb
+++ b/spec/flipper/adapters/sync/synchronizer_spec.rb
@@ -32,10 +32,7 @@ RSpec.describe Flipper::Adapters::Sync::Synchronizer do
 
   context "when raise disabled" do
     subject do
-      options = {
-        instrumenter: instrumenter,
-        raise: false,
-      }
+      options = { raise: false }
       described_class.new(local, remote, options)
     end
 

--- a/spec/flipper/adapters/sync/synchronizer_spec.rb
+++ b/spec/flipper/adapters/sync/synchronizer_spec.rb
@@ -9,7 +9,11 @@ RSpec.describe Flipper::Adapters::Sync::Synchronizer do
   let(:remote_flipper) { Flipper.new(remote) }
   let(:instrumenter) { Flipper::Instrumenters::Memory.new }
 
-  subject { described_class.new(local, remote, instrumenter: instrumenter) }
+  subject { described_class.new(local, remote) }
+
+  before do
+    Flipper.instrumenter = instrumenter
+  end
 
   it "instruments call" do
     subject.call

--- a/spec/flipper/adapters/sync_spec.rb
+++ b/spec/flipper/adapters/sync_spec.rb
@@ -1,5 +1,6 @@
 require 'flipper/adapters/sync'
 require 'flipper/adapters/operation_logger'
+require 'active_support'
 require 'active_support/notifications'
 
 RSpec.describe Flipper::Adapters::Sync do

--- a/spec/flipper/cloud/configuration_spec.rb
+++ b/spec/flipper/cloud/configuration_spec.rb
@@ -17,12 +17,6 @@ RSpec.describe Flipper::Cloud::Configuration do
     expect(instance.token).to eq("from_env")
   end
 
-  it "can set instrumenter" do
-    instrumenter = Object.new
-    instance = described_class.new(required_options.merge(instrumenter: instrumenter))
-    expect(instance.instrumenter).to be(instrumenter)
-  end
-
   it "can set read_timeout" do
     instance = described_class.new(required_options.merge(read_timeout: 5))
     expect(instance.read_timeout).to eq(5)

--- a/spec/flipper/cloud/engine_spec.rb
+++ b/spec/flipper/cloud/engine_spec.rb
@@ -32,7 +32,7 @@ RSpec.describe Flipper::Cloud::Engine do
     application.initialize!
 
     expect(Flipper.instance).to be_a(Flipper::Cloud::DSL)
-    expect(Flipper.instance.instrumenter).to be(ActiveSupport::Notifications)
+    expect(Flipper.instrumenter).to be(ActiveSupport::Notifications)
   end
 
   context "with CLOUD_SYNC_SECRET" do

--- a/spec/flipper/cloud_spec.rb
+++ b/spec/flipper/cloud_spec.rb
@@ -41,10 +41,6 @@ RSpec.describe Flipper::Cloud do
       headers = @http_client.instance_variable_get('@headers')
       expect(headers['Flipper-Cloud-Token']).to eq(token)
     end
-
-    it 'uses noop instrumenter' do
-      expect(@instance.instrumenter).to be(Flipper::Instrumenters::Noop)
-    end
   end
 
   context 'initialize with token and options' do
@@ -69,12 +65,6 @@ RSpec.describe Flipper::Cloud do
   it 'can initialize with no token explicitly provided' do
     ENV['FLIPPER_CLOUD_TOKEN'] = 'asdf'
     expect(described_class.new).to be_instance_of(Flipper::Cloud::DSL)
-  end
-
-  it 'can set instrumenter' do
-    instrumenter = Flipper::Instrumenters::Memory.new
-    instance = described_class.new(token: 'asdf', instrumenter: instrumenter)
-    expect(instance.instrumenter).to be(instrumenter)
   end
 
   it 'allows wrapping adapter with another adapter like the instrumenter' do

--- a/spec/flipper/configuration_spec.rb
+++ b/spec/flipper/configuration_spec.rb
@@ -30,4 +30,22 @@ RSpec.describe Flipper::Configuration do
       expect(subject.default).to be(instance)
     end
   end
+
+  describe '#instrumenter' do
+    it 'defaults to noop' do
+      expect(subject.instrumenter).to be(Flipper::Instrumenters::Noop)
+    end
+
+    it 'overrides default instrumenter' do
+      instrumenter = double('Instrumentor', instrument: nil)
+      subject.instrumenter instrumenter
+      expect(subject.instrumenter).to be(instrumenter)
+    end
+
+    it 'overrides instrumenter with =' do
+      instrumenter = double('Instrumentor', instrument: nil)
+      subject.instrumenter = instrumenter
+      expect(subject.instrumenter).to be(instrumenter)
+    end
+  end
 end

--- a/spec/flipper/dsl_spec.rb
+++ b/spec/flipper/dsl_spec.rb
@@ -20,34 +20,18 @@ RSpec.describe Flipper::DSL do
         expect(dsl.adapter).to be(adapter)
       end
     end
-
-    it 'defaults instrumenter to noop' do
-      dsl = described_class.new(adapter)
-      expect(dsl.instrumenter).to be(Flipper::Instrumenters::Noop)
-    end
-
-    context 'with overriden instrumenter' do
-      let(:instrumenter) { double('Instrumentor', instrument: nil) }
-
-      it 'overrides default instrumenter' do
-        dsl = described_class.new(adapter, instrumenter: instrumenter)
-        expect(dsl.instrumenter).to be(instrumenter)
-      end
-    end
   end
 
   describe '#feature' do
     it_should_behave_like 'a DSL feature' do
       let(:method_name) { :feature }
-      let(:instrumenter) { double('Instrumentor', instrument: nil) }
       let(:feature) { dsl.send(method_name, :stats) }
-      let(:dsl) { described_class.new(adapter, instrumenter: instrumenter) }
+      let(:dsl) { described_class.new(adapter) }
     end
   end
 
   describe '#preload' do
-    let(:instrumenter) { double('Instrumentor', instrument: nil) }
-    let(:dsl) { described_class.new(adapter, instrumenter: instrumenter) }
+    let(:dsl) { described_class.new(adapter) }
     let(:names) { %i(stats shiny) }
     let(:features) { dsl.preload(names) }
 
@@ -65,12 +49,6 @@ RSpec.describe Flipper::DSL do
       end
     end
 
-    it 'sets instrumenter' do
-      features.each do |feature|
-        expect(feature.instrumenter).to eq(dsl.instrumenter)
-      end
-    end
-
     it 'memoizes the feature' do
       features.each do |feature|
         expect(dsl.feature(feature.name)).to equal(feature)
@@ -79,10 +57,9 @@ RSpec.describe Flipper::DSL do
   end
 
   describe '#preload_all' do
-    let(:instrumenter) { double('Instrumentor', instrument: nil) }
     let(:dsl) do
       names.each { |name| adapter.add subject[name] }
-      described_class.new(adapter, instrumenter: instrumenter)
+      described_class.new(adapter)
     end
     let(:names) { %i(stats shiny) }
     let(:features) { dsl.preload_all }
@@ -101,12 +78,6 @@ RSpec.describe Flipper::DSL do
       end
     end
 
-    it 'sets instrumenter' do
-      features.each do |feature|
-        expect(feature.instrumenter).to eq(dsl.instrumenter)
-      end
-    end
-
     it 'memoizes the feature' do
       features.each do |feature|
         expect(dsl.feature(feature.name)).to equal(feature)
@@ -117,9 +88,8 @@ RSpec.describe Flipper::DSL do
   describe '#[]' do
     it_should_behave_like 'a DSL feature' do
       let(:method_name) { :[] }
-      let(:instrumenter) { double('Instrumentor', instrument: nil) }
       let(:feature) { dsl.send(method_name, :stats) }
-      let(:dsl) { described_class.new(adapter, instrumenter: instrumenter) }
+      let(:dsl) { described_class.new(adapter) }
     end
   end
 

--- a/spec/flipper/feature_spec.rb
+++ b/spec/flipper/feature_spec.rb
@@ -16,20 +16,6 @@ RSpec.describe Flipper::Feature do
       feature = described_class.new(:search, adapter)
       expect(feature.adapter).to eq(adapter)
     end
-
-    it 'defaults instrumenter' do
-      feature = described_class.new(:search, adapter)
-      expect(feature.instrumenter).to be(Flipper::Instrumenters::Noop)
-    end
-
-    context 'with overriden instrumenter' do
-      let(:instrumenter) { double('Instrumentor', instrument: nil) }
-
-      it 'overrides default instrumenter' do
-        feature = described_class.new(:search, adapter, instrumenter: instrumenter)
-        expect(feature.instrumenter).to be(instrumenter)
-      end
-    end
   end
 
   describe '#to_s' do
@@ -144,7 +130,8 @@ RSpec.describe Flipper::Feature do
     let(:instrumenter) { Flipper::Instrumenters::Memory.new }
 
     subject do
-      described_class.new(:search, adapter, instrumenter: instrumenter)
+      Flipper.instrumenter = instrumenter
+      described_class.new(:search, adapter)
     end
 
     it 'is recorded for enable' do

--- a/spec/flipper/instrumentation/log_subscriber_spec.rb
+++ b/spec/flipper/instrumentation/log_subscriber_spec.rb
@@ -4,14 +4,14 @@ require 'flipper/instrumentation/log_subscriber'
 
 RSpec.describe Flipper::Instrumentation::LogSubscriber do
   let(:adapter) do
-    memory = Flipper::Adapters::Memory.new
-    Flipper::Adapters::Instrumented.new(memory, instrumenter: ActiveSupport::Notifications)
+    Flipper::Adapters::Instrumented.new(Flipper::Adapters::Memory.new)
   end
   let(:flipper) do
-    Flipper.new(adapter, instrumenter: ActiveSupport::Notifications)
+    Flipper.new(adapter)
   end
 
   before do
+    Flipper.instrumenter = ActiveSupport::Notifications
     Flipper.register(:admins) do |thing|
       thing.respond_to?(:admin?) && thing.admin?
     end

--- a/spec/flipper/instrumentation/statsd_subscriber_spec.rb
+++ b/spec/flipper/instrumentation/statsd_subscriber_spec.rb
@@ -6,16 +6,16 @@ RSpec.describe Flipper::Instrumentation::StatsdSubscriber do
   let(:statsd_client) { Statsd.new }
   let(:socket) { FakeUDPSocket.new }
   let(:adapter) do
-    memory = Flipper::Adapters::Memory.new
-    Flipper::Adapters::Instrumented.new(memory, instrumenter: ActiveSupport::Notifications)
+    Flipper::Adapters::Instrumented.new(Flipper::Adapters::Memory.new)
   end
   let(:flipper) do
-    Flipper.new(adapter, instrumenter: ActiveSupport::Notifications)
+    Flipper.new(adapter)
   end
 
   let(:user) { user = Flipper::Actor.new('1') }
 
   before do
+    Flipper.instrumenter = ActiveSupport::Notifications
     described_class.client = statsd_client
     Thread.current[:statsd_socket] = socket
   end

--- a/spec/flipper/railtie_spec.rb
+++ b/spec/flipper/railtie_spec.rb
@@ -27,7 +27,7 @@ RSpec.describe Flipper::Railtie do
 
     it "configures instrumentor on default instance" do
       subject # initialize
-      expect(Flipper.instance.instrumenter).to eq(ActiveSupport::Notifications)
+      expect(Flipper.instrumenter).to eq(ActiveSupport::Notifications)
     end
 
     it 'uses Memoizer middleware if config.memoize = true' do

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -77,10 +77,6 @@ RSpec.shared_examples_for 'a DSL feature' do
     expect(feature.adapter.name).to eq(dsl.adapter.name)
   end
 
-  it 'sets instrumenter' do
-    expect(feature.instrumenter).to eq(dsl.instrumenter)
-  end
-
   it 'memoizes the feature' do
     expect(dsl.send(method_name, :stats)).to equal(feature)
   end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -27,6 +27,14 @@ RSpec.configure do |config|
     Flipper.configuration = nil
   end
 
+  config.after(:each) do
+    # Remove all subscribers once AS::Notifications is loaded
+    if defined?(ActiveSupport::Notifications)
+      ActiveSupport::Notifications.unsubscribe /\.flipper$/
+    end
+  end
+
+
   config.disable_monkey_patching!
 
   config.filter_run focus: true


### PR DESCRIPTION
While working on some changes for a different PR, I was running into some friction with having to pass the instrumenter option around everywhere. This doesn't seem like something that needs configured per object. This PR adds a global `Flipper.instrumenter` config and a `Flipper.instrument` method.

```diff
# config/initializers/flipper.rb
  Flipper.configure do |config|
    config.adapter do
-     Flipper::Adapters::Instrumented.new(my_adapter, instrumenter: MyInstrumenter)
+     Flipper::Adapters::Instrumented.new(my_adapter)
    end
+   config.instrumenter MyInstrumenter
  end
```
