### PR TITLE
Flipper UI - Fix issue preventing feature flags being enabled when confirm_fully_enable is on and feature_removal_enabled is off

### DIFF
--- a/lib/flipper/ui/public/js/application.js
+++ b/lib/flipper/ui/public/js/application.js
@@ -5,7 +5,7 @@ $(function () {
   });
 
   $("#enable_feature__button").on("click", function (e) {
-    const featureName = $("#feature_name").val();
+    const featureName = $(e.target).data("confirmation-text");
     const promptMessage = prompt(
       `Are you sure you want to fully enable this feature for everyone? Please enter the name of the feature to confirm it: ${featureName}`
     );
@@ -16,7 +16,7 @@ $(function () {
   });
   
   $("#delete_feature__button").on("click", function (e) {
-    const featureName = $("#feature_name").val();
+    const featureName = $(e.target).data("confirmation-text");
     const promptMessage = prompt(
       `Are you sure you want to remove this feature from the list of features and disable it for everyone? Please enter the name of the feature to confirm it: ${featureName}`
     );

--- a/lib/flipper/ui/views/feature.erb
+++ b/lib/flipper/ui/views/feature.erb
@@ -243,6 +243,9 @@
               <div class="col">
                 <button type="submit" name="action" value="Enable" <% if Flipper::UI.configuration.confirm_fully_enable %>id="enable_feature__button"<% end %> class="btn btn-outline-success btn-block" <% if Flipper::UI.configuration.read_only %>disabled<% end %>>
                   <span class="d-block" data-toggle="tooltip"
+                    <% if Flipper::UI.configuration.confirm_fully_enable %>
+                      data-confirmation-text="<%= feature_name %>"
+                    <% end %>
                     <% if Flipper::UI.configuration.read_only %>
                       title="Fully enable is not allowed in read only mode."
                     <% else %>
@@ -289,7 +292,7 @@
             <%== csrf_input_tag %>
             <input type="hidden" id="feature_name" name="_feature" value="<%= feature_name %>">
             <input type="hidden" name="_method" value="DELETE">
-            <button type="submit" name="action" value="Delete" id="delete_feature__button" class="btn btn-outline-danger" data-toggle="tooltip" title="Remove feature from list of features and disable it." data-placement="right">Delete</button>
+            <button type="submit" name="action" value="Delete" id="delete_feature__button" data-confirmation-text="<%= feature_name %>" class="btn btn-outline-danger" data-toggle="tooltip" title="Remove feature from list of features and disable it." data-placement="right">Delete</button>
           </form>
         </div>
       </div>

--- a/spec/flipper/ui/configuration_spec.rb
+++ b/spec/flipper/ui/configuration_spec.rb
@@ -110,6 +110,17 @@ RSpec.describe Flipper::UI::Configuration do
     end
   end
 
+  describe "#confirm_fully_enable" do
+    it "has default value" do
+      expect(configuration.confirm_fully_enable).to eq(false)
+    end
+
+    it "can be updated" do
+      configuration.confirm_fully_enable = true
+      expect(configuration.confirm_fully_enable).to eq(true)
+    end
+  end
+
   describe "#show_feature_description_in_list" do
     it "has default value" do
       expect(configuration.show_feature_description_in_list).to eq(false)


### PR DESCRIPTION
I noticed that the confirmation text set up by `confirm_fully_enable` does not work correctly if `feature_removal_enabled` was set to `false`.

This was due to the node with ID `feature_name` only being present within the form included when `feature_removal_enabled` was set to true. This lead to a situation where your UI would display "undefined" as the prompt text though when that or the actual feature name was used the  flag was not toggled since it was comparing the string "undefined" to an undefined variable.


This commit fixes this edge case by decoupling the confirmation text for both buttons from the `feature_removal_enabled` form and moving them into data attributes on the button being clicked. This allows them to be enabled/disabled separately without impacting each other. The appearance of these attributes are controlled by the flags themselves.

| Before | After |
|-|-|
| <img width="587" alt="before" src="https://user-images.githubusercontent.com/1465268/201092051-d4800a70-7c9d-46f8-8d7d-651a7808e8cf.png"> | <img width="587" alt="after" src="https://user-images.githubusercontent.com/1465268/201092043-c10a6839-52ae-4581-95ac-30af560ded0f.png"> |
