### PR TITLE
Refactor memoization

### DIFF
--- a/examples/memoizing.rb
+++ b/examples/memoizing.rb
@@ -18,17 +18,14 @@ Flipper.disable(:wick)
 Flipper.adapter.reset
 
 # Turn on memoization (the memoizing middleware does this per request).
-Flipper.memoize = true
-
-# Preload all the features.
-Flipper.preload_all
-
-# Do as many feature checks as your heart desires.
-%w[foo bar baz wick].each do |name|
-  Flipper.enabled?(name)
+Flipper.memoize(preload: true) do |flipper|
+  # Do as many feature checks as your heart desires.
+  %w[foo bar baz wick].each do |name|
+    flipper.enabled?(name)
+  end
 end
 
-# See that only one operation exists, a get_all (which is the preload_all).
+# See that only one operation exists, a get_all (which is the preload).
 pp Flipper.adapter.operations
 # [#<Flipper::Adapters::OperationLogger::Operation:0x00007fdcfe1100e8
 #   @args=[],

--- a/examples/mongo/internals.rb
+++ b/examples/mongo/internals.rb
@@ -24,7 +24,7 @@ Flipper[:stats].enable_percentage_of_actors 45
 Flipper[:search].enable
 
 puts 'all docs in collection'
-pp Flipper.adapter.adapter.collection.find.to_a
+pp Flipper.adapter.collection.find.to_a
 # all docs in collection
 # [{"_id"=>"stats",
 #   "actors"=>["25", "90", "180"],

--- a/lib/flipper.rb
+++ b/lib/flipper.rb
@@ -53,6 +53,15 @@ module Flipper
     Thread.current[:flipper_instance] = flipper
   end
 
+  # Public: Set the flipper instance for the duration of the given block.
+  def with_instance(new_instance, &block)
+    original_instance = self.instance
+    self.instance = new_instance
+    block.call
+  ensure
+    self.instance = original_instance
+  end
+
   # Public: All the methods delegated to instance. These should match the
   # interface of Flipper::DSL.
   def_delegators :instance,
@@ -65,7 +74,7 @@ module Flipper
                  :time, :percentage_of_time,
                  :features, :feature, :[], :preload, :preload_all,
                  :adapter, :add, :exist?, :remove, :import,
-                 :memoize=, :memoizing?,
+                 :memoize=, :memoizing?, :memoize,
                  :sync, :sync_secret # For Flipper::Cloud. Will error for OSS Flipper.
 
   # Public: Use this to register a group by name.

--- a/lib/flipper/adapters/memoizable.rb
+++ b/lib/flipper/adapters/memoizable.rb
@@ -31,16 +31,11 @@ module Flipper
         @adapter = adapter
         @name = :memoizable
         @cache = cache || {}
-        @memoize = false
       end
 
       # Public
       def features
-        if memoizing?
-          cache.fetch(FeaturesKey) { cache[FeaturesKey] = @adapter.features }
-        else
-          @adapter.features
-        end
+        cache.fetch(FeaturesKey) { cache[FeaturesKey] = @adapter.features }
       end
 
       # Public
@@ -63,59 +58,47 @@ module Flipper
 
       # Public
       def get(feature)
-        if memoizing?
-          cache.fetch(key_for(feature.key)) { cache[key_for(feature.key)] = @adapter.get(feature) }
-        else
-          @adapter.get(feature)
-        end
+        cache.fetch(key_for(feature.key)) { cache[key_for(feature.key)] = @adapter.get(feature) }
       end
 
       # Public
       def get_multi(features)
-        if memoizing?
-          uncached_features = features.reject { |feature| cache[key_for(feature.key)] }
+        uncached_features = features.reject { |feature| cache[key_for(feature.key)] }
 
-          if uncached_features.any?
-            response = @adapter.get_multi(uncached_features)
-            response.each do |key, hash|
-              cache[key_for(key)] = hash
-            end
+        if uncached_features.any?
+          response = @adapter.get_multi(uncached_features)
+          response.each do |key, hash|
+            cache[key_for(key)] = hash
           end
-
-          result = {}
-          features.each do |feature|
-            result[feature.key] = cache[key_for(feature.key)]
-          end
-          result
-        else
-          @adapter.get_multi(features)
         end
+
+        result = {}
+        features.each do |feature|
+          result[feature.key] = cache[key_for(feature.key)]
+        end
+        result
       end
 
       def get_all
-        if memoizing?
-          response = nil
-          if cache[GetAllKey]
-            response = {}
-            cache[FeaturesKey].each do |key|
-              response[key] = cache[key_for(key)]
-            end
-          else
-            response = @adapter.get_all
-            response.each do |key, value|
-              cache[key_for(key)] = value
-            end
-            cache[FeaturesKey] = response.keys.to_set
-            cache[GetAllKey] = true
+        response = nil
+        if cache[GetAllKey]
+          response = {}
+          cache[FeaturesKey].each do |key|
+            response[key] = cache[key_for(key)]
           end
-
-          # Ensures that looking up other features that do not exist doesn't
-          # result in N+1 adapter calls.
-          response.default_proc = ->(memo, key) { memo[key] = default_config }
-          response
         else
-          @adapter.get_all
+          response = @adapter.get_all
+          response.each do |key, value|
+            cache[key_for(key)] = value
+          end
+          cache[FeaturesKey] = response.keys.to_set
+          cache[GetAllKey] = true
         end
+
+        # Ensures that looking up other features that do not exist doesn't
+        # result in N+1 adapter calls.
+        response.default_proc = ->(memo, key) { memo[key] = default_config }
+        response
       end
 
       # Public
@@ -128,19 +111,6 @@ module Flipper
         @adapter.disable(feature, gate, thing).tap { expire_feature(feature) }
       end
 
-      # Internal: Turns local caching on/off.
-      #
-      # value - The Boolean that decides if local caching is on.
-      def memoize=(value)
-        cache.clear
-        @memoize = value
-      end
-
-      # Internal: Returns true for using local cache, false for not.
-      def memoizing?
-        !!@memoize
-      end
-
       private
 
       def key_for(key)
@@ -148,11 +118,11 @@ module Flipper
       end
 
       def expire_feature(feature)
-        cache.delete(key_for(feature.key)) if memoizing?
+        cache.delete(key_for(feature.key))
       end
 
       def expire_features_set
-        cache.delete(FeaturesKey) if memoizing?
+        cache.delete(FeaturesKey)
       end
     end
   end

--- a/lib/flipper/feature.rb
+++ b/lib/flipper/feature.rb
@@ -36,6 +36,10 @@ module Flipper
       @adapter = adapter
     end
 
+    def ==(other)
+      other.is_a?(self.class) && other.to_s == to_s
+    end
+
     # Public: Enable this feature for something.
     #
     # Returns the result of Adapter#enable.

--- a/lib/flipper/feature.rb
+++ b/lib/flipper/feature.rb
@@ -36,10 +36,6 @@ module Flipper
       @adapter = adapter
     end
 
-    def ==(other)
-      other.is_a?(self.class) && other.to_s == to_s
-    end
-
     # Public: Enable this feature for something.
     #
     # Returns the result of Adapter#enable.

--- a/spec/flipper/adapters/active_record_spec.rb
+++ b/spec/flipper/adapters/active_record_spec.rb
@@ -54,7 +54,7 @@ RSpec.describe Flipper::Adapters::ActiveRecord do
     end
 
     it 'configures itself' do
-      expect(Flipper.adapter.adapter).to be_a(Flipper::Adapters::ActiveRecord)
+      expect(Flipper.adapter).to be_a(Flipper::Adapters::ActiveRecord)
     end
   end
 end

--- a/spec/flipper/adapters/memoizable_spec.rb
+++ b/spec/flipper/adapters/memoizable_spec.rb
@@ -27,331 +27,117 @@ RSpec.describe Flipper::Adapters::Memoizable do
     end
   end
 
-  describe '#memoize=' do
-    it 'sets value' do
-      subject.memoize = true
-      expect(subject.memoizing?).to eq(true)
-
-      subject.memoize = false
-      expect(subject.memoizing?).to eq(false)
-    end
-
-    it 'clears the local cache' do
-      subject.cache['some'] = 'thing'
-      subject.memoize = true
-      expect(subject.cache).to be_empty
-    end
-  end
-
-  describe '#memoizing?' do
-    it 'returns true if enabled' do
-      subject.memoize = true
-      expect(subject.memoizing?).to eq(true)
-    end
-
-    it 'returns false if disabled' do
-      subject.memoize = false
-      expect(subject.memoizing?).to eq(false)
-    end
-  end
-
   describe '#get' do
-    context 'with memoization enabled' do
-      before do
-        subject.memoize = true
-      end
-
-      it 'memoizes feature' do
-        feature = flipper[:stats]
-        result = subject.get(feature)
-        expect(cache[described_class.key_for(feature.key)]).to be(result)
-      end
-    end
-
-    context 'with memoization disabled' do
-      before do
-        subject.memoize = false
-      end
-
-      it 'returns result' do
-        feature = flipper[:stats]
-        result = subject.get(feature)
-        adapter_result = adapter.get(feature)
-        expect(result).to eq(adapter_result)
-      end
+    it 'memoizes feature' do
+      feature = flipper[:stats]
+      result = subject.get(feature)
+      expect(cache[described_class.key_for(feature.key)]).to be(result)
     end
   end
 
   describe '#get_multi' do
-    context 'with memoization enabled' do
-      before do
-        subject.memoize = true
-      end
-
-      it 'memoizes features' do
-        names = %i(stats shiny)
-        features = names.map { |name| flipper[name] }
-        results = subject.get_multi(features)
-        features.each do |feature|
-          expect(cache[described_class.key_for(feature.key)]).not_to be(nil)
-          expect(cache[described_class.key_for(feature.key)]).to be(results[feature.key])
-        end
-      end
-    end
-
-    context 'with memoization disabled' do
-      before do
-        subject.memoize = false
-      end
-
-      it 'returns result' do
-        names = %i(stats shiny)
-        features = names.map { |name| flipper[name] }
-        result = subject.get_multi(features)
-        adapter_result = adapter.get_multi(features)
-        expect(result).to eq(adapter_result)
+    it 'memoizes features' do
+      names = %i(stats shiny)
+      features = names.map { |name| flipper[name] }
+      results = subject.get_multi(features)
+      features.each do |feature|
+        expect(cache[described_class.key_for(feature.key)]).not_to be(nil)
+        expect(cache[described_class.key_for(feature.key)]).to be(results[feature.key])
       end
     end
   end
 
   describe '#get_all' do
-    context "with memoization enabled" do
-      before do
-        subject.memoize = true
+    it 'memoizes features' do
+      names = %i(stats shiny)
+      features = names.map { |name| flipper[name].tap(&:enable) }
+      results = subject.get_all
+      features.each do |feature|
+        expect(cache[described_class.key_for(feature.key)]).not_to be(nil)
+        expect(cache[described_class.key_for(feature.key)]).to be(results[feature.key])
       end
-
-      it 'memoizes features' do
-        names = %i(stats shiny)
-        features = names.map { |name| flipper[name].tap(&:enable) }
-        results = subject.get_all
-        features.each do |feature|
-          expect(cache[described_class.key_for(feature.key)]).not_to be(nil)
-          expect(cache[described_class.key_for(feature.key)]).to be(results[feature.key])
-        end
-        expect(cache[subject.class::FeaturesKey]).to eq(names.map(&:to_s).to_set)
-      end
-
-      it 'only calls get_all once for memoized adapter' do
-        adapter = Flipper::Adapters::OperationLogger.new(Flipper::Adapters::Memory.new)
-        cache = {}
-        instance = described_class.new(adapter, cache)
-        instance.memoize = true
-
-        instance.get_all
-        expect(adapter.count(:get_all)).to be(1)
-
-        instance.get_all
-        expect(adapter.count(:get_all)).to be(1)
-      end
-
-      it 'returns default_config for unknown feature keys' do
-        first = subject.get_all
-        expect(first['doesntexist']).to eq(subject.default_config)
-
-        second = subject.get_all
-        expect(second['doesntexist']).to eq(subject.default_config)
-      end
+      expect(cache[subject.class::FeaturesKey]).to eq(names.map(&:to_s).to_set)
     end
 
-    context "with memoization disabled" do
-      before do
-        subject.memoize = false
-      end
+    it 'only calls get_all once for memoized adapter' do
+      adapter = Flipper::Adapters::OperationLogger.new(Flipper::Adapters::Memory.new)
+      cache = {}
+      instance = described_class.new(adapter, cache)
 
-      it 'returns result' do
-        names = %i(stats shiny)
-        names.map { |name| flipper[name].tap(&:enable) }
-        result = subject.get_all
-        adapter_result = adapter.get_all
-        expect(result).to eq(adapter_result)
-      end
+      instance.get_all
+      expect(adapter.count(:get_all)).to be(1)
 
-      it 'calls get_all every time for memoized adapter' do
-        adapter = Flipper::Adapters::OperationLogger.new(Flipper::Adapters::Memory.new)
-        cache = {}
-        instance = described_class.new(adapter, cache)
-        instance.memoize = false
+      instance.get_all
+      expect(adapter.count(:get_all)).to be(1)
+    end
 
-        instance.get_all
-        expect(adapter.count(:get_all)).to be(1)
+    it 'returns default_config for unknown feature keys' do
+      first = subject.get_all
+      expect(first['doesntexist']).to eq(subject.default_config)
 
-        instance.get_all
-        expect(adapter.count(:get_all)).to be(2)
-      end
-
-      it 'returns nil for unknown feature keys' do
-        first = subject.get_all
-        expect(first['doesntexist']).to be(nil)
-
-        second = subject.get_all
-        expect(second['doesntexist']).to be(nil)
-      end
+      second = subject.get_all
+      expect(second['doesntexist']).to eq(subject.default_config)
     end
   end
 
   describe '#enable' do
-    context 'with memoization enabled' do
-      before do
-        subject.memoize = true
-      end
-
-      it 'unmemoizes feature' do
-        feature = flipper[:stats]
-        gate = feature.gate(:boolean)
-        cache[described_class.key_for(feature.key)] = { some: 'thing' }
-        subject.enable(feature, gate, flipper.bool)
-        expect(cache[described_class.key_for(feature.key)]).to be_nil
-      end
-    end
-
-    context 'with memoization disabled' do
-      before do
-        subject.memoize = false
-      end
-
-      it 'returns result' do
-        feature = flipper[:stats]
-        gate = feature.gate(:boolean)
-        result = subject.enable(feature, gate, flipper.bool)
-        adapter_result = adapter.enable(feature, gate, flipper.bool)
-        expect(result).to eq(adapter_result)
-      end
+    it 'unmemoizes feature' do
+      feature = flipper[:stats]
+      gate = feature.gate(:boolean)
+      cache[described_class.key_for(feature.key)] = { some: 'thing' }
+      subject.enable(feature, gate, flipper.bool)
+      expect(cache[described_class.key_for(feature.key)]).to be_nil
     end
   end
 
   describe '#disable' do
-    context 'with memoization enabled' do
-      before do
-        subject.memoize = true
-      end
-
-      it 'unmemoizes feature' do
-        feature = flipper[:stats]
-        gate = feature.gate(:boolean)
-        cache[described_class.key_for(feature.key)] = { some: 'thing' }
-        subject.disable(feature, gate, flipper.bool)
-        expect(cache[described_class.key_for(feature.key)]).to be_nil
-      end
-    end
-
-    context 'with memoization disabled' do
-      before do
-        subject.memoize = false
-      end
-
-      it 'returns result' do
-        feature = flipper[:stats]
-        gate = feature.gate(:boolean)
-        result = subject.disable(feature, gate, flipper.bool)
-        adapter_result = adapter.disable(feature, gate, flipper.bool)
-        expect(result).to eq(adapter_result)
-      end
+    it 'unmemoizes feature' do
+      feature = flipper[:stats]
+      gate = feature.gate(:boolean)
+      cache[described_class.key_for(feature.key)] = { some: 'thing' }
+      subject.disable(feature, gate, flipper.bool)
+      expect(cache[described_class.key_for(feature.key)]).to be_nil
     end
   end
 
   describe '#features' do
-    context 'with memoization enabled' do
-      before do
-        subject.memoize = true
-      end
-
-      it 'memoizes features' do
-        flipper[:stats].enable
-        flipper[:search].disable
-        result = subject.features
-        expect(cache[:flipper_features]).to be(result)
-      end
-    end
-
-    context 'with memoization disabled' do
-      before do
-        subject.memoize = false
-      end
-
-      it 'returns result' do
-        expect(subject.features).to eq(adapter.features)
-      end
+    it 'memoizes features' do
+      flipper[:stats].enable
+      flipper[:search].disable
+      result = subject.features
+      expect(cache[:flipper_features]).to be(result)
     end
   end
 
   describe '#add' do
-    context 'with memoization enabled' do
-      before do
-        subject.memoize = true
-      end
-
-      it 'unmemoizes the known features' do
-        cache[features_key] = { some: 'thing' }
-        subject.add(flipper[:stats])
-        expect(cache).to be_empty
-      end
-    end
-
-    context 'with memoization disabled' do
-      before do
-        subject.memoize = false
-      end
-
-      it 'returns result' do
-        expect(subject.add(flipper[:stats])).to eq(adapter.add(flipper[:stats]))
-      end
+    it 'unmemoizes the known features' do
+      cache[features_key] = { some: 'thing' }
+      subject.add(flipper[:stats])
+      expect(cache).to be_empty
     end
   end
 
   describe '#remove' do
-    context 'with memoization enabled' do
-      before do
-        subject.memoize = true
-      end
-
-      it 'unmemoizes the known features' do
-        cache[features_key] = { some: 'thing' }
-        subject.remove(flipper[:stats])
-        expect(cache).to be_empty
-      end
-
-      it 'unmemoizes the feature' do
-        feature = flipper[:stats]
-        cache[described_class.key_for(feature.key)] = { some: 'thing' }
-        subject.remove(feature)
-        expect(cache[described_class.key_for(feature.key)]).to be_nil
-      end
+    it 'unmemoizes the known features' do
+      cache[features_key] = { some: 'thing' }
+      subject.remove(flipper[:stats])
+      expect(cache).to be_empty
     end
 
-    context 'with memoization disabled' do
-      before do
-        subject.memoize = false
-      end
-
-      it 'returns result' do
-        expect(subject.remove(flipper[:stats])).to eq(adapter.remove(flipper[:stats]))
-      end
+    it 'unmemoizes the feature' do
+      feature = flipper[:stats]
+      cache[described_class.key_for(feature.key)] = { some: 'thing' }
+      subject.remove(feature)
+      expect(cache[described_class.key_for(feature.key)]).to be_nil
     end
   end
 
   describe '#clear' do
-    context 'with memoization enabled' do
-      before do
-        subject.memoize = true
-      end
-
-      it 'unmemoizes feature' do
-        feature = flipper[:stats]
-        cache[described_class.key_for(feature.key)] = { some: 'thing' }
-        subject.clear(feature)
-        expect(cache[described_class.key_for(feature.key)]).to be_nil
-      end
-    end
-
-    context 'with memoization disabled' do
-      before do
-        subject.memoize = false
-      end
-
-      it 'returns result' do
-        feature = flipper[:stats]
-        expect(subject.clear(feature)).to eq(adapter.clear(feature))
-      end
+    it 'unmemoizes feature' do
+      feature = flipper[:stats]
+      cache[described_class.key_for(feature.key)] = { some: 'thing' }
+      subject.clear(feature)
+      expect(cache[described_class.key_for(feature.key)]).to be_nil
     end
   end
 end

--- a/spec/flipper/adapters/mongo_spec.rb
+++ b/spec/flipper/adapters/mongo_spec.rb
@@ -33,6 +33,6 @@ RSpec.describe Flipper::Adapters::Mongo do
     load 'flipper/adapters/mongo.rb'
 
     ENV["MONGO_URL"] ||= "mongodb://127.0.0.1:27017/testing"
-    expect(Flipper.adapter.adapter).to be_a(Flipper::Adapters::Mongo)
+    expect(Flipper.adapter).to be_a(Flipper::Adapters::Mongo)
   end
 end

--- a/spec/flipper/adapters/redis_spec.rb
+++ b/spec/flipper/adapters/redis_spec.rb
@@ -27,6 +27,6 @@ RSpec.describe Flipper::Adapters::Redis do
 
     silence { load 'flipper/adapters/redis.rb' }
 
-    expect(Flipper.adapter.adapter).to be_a(Flipper::Adapters::Redis)
+    expect(Flipper.adapter).to be_a(Flipper::Adapters::Redis)
   end
 end

--- a/spec/flipper/adapters/sequel_spec.rb
+++ b/spec/flipper/adapters/sequel_spec.rb
@@ -36,7 +36,7 @@ RSpec.describe Flipper::Adapters::Sequel do
     end
 
     it 'configures itself' do
-      expect(Flipper.adapter.adapter).to be_a(Flipper::Adapters::Sequel)
+      expect(Flipper.adapter).to be_a(Flipper::Adapters::Sequel)
     end
 
     it "defines #flipper_id on Sequel::Model" do

--- a/spec/flipper/cloud_spec.rb
+++ b/spec/flipper/cloud_spec.rb
@@ -12,8 +12,7 @@ RSpec.describe Flipper::Cloud do
 
     before do
       @instance = described_class.new(token: token)
-      memoized_adapter = @instance.adapter
-      sync_adapter = memoized_adapter.adapter
+      sync_adapter = @instance.adapter
       @http_adapter = sync_adapter.instance_variable_get('@remote')
       @http_client = @http_adapter.instance_variable_get('@client')
     end
@@ -52,8 +51,7 @@ RSpec.describe Flipper::Cloud do
       stub_request(:get, /fakeflipper\.com/).to_return(status: 200, body: "{}")
 
       @instance = described_class.new(token: 'asdf', url: 'https://www.fakeflipper.com/sadpanda')
-      memoized_adapter = @instance.adapter
-      sync_adapter = memoized_adapter.adapter
+      sync_adapter = @instance.adapter
       @http_adapter = sync_adapter.instance_variable_get('@remote')
       @http_client = @http_adapter.instance_variable_get('@client')
     end
@@ -83,8 +81,7 @@ RSpec.describe Flipper::Cloud do
         Flipper::Adapters::Instrumented.new(adapter)
       end
     end
-    # instance.adapter is memoizable adapter instance
-    expect(instance.adapter.adapter).to be_instance_of(Flipper::Adapters::Instrumented)
+    expect(instance.adapter).to be_instance_of(Flipper::Adapters::Instrumented)
   end
 
   it 'can set debug_output' do

--- a/spec/flipper/configuration_spec.rb
+++ b/spec/flipper/configuration_spec.rb
@@ -11,16 +11,14 @@ RSpec.describe Flipper::Configuration do
       expect(subject.adapter).not_to be(instance)
       subject.adapter { instance }
       expect(subject.adapter).to be(instance)
-      # All adapters are wrapped in Memoizable
-      expect(subject.default.adapter.adapter).to be(instance)
+      expect(subject.default.adapter).to be(instance)
     end
   end
 
   describe '#default' do
     it 'returns instance using Memory adapter' do
       expect(subject.default).to be_a(Flipper::DSL)
-      # All adapters are wrapped in Memoizable
-      expect(subject.default.adapter.adapter).to be_a(Flipper::Adapters::Memory)
+      expect(subject.default.adapter).to be_a(Flipper::Adapters::Memory)
     end
 
     it 'can be set default' do

--- a/spec/flipper_spec.rb
+++ b/spec/flipper_spec.rb
@@ -206,14 +206,17 @@ RSpec.describe Flipper do
       expect(described_class.adapter).to eq(described_class.instance.adapter)
     end
 
-    it 'delegates memoize= to instance' do
-      expect(described_class.adapter.memoizing?).to be(false)
-      described_class.memoize = true
-      expect(described_class.adapter.memoizing?).to be(true)
-    end
+    it 'delegates memoize to instance' do
+      expect(described_class.memoizing?).to be(false)
 
-    it 'delegates memoizing? to instance' do
-      expect(described_class.memoizing?).to eq(described_class.adapter.memoizing?)
+      called = false
+
+      described_class.memoize do |flipper|
+        called = true
+        expect(flipper.memoizing?).to be(true)
+      end
+
+      expect(called).to be(true)
     end
 
     it 'delegates sync stuff to instance and does nothing' do


### PR DESCRIPTION
This adds `#memoize(&block)` method to perform memoization. It removes conditional memoization logic and mutating adapter/DSL in favor of just returning new DSL instance with wrapped adapter.

My best guess as to the cause of #604 is just that there is a lot of internal state mutation happening when enabling memoization. This branch is an attempt to reduce the state mutation down to just setting `Flipper.instance` to a new DSL with a wrapped adapter.

TODO:
- [ ] Make this work with `flipper-cloud`