### PR TITLE
Relax redis constraint in flipper-redis.gemspec from `< 5` to `< 6`

### DIFF
--- a/flipper-redis.gemspec
+++ b/flipper-redis.gemspec
@@ -21,5 +21,5 @@ Gem::Specification.new do |gem|
   gem.metadata      = Flipper::METADATA
 
   gem.add_dependency 'flipper', "~> #{Flipper::VERSION}"
-  gem.add_dependency 'redis', '>= 3.0', '< 5'
+  gem.add_dependency 'redis', '>= 3.0', '< 6'
 end


### PR DESCRIPTION
Fixes https://github.com/jnunemaker/flipper/issues/666.

I have deployed this branch to production using `redis` gem version 5.0.5 and it works for me.