### PR TITLE
Check sadd_returns_boolean on the actual client class rather than `::Redis`

### DIFF
--- a/lib/flipper/adapters/redis.rb
+++ b/lib/flipper/adapters/redis.rb
@@ -118,7 +118,7 @@ module Flipper
       private
 
       def redis_sadd_returns_boolean?
-        ::Redis.respond_to?(:sadd_returns_boolean) && ::Redis.sadd_returns_boolean
+        @client.class.respond_to?(:sadd_returns_boolean) && @client.class.sadd_returns_boolean
       end
 
       def read_many_features(features)


### PR DESCRIPTION
Because the client might not be a `::Redis` instance, for example it could be a [`MockRedis` ](https://github.com/sds/mock_redis/) instance