### PR TITLE
Fixes examples/instrumentation* NameError

### DIFF
--- a/examples/instrumentation.rb
+++ b/examples/instrumentation.rb
@@ -1,5 +1,6 @@
 require 'bundler/setup'
 require 'securerandom'
+require 'active_support/isolated_execution_state'
 require 'active_support/notifications'
 
 class FlipperSubscriber

--- a/examples/instrumentation_last_accessed_at.rb
+++ b/examples/instrumentation_last_accessed_at.rb
@@ -1,6 +1,7 @@
 # Quick example of how to keep track of when a feature was last checked.
 require 'bundler/setup'
 require 'securerandom'
+require 'active_support/isolated_execution_state'
 require 'active_support/notifications'
 require 'flipper'
 


### PR DESCRIPTION
Running the instrumentation examples I experienced `uninitialized constant ActiveSupport::IsolatedExecutionState (NameError)`

This PR adds the specific require statement, resolving the error.