### PR TITLE
Bugsnag integration

### DIFF
--- a/lib/flipper/instrumentation/bugsnag.rb
+++ b/lib/flipper/instrumentation/bugsnag.rb
@@ -1,0 +1,21 @@
+module Flipper
+  module Instrumentation
+    class Bugsnag
+      def call(event)
+        operation, feature_name, result = event.payload.values_at(:operation, :feature_name, :result)
+        return unless operation == :enabled?
+
+        if result
+          ::Bugsnag.add_feature_flag(feature_name)
+        else
+          ::Bugsnag.clear_feature_flag(feature_name)
+        end
+      end
+    end
+
+    # Register the subscriber if using ActiveSupport::Notifications
+    if defined?(ActiveSupport::Notifications)
+      ActiveSupport::Notifications.subscribe('feature_operation.flipper', Bugsnag.new)
+    end
+  end
+end

--- a/lib/flipper/instrumentation/bugsnag.rb
+++ b/lib/flipper/instrumentation/bugsnag.rb
@@ -1,8 +1,8 @@
 module Flipper
   module Instrumentation
     class Bugsnag
-      def call(event)
-        operation, feature_name, result = event.payload.values_at(:operation, :feature_name, :result)
+      def call(name, start, finish, id, payload)
+        operation, feature_name, result = payload.values_at(:operation, :feature_name, :result)
         return unless operation == :enabled?
 
         if result

--- a/lib/flipper/railtie.rb
+++ b/lib/flipper/railtie.rb
@@ -45,9 +45,9 @@ module Flipper
     end
 
     initializer "flipper.instrumentation" do |app|
-      return unless app.config.flipper.instrumenter == ActiveSupport::Notifications
-
-      require "flipper/instrumentation/bugsnag" if defined?(Bugsnag)
+      if app.config.flipper.instrumenter == ActiveSupport::Notifications
+        require "flipper/instrumentation/bugsnag" if defined?(Bugsnag)
+      end
     end
   end
 end

--- a/lib/flipper/railtie.rb
+++ b/lib/flipper/railtie.rb
@@ -43,5 +43,11 @@ module Flipper
         }
       end
     end
+
+    initializer "flipper.instrumentation" do |app|
+      return unless app.config.flipper.instrumenter == ActiveSupport::Notifications
+
+      require "flipper/instrumentation/bugsnag" if defined?(Bugsnag)
+    end
   end
 end

--- a/spec/flipper/instrumentation/bugsnag_spec.rb
+++ b/spec/flipper/instrumentation/bugsnag_spec.rb
@@ -1,0 +1,29 @@
+require 'active_support'
+require 'flipper/instrumentation/bugsnag'
+
+# test double for Bugsnag
+class Bugsnag
+  def self.clear_feature_flag(feature_name)
+  end
+
+  def self.add_feature_flag(feature_name)
+  end
+end
+
+RSpec.describe Flipper::Instrumentation::Bugsnag do
+  let(:adapter) { Flipper::Adapters::Memory.new }
+  let(:flipper) { Flipper.new(adapter, instrumenter: ActiveSupport::Notifications) }
+
+  context 'feature enabled checks' do
+    it 'clears disabled features' do
+      expect(Bugsnag).to receive(:clear_feature_flag).with(:search)
+      flipper.enabled? :search
+    end
+
+    it 'adds enabled features' do
+      flipper.enable :search
+      expect(Bugsnag).to receive(:add_feature_flag).with(:search)
+      flipper.enabled? :search
+    end
+  end
+end


### PR DESCRIPTION
#686 got me thinking about flipper integration with other libraries and I wanted to see what it would like if we just automatically loaded integrations.

This adds an instrumentation subscriber for Bugsnag which uses it's support for [feature flags & experiments](https://docs.bugsnag.com/product/features-experiments/) to mark features as enabled/disabled whenever they are checked.

I'm guessing eventually someone will want to customize the integration. We could just provide a way to disable automatic loading and they can add their own subscriber.

Thoughts/concerns about this approach?