### PR TITLE
Configure ActiveRecord adapter immediately upon require of `flipper-active_record`

### DIFF
--- a/lib/flipper-active_record.rb
+++ b/lib/flipper-active_record.rb
@@ -1,5 +1,1 @@
-require 'active_support/lazy_load_hooks'
-
-ActiveSupport.on_load(:active_record) do
-  require 'flipper/adapters/active_record'
-end
+require 'flipper/adapters/active_record'


### PR DESCRIPTION
After digging into https://github.com/jnunemaker/flipper/issues/634, it looks like this odd behavior is caused by a load order issue with ActiveRecord. If `ActiveRecord::Base` is not referenced by another gem or an initializer (which is the case in a pristine Rails app), it won't be loaded until the [`runner` callback of the railtie](https://github.com/rails/rails/blob/e2d9747123b5b85904d6accdd182885d3af5564a/activerecord/lib/active_record/railtie.rb#L71-L73) right before the app finishes loading. The `flipper-active_record` adapter will configure itself when ActiveRecord is loaded, but if this doesn't happen until after all other initializers run, then it will overwrite the adapter configured by the user.

However, if `ActiveRecord::Base` _is_ referenced by a gem or in an initializer, then flipper default adapter will be immediately and everything works as expected:

```diff
  require 'active_support/cache'
  require 'flipper/adapters/active_support_cache_store'

+ # Just referencing AR here fixes #634 🙄
+ ActiveRecord::Base

  Flipper.configure do |config|
    config.adapter do
      puts "setting adapter"
      Flipper::Adapters::ActiveSupportCacheStore.new(
        Flipper::Adapters::Memory.new,
        ActiveSupport::Cache::MemoryStore.new, # Or Rails.cache
        expires_in: 5.minutes
      )
    end
  end
````

This load hook causes the order of ActiveRecord loading to be indeterminate. I've tested this in 3 other Rails apps that I work on and they all have a gem or initializer that causes ActiveRecord to load. The `ActiveSupport.on_load` hooks are intended to be a convenience for gems that have _optional_ behavior depending on which parts of Rails are loaded. Since the whole point of the `flipper-active_record` gem is to use ActiveRecord, I think it's reasonable to skip using this hook and just require it immediately. This change also makes the AR adapter consistent with the others that configure themselves (redis, mongo, etc).

