### PR TITLE
Stop poller instances when resetting

### DIFF
--- a/lib/flipper/adapters/poll/poller.rb
+++ b/lib/flipper/adapters/poll/poller.rb
@@ -19,7 +19,7 @@ module Flipper
         end
 
         def self.reset
-          instances.clear
+          instances.each {|_,poller| poller.stop }.clear
         end
 
         def initialize(options = {})


### PR DESCRIPTION
Fixes these webmock warnings in the specs by stopping any pollers when resetting.

```
000000010aa163e0 /Users/bkeepers/projects/flipper/lib/flipper/adapters/poll/poller.rb:105 run> terminated with exception (report_on_exception is true):
/Users/bkeepers/.asdf/installs/ruby/3.1.2/lib/ruby/gems/3.1.0/gems/webmock-3.14.0/lib/webmock/http_lib_adapters/net_http.rb:114:in `request': Real HTTP connections are disabled. Unregistered request: GET https://www.flippercloud.io/adapter/features with headers {'Accept'=>'application/json', 'Client-Engine'=>'ruby', 'Client-Hostname'=>'Brandons-MacBook-Air.local', 'Client-Language'=>'ruby', 'Client-Language-Version'=>'3.1.2 p20 (2022-04-12)', 'Client-Pid'=>'20281', 'Client-Platform'=>'arm64-darwin21', 'Client-Thread'=>'44440', 'Content-Type'=>'application/json', 'Flipper-Cloud-Token'=>'asdf', 'User-Agent'=>'Flipper HTTP Adapter v0.26.0.rc2'} (WebMock::NetConnectNotAllowedError)

You can stub this request with the following snippet:

stub_request(:get, "https://www.flippercloud.io/adapter/features").
  with(
    headers: {
	  'Accept'=>'application/json',
	  'Client-Engine'=>'ruby',
	  'Client-Hostname'=>'Brandons-MacBook-Air.local',
	  'Client-Language'=>'ruby',
	  'Client-Language-Version'=>'3.1.2 p20 (2022-04-12)',
	  'Client-Pid'=>'20281',
	  'Client-Platform'=>'arm64-darwin21',
	  'Client-Thread'=>'44440',
	  'Content-Type'=>'application/json',
	  'Flipper-Cloud-Token'=>'asdf',
	  'User-Agent'=>'Flipper HTTP Adapter v0.26.0.rc2'
    }).
  to_return(status: 200, body: "", headers: {})

============================================================
	from /Users/bkeepers/projects/flipper/lib/flipper/adapters/http/client.rb:51:in `perform'
	from /Users/bkeepers/projects/flipper/lib/flipper/adapters/http/client.rb:34:in `get'
	from /Users/bkeepers/projects/flipper/lib/flipper/adapters/http.rb:60:in `get_all'
	from /Users/bkeepers/projects/flipper/lib/flipper/adapters/sync/synchronizer.rb:35:in `sync'
	from /Users/bkeepers/projects/flipper/lib/flipper/adapters/sync/synchronizer.rb:28:in `block in call'
	from /Users/bkeepers/projects/flipper/lib/flipper/instrumenters/noop.rb:5:in `instrument'
	from /Users/bkeepers/projects/flipper/lib/flipper/adapters/sync/synchronizer.rb:28:in `call'
	from /Users/bkeepers/projects/flipper/lib/flipper/adapter.rb:48:in `import'
	from /Users/bkeepers/projects/flipper/lib/flipper/adapters/poll/poller.rb:71:in `block (2 levels) in run'
	from /Users/bkeepers/projects/flipper/lib/flipper/instrumenters/noop.rb:5:in `instrument'
	from /Users/bkeepers/projects/flipper/lib/flipper/adapters/poll/poller.rb:69:in `block in run'
	from /Users/bkeepers/projects/flipper/lib/flipper/adapters/poll/poller.rb:65:in `loop'
	from /Users/bkeepers/projects/flipper/lib/flipper/adapters/poll/poller.rb:65:in `run'
	from /Users/bkeepers/projects/flipper/lib/flipper/adapters/poll/poller.rb:105:in `block in ensure_worker_running'
```