### PR TITLE
Remove executables directive, this gem has 0 exe

### DIFF
--- a/flipper.gemspec
+++ b/flipper.gemspec
@@ -13,7 +13,6 @@ end
 
 ignored_files = plugin_files
 ignored_files << Dir['script/*']
-ignored_files << '.travis.yml'
 ignored_files << '.gitignore'
 ignored_files << 'Guardfile'
 ignored_files.flatten!.uniq!
@@ -28,7 +27,6 @@ Gem::Specification.new do |gem|
   gem.homepage      = 'https://github.com/jnunemaker/flipper'
   gem.license       = 'MIT'
 
-  gem.executables   = `git ls-files -- bin/*`.split("\n").map { |f| File.basename(f) }
   gem.files         = `git ls-files`.split("\n") - ignored_files + ['lib/flipper/version.rb']
   gem.test_files    = `git ls-files -- {test,spec,features}/*`.split("\n") - ignored_test_files
   gem.name          = 'flipper'


### PR DESCRIPTION
This PR cleans up two small things in the gemspec:

- Drop reference to non-existent bin/ directory
- Drop Travis reference