### PR TITLE
Refactor Sync and Poll adapters to remove duplication

### DIFF
--- a/lib/flipper/adapters/poll.rb
+++ b/lib/flipper/adapters/poll.rb
@@ -3,6 +3,16 @@ require 'flipper/poller'
 
 module Flipper
   module Adapters
+    # Adapter that keeps a local and remote adapter in sync via a background poller.
+    #
+    # Synchronization is performed whenever the adapter is access if the background
+    # poller has been synced.
+    #
+    #   remote_adapter = Flipper::Adapters::Http.new(url: 'http://example.com/flipper')
+    #   local_adapter = Flipper::Adapters::Memory.new
+    #   poller = Flipper::Poller.get('my_poller', remote_adapter: remote_adapter, interval: 5)
+    #   adapter = Flipper::Adapters::Poll.new(poller, local_adapter)
+    #
     class Poll < Adapters::Sync
       # Private: Synchronizer that only runs when the poller has synced.
       class Synchronizer < Sync::Synchronizer

--- a/lib/flipper/adapters/poll/poller.rb
+++ b/lib/flipper/adapters/poll/poller.rb
@@ -1,2 +1,3 @@
 warn "DEPRECATION WARNING: Flipper::Adapters::Poll::Poller is deprecated. Use Flipper::Poller instead."
 require 'flipper/adapters/poll'
+Flipper::Adapters::Poll::Poller = ::Flipper::Poller

--- a/lib/flipper/adapters/sync.rb
+++ b/lib/flipper/adapters/sync.rb
@@ -4,8 +4,11 @@ require "flipper/adapters/sync/interval_synchronizer"
 
 module Flipper
   module Adapters
-    # TODO: Syncing should happen in a background thread on a regular interval
-    # rather than in the main thread only when reads happen.
+    # Adapter that periodically keeps a local and remote adapter in sync.
+    #
+    # Synchronization is performed on an interval in the current thread whenever
+    # the adapter is accessed. Use `Flipper::Adapters::Poll` if you want to
+    # perform synchronization in a background thread.
     class Sync
       extend Forwardable
       include ::Flipper::Adapter
@@ -27,9 +30,7 @@ module Flipper
       # remote to local. Default value is set in IntervalSynchronizer.
       def initialize(local, remote, options = {})
         @name = :sync
-
         @adapter = DualWrite.new(local, remote)
-
         @synchronizer = options.fetch(:synchronizer) do
           sync_options = {
             raise: false,
@@ -47,7 +48,6 @@ module Flipper
         @synchronizer.call
         @adapter
       end
-
     end
   end
 end

--- a/lib/flipper/adapters/sync.rb
+++ b/lib/flipper/adapters/sync.rb
@@ -39,8 +39,6 @@ module Flipper
           synchronizer = Synchronizer.new(local, remote, sync_options)
           IntervalSynchronizer.new(synchronizer, interval: options[:interval])
         end
-
-        @synchronizer.call
       end
 
       private

--- a/spec/flipper/adapters/poll_spec.rb
+++ b/spec/flipper/adapters/poll_spec.rb
@@ -1,0 +1,44 @@
+require 'flipper/adapters/poll'
+require 'flipper/adapters/operation_logger'
+require 'active_support/notifications'
+
+RSpec.describe Flipper::Adapters::Poll do
+  let(:remote_adapter) do
+    Flipper::Adapters::OperationLogger.new Flipper::Adapters::Memory.new
+  end
+  let(:local_adapter) do
+    Flipper::Adapters::OperationLogger.new Flipper::Adapters::Memory.new
+  end
+  let(:local) { Flipper.new(local_adapter) }
+  let(:remote) { Flipper.new(remote_adapter) }
+  let(:poll) { Flipper.new(subject) }
+  let(:poller) { Flipper::Poller.new(remote_adapter: remote_adapter, start_automatically: false) }
+
+  subject do
+    described_class.new(poller, local_adapter)
+  end
+
+  it_should_behave_like 'a flipper adapter'
+
+  it 'syncs features with poller has been synced' do
+    remote.enable(:search)
+
+    poller.sync # sync poller from remote
+
+    expect(poller.adapter).to receive(:get_all).and_call_original
+    expect(poll[:search].boolean_value).to be(true)
+    expect(subject.features.sort).to eq(%w(search))
+  end
+
+  it 'does not sync features with poller has not been synced' do
+    # Perform initial sync
+    poller.sync
+    subject.features
+
+    # Remote feature enabled, but poller has not synced yet
+    remote.enable(:search)
+    expect(poller.adapter).to_not receive(:get_all)
+
+    expect(subject.features.sort).to eq(%w())
+  end
+end

--- a/spec/flipper/adapters/sync_spec.rb
+++ b/spec/flipper/adapters/sync_spec.rb
@@ -56,7 +56,7 @@ RSpec.describe Flipper::Adapters::Sync do
     remote.disable(:search)
     local.disable(:search)
     remote.enable(:search)
-    subject # initialize forces sync
+    expect(sync[:search].boolean_value).to be(true)
     expect(local[:search].boolean_value).to be(true)
   end
 
@@ -64,14 +64,14 @@ RSpec.describe Flipper::Adapters::Sync do
     remote.enable(:search)
     local.enable(:search)
     remote.disable(:search)
-    subject # initialize forces sync
+    expect(sync[:search].boolean_value).to be(false)
     expect(local[:search].boolean_value).to be(false)
   end
 
   it 'adds local actor when remote actor is added' do
     actor = Flipper::Actor.new("User;235")
     remote.enable_actor(:search, actor)
-    subject # initialize forces sync
+    expect(sync[:search].actors_value).to eq(Set[actor.flipper_id])
     expect(local[:search].actors_value).to eq(Set[actor.flipper_id])
   end
 
@@ -80,14 +80,14 @@ RSpec.describe Flipper::Adapters::Sync do
     remote.enable_actor(:search, actor)
     local.enable_actor(:search, actor)
     remote.disable(:search, actor)
-    subject # initialize forces sync
+    expect(sync[:search].actors_value).to eq(Set.new)
     expect(local[:search].actors_value).to eq(Set.new)
   end
 
   it 'adds local group when remote group is added' do
     group = Flipper::Types::Group.new(:staff)
     remote.enable_group(:search, group)
-    subject # initialize forces sync
+    expect(sync[:search].groups_value).to eq(Set["staff"])
     expect(local[:search].groups_value).to eq(Set["staff"])
   end
 
@@ -96,7 +96,7 @@ RSpec.describe Flipper::Adapters::Sync do
     remote.enable_group(:search, group)
     local.enable_group(:search, group)
     remote.disable(:search, group)
-    subject # initialize forces sync
+    expect(sync[:search].groups_value).to eq(Set.new)
     expect(local[:search].groups_value).to eq(Set.new)
   end
 
@@ -104,7 +104,7 @@ RSpec.describe Flipper::Adapters::Sync do
     remote.enable_percentage_of_actors(:search, 10)
     local.enable_percentage_of_actors(:search, 10)
     remote.enable_percentage_of_actors(:search, 15)
-    subject # initialize forces sync
+    expect(sync[:search].percentage_of_actors_value).to eq(15)
     expect(local[:search].percentage_of_actors_value).to eq(15)
   end
 
@@ -112,7 +112,7 @@ RSpec.describe Flipper::Adapters::Sync do
     remote.enable_percentage_of_time(:search, 10)
     local.enable_percentage_of_time(:search, 10)
     remote.enable_percentage_of_time(:search, 15)
-    subject # initialize forces sync
+    expect(sync[:search].percentage_of_time_value).to eq(15)
     expect(local[:search].percentage_of_time_value).to eq(15)
   end
 
@@ -121,7 +121,7 @@ RSpec.describe Flipper::Adapters::Sync do
       local.enable(:search)
       remote.enable(:search)
       local_adapter.reset
-      subject # initialize forces sync
+      subject.features # force sync
       expect(local_adapter.count(:enable)).to be(0)
     end
 
@@ -129,7 +129,7 @@ RSpec.describe Flipper::Adapters::Sync do
       local.disable(:search)
       remote.disable(:search)
       local_adapter.reset
-      subject # initialize forces sync
+      subject.features # force sync
       expect(local_adapter.count(:disable)).to be(0)
     end
 
@@ -138,7 +138,7 @@ RSpec.describe Flipper::Adapters::Sync do
       local.enable_actor(:search, actor)
       remote.enable_actor(:search, actor)
       local_adapter.reset
-      subject # initialize forces sync
+      subject.features # force sync
       expect(local_adapter.count(:enable)).to be(0)
       expect(local_adapter.count(:disable)).to be(0)
     end
@@ -148,7 +148,7 @@ RSpec.describe Flipper::Adapters::Sync do
       local.enable_group(:search, group)
       remote.enable_group(:search, group)
       local_adapter.reset
-      subject # initialize forces sync
+      subject.features # force sync
       expect(local_adapter.count(:enable)).to be(0)
       expect(local_adapter.count(:disable)).to be(0)
     end
@@ -157,7 +157,7 @@ RSpec.describe Flipper::Adapters::Sync do
       local.enable_percentage_of_actors(:search, 10)
       remote.enable_percentage_of_actors(:search, 10)
       local_adapter.reset
-      subject # initialize forces sync
+      subject.features # force sync
       expect(local_adapter.count(:enable)).to be(0)
       expect(local_adapter.count(:disable)).to be(0)
     end
@@ -166,7 +166,7 @@ RSpec.describe Flipper::Adapters::Sync do
       local.enable_percentage_of_time(:search, 10)
       remote.enable_percentage_of_time(:search, 10)
       local_adapter.reset
-      subject # initialize forces sync
+      subject.features # force sync
       expect(local_adapter.count(:enable)).to be(0)
       expect(local_adapter.count(:disable)).to be(0)
     end

--- a/spec/flipper/adapters/sync_spec.rb
+++ b/spec/flipper/adapters/sync_spec.rb
@@ -173,22 +173,22 @@ RSpec.describe Flipper::Adapters::Sync do
   end
 
   it 'synchronizes for #features' do
-    expect(subject).to receive(:synchronize)
+    expect(subject.synchronizer).to receive(:call)
     subject.features
   end
 
   it 'synchronizes for #get' do
-    expect(subject).to receive(:synchronize)
+    expect(subject.synchronizer).to receive(:call)
     subject.get sync[:search]
   end
 
   it 'synchronizes for #get_multi' do
-    expect(subject).to receive(:synchronize)
+    expect(subject.synchronizer).to receive(:call)
     subject.get_multi [sync[:search]]
   end
 
   it 'synchronizes for #get_all' do
-    expect(subject).to receive(:synchronize)
+    expect(subject.synchronizer).to receive(:call)
     subject.get_all
   end
 


### PR DESCRIPTION
They are effectively doing the same thing with just slightly different logic. This makes `Poll < Sync` and updates `Sync` to use `DualWrite` internally.

I don't think `Sync` is used anymore internally, so it might make sense to just depreciate and remove it, but not sure if there are other use cases for it.