### PR TITLE
Make Memory adapter threadsafe

### DIFF
--- a/lib/flipper/adapters/poll/poller.rb
+++ b/lib/flipper/adapters/poll/poller.rb
@@ -2,7 +2,6 @@ require 'logger'
 require 'concurrent/utility/monotonic_time'
 require 'concurrent/map'
 require 'concurrent/atomic/atomic_fixnum'
-require 'concurrent/hash'
 
 module Flipper
   module Adapters
@@ -31,8 +30,7 @@ module Flipper
           @remote_adapter = options.fetch(:remote_adapter)
           @interval = options.fetch(:interval, 10).to_f
           @last_synced_at = Concurrent::AtomicFixnum.new(0)
-          @data = Concurrent::Hash.new
-          @adapter = Memory.new(@data)
+          @adapter = Memory.new
 
           if @interval < 1
             warn "Flipper::Cloud poll interval must be greater than or equal to 1 but was #{@interval}. Setting @interval to 1."
@@ -75,8 +73,7 @@ module Flipper
 
         def sync
           @instrumenter.instrument("poller.#{InstrumentationNamespace}", operation: :poll) do
-            # Mutate threadsafe hash with remote adapter's data
-            @data.update @remote_adapter.get_all
+            @adapter.import @remote_adapter
             @last_synced_at.update { |time| Concurrent.monotonic_time }
           end
         end

--- a/spec/flipper/adapters/memory_spec.rb
+++ b/spec/flipper/adapters/memory_spec.rb
@@ -14,7 +14,9 @@ RSpec.describe Flipper::Adapters::Memory do
     flipper.enable_actor :following, Flipper::Actor.new('3')
     flipper.enable_group :following, Flipper::Types::Group.new(:staff)
 
-    expect(source).to eq({
+    dup = described_class.new(subject.get_all)
+
+    expect(dup.get_all).to eq({
       "subscriptions" => subject.default_config.merge(boolean: "true"),
       "search" => subject.default_config,
       "logging" => subject.default_config.merge(:percentage_of_time => "30"),

--- a/spec/flipper/adapters/poll/poller_spec.rb
+++ b/spec/flipper/adapters/poll/poller_spec.rb
@@ -23,7 +23,6 @@ RSpec.describe Flipper::Adapters::Poll::Poller do
     it "always returns same memory adapter instance" do
       expect(subject.adapter).to be_a(Flipper::Adapters::Memory)
       expect(subject.adapter.object_id).to eq(subject.adapter.object_id)
-      expect(subject.adapter.get_all.object_id).to eq(subject.adapter.get_all.object_id)
     end
   end
 


### PR DESCRIPTION
Addresses https://github.com/jnunemaker/flipper/pull/699#discussion_r1126465923

~~This uses `Concurrent::Hash` (which just uses `Hash` on MRI since any C function is thread safe and Hash is implemented in C) as the backend source for the memory adapter and replaces any non-threadsafe uses (like `||=`).~~

See [update](https://github.com/jnunemaker/flipper/pull/702#issuecomment-1462629962)