### PR TITLE
CI: Use bundler-cache: true to simplify the installation parts

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -36,6 +36,7 @@ jobs:
       SQLITE3_VERSION: 1.4.1
       REDIS_URL: redis://localhost:6379/0
       CI: true
+      RAILS_VERSION: ${{ matrix.rails }}
     steps:
       - name: Setup memcached
         uses: KeisukeYamashita/memcached-actions@v1
@@ -52,17 +53,12 @@ jobs:
           key: ${{ runner.os }}-gems-${{ matrix.ruby }}-${{ matrix.rails }}-${{ hashFiles('**/Gemfile.lock') }}
           restore-keys: |
             ${{ runner.os }}-gems-${{ matrix.ruby }}-${{ matrix.rails }}-
+      - name: Install libpq-dev
+        run: sudo apt-get -yqq install libpq-dev
       - name: Set up Ruby ${{ matrix.ruby }}
         uses: ruby/setup-ruby@v1
         with:
           ruby-version: ${{ matrix.ruby }}
-      - name: Install libpq-dev
-        run: sudo apt-get -yqq install libpq-dev
-      - name: Install bundler
-        run: gem install bundler
+          bundler-cache: true # 'bundle install' and cache gems
       - name: Run Rake with Rails ${{ matrix.rails }}
-        env:
-          RAILS_VERSION: ${{ matrix.rails }}
-        run: |
-          bundle install --jobs 4 --retry 3
-          bundle exec rake
+        run: bundle exec rake

--- a/.github/workflows/examples.yml
+++ b/.github/workflows/examples.yml
@@ -32,6 +32,7 @@ jobs:
       SQLITE3_VERSION: 1.4.1
       REDIS_URL: redis://localhost:6379/0
       CI: true
+      RAILS_VERSION: ${{ matrix.rails }}
     steps:
       - name: Setup memcached
         uses: KeisukeYamashita/memcached-actions@v1
@@ -48,20 +49,14 @@ jobs:
           key: ${{ runner.os }}-gems-${{ matrix.ruby }}-${{ matrix.rails }}-${{ hashFiles('**/Gemfile.lock') }}
           restore-keys: |
             ${{ runner.os }}-gems-${{ matrix.ruby }}-${{ matrix.rails }}-
+      - name: Install libpq-dev
+        run: sudo apt-get -yqq install libpq-dev
       - name: Set up Ruby ${{ matrix.ruby }}
         uses: ruby/setup-ruby@v1
         with:
           ruby-version: ${{ matrix.ruby }}
-      - name: Install libpq-dev
-        run: sudo apt-get -yqq install libpq-dev
-      - name: Install bundler
-        run: gem install bundler
-      - name: Bundle install with Rails ${{ matrix.rails }}
-        env:
-          RAILS_VERSION: ${{ matrix.rails }}
-        run: bundle install --jobs 4 --retry 3
+          bundler-cache: true # 'bundle install' and cache gems
       - name: Run Examples with Rails ${{ matrix.rails }}
         env:
           FLIPPER_CLOUD_TOKEN: ${{ secrets.FLIPPER_CLOUD_TOKEN }}
-          RAILS_VERSION: ${{ matrix.rails }}
         run: script/examples


### PR DESCRIPTION
This PR tries to use `bundler-cache: true`, and in order to do that, moves around some instructions.

- [x] workflows/ci.yml
- [x] workflows/examples.yml