### PR TITLE
Improve `Flipper#enabled?` Performance

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -20,6 +20,10 @@ gem 'webmock', '~> 3.0'
 gem 'ice_age'
 gem 'redis-namespace'
 gem 'webrick'
+gem 'stackprof'
+gem 'benchmark-ips'
+gem 'stackprof-webnav'
+gem 'flamegraph'
 
 group(:guard) do
   gem 'guard', '~> 2.15'

--- a/benchmark/enabled_ips.rb
+++ b/benchmark/enabled_ips.rb
@@ -1,0 +1,10 @@
+require 'bundler/setup'
+require 'flipper'
+require 'benchmark/ips'
+
+actor = Flipper::Actor.new("User;1")
+
+Benchmark.ips do |x|
+  x.report("with actor") { Flipper.enabled?(:foo, actor) }
+  x.report("without actor") { Flipper.enabled?(:foo) }
+end

--- a/benchmark/enabled_profile.rb
+++ b/benchmark/enabled_profile.rb
@@ -4,11 +4,12 @@ require 'stackprof'
 require 'benchmark/ips'
 
 flipper = Flipper.new(Flipper::Adapters::Memory.new)
+feature = flipper.feature(:foo)
 actor = Flipper::Actor.new("User;1")
 
-profile = StackProf.run(mode: :cpu, interval: 100) do
-  1_000_000.times do
-    flipper.enabled?(:foo, actor)
+profile = StackProf.run(mode: :wall, interval: 1_000) do
+  2_000_000.times do
+    feature.enabled?(actor)
   end
 end
 
@@ -16,11 +17,4 @@ result = StackProf::Report.new(profile)
 puts
 result.print_text
 puts "\n\n\n"
-result.print_method(/Class#new/)
-puts "\n\n\n"
-result.print_method(/gate_values/)
-puts "\n\n\n"
-result.print_method(/enabled?/)
-puts "\n\n\n"
-result.print_method(/GateValues/)
-puts "\n\n\n"
+result.print_method(/Flipper::Feature#enabled?/)

--- a/benchmark/enabled_profile.rb
+++ b/benchmark/enabled_profile.rb
@@ -1,0 +1,26 @@
+require 'bundler/setup'
+require 'flipper'
+require 'stackprof'
+require 'benchmark/ips'
+
+flipper = Flipper.new(Flipper::Adapters::Memory.new)
+actor = Flipper::Actor.new("User;1")
+
+profile = StackProf.run(mode: :cpu, interval: 100) do
+  1_000_000.times do
+    flipper.enabled?(:foo, actor)
+  end
+end
+
+result = StackProf::Report.new(profile)
+puts
+result.print_text
+puts "\n\n\n"
+result.print_method(/Class#new/)
+puts "\n\n\n"
+result.print_method(/gate_values/)
+puts "\n\n\n"
+result.print_method(/enabled?/)
+puts "\n\n\n"
+result.print_method(/GateValues/)
+puts "\n\n\n"

--- a/benchmark/instrumentation_ips.rb
+++ b/benchmark/instrumentation_ips.rb
@@ -1,0 +1,21 @@
+require 'bundler/setup'
+require 'flipper'
+require 'active_support/notifications'
+require 'active_support/isolated_execution_state'
+require 'benchmark/ips'
+
+class FlipperSubscriber
+  def call(name, start, finish, id, payload)
+  end
+
+  ActiveSupport::Notifications.subscribe(/flipper/, new)
+end
+
+actor = Flipper::Actor.new("User;1")
+bare = Flipper.new(Flipper::Adapters::Memory.new)
+instrumented = Flipper.new(Flipper::Adapters::Memory.new, instrumenter: ActiveSupport::Notifications)
+
+Benchmark.ips do |x|
+  x.report("with instrumentation") { instrumented.enabled?(:foo, actor) }
+  x.report("without instrumentation") { bare.enabled?(:foo, actor) }
+end

--- a/benchmark/typecast_ips.rb
+++ b/benchmark/typecast_ips.rb
@@ -1,0 +1,19 @@
+require 'bundler/setup'
+require 'flipper'
+require 'benchmark/ips'
+
+Benchmark.ips do |x|
+  x.report("Typecast.to_boolean true") { Flipper::Typecast.to_boolean(true) }
+  x.report("Typecast.to_boolean 1") { Flipper::Typecast.to_boolean(1) }
+  x.report("Typecast.to_boolean 'true'") { Flipper::Typecast.to_boolean('true'.freeze) }
+  x.report("Typecast.to_boolean '1'") { Flipper::Typecast.to_boolean('1'.freeze) }
+  x.report("Typecast.to_boolean false") { Flipper::Typecast.to_boolean(false) }
+
+  x.report("Typecast.to_integer 1") { Flipper::Typecast.to_integer(1) }
+  x.report("Typecast.to_integer '1'") { Flipper::Typecast.to_integer('1') }
+
+  x.report("Typecast.to_float 1") { Flipper::Typecast.to_float(1) }
+  x.report("Typecast.to_float '1'") { Flipper::Typecast.to_float('1'.freeze) }
+  x.report("Typecast.to_float 1.01") { Flipper::Typecast.to_float(1) }
+  x.report("Typecast.to_float '1.01'") { Flipper::Typecast.to_float('1'.freeze) }
+end

--- a/lib/flipper/feature.rb
+++ b/lib/flipper/feature.rb
@@ -207,7 +207,7 @@ module Flipper
 
       if values.boolean || values.percentage_of_time == 100
         :on
-      elsif non_boolean_gates.detect { |gate| gate.enabled?(values[gate.key]) }
+      elsif non_boolean_gates.detect { |gate| gate.enabled?(values.send(gate.key)) }
         :conditional
       else
         :off
@@ -290,7 +290,7 @@ module Flipper
     # Returns an Array of Flipper::Gate instances.
     def enabled_gates
       values = gate_values
-      gates.select { |gate| gate.enabled?(values[gate.key]) }
+      gates.select { |gate| gate.enabled?(values.send(gate.key)) }
     end
 
     # Public: Get the names of the enabled gates.

--- a/lib/flipper/feature.rb
+++ b/lib/flipper/feature.rb
@@ -102,7 +102,7 @@ module Flipper
     def enabled?(thing = nil)
       instrument(:enabled?) do |payload|
         values = gate_values
-        thing = gate(:actor).wrap(thing) unless thing.nil?
+        thing = Types::Actor.wrap(thing) unless thing.nil?
         payload[:thing] = thing
         context = FeatureCheckContext.new(
           feature_name: @name,

--- a/lib/flipper/feature.rb
+++ b/lib/flipper/feature.rb
@@ -100,13 +100,12 @@ module Flipper
     #
     # Returns true if enabled, false if not.
     def enabled?(thing = nil)
-      instrument(:enabled?) do |payload|
-        values = gate_values
-        thing = Types::Actor.wrap(thing) unless thing.nil?
-        payload[:thing] = thing
+      thing = Types::Actor.wrap(thing) unless thing.nil?
+
+      instrument(:enabled?, thing: thing) do |payload|
         context = FeatureCheckContext.new(
           feature_name: @name,
-          values: values,
+          values: gate_values,
           thing: thing
         )
 
@@ -373,8 +372,8 @@ module Flipper
     private
 
     # Private: Instrument a feature operation.
-    def instrument(operation)
-      @instrumenter.instrument(InstrumentationName) do |payload|
+    def instrument(operation, initial_payload = {})
+      @instrumenter.instrument(InstrumentationName, initial_payload) do |payload|
         payload[:feature_name] = name
         payload[:operation] = operation
         payload[:result] = yield(payload) if block_given?

--- a/lib/flipper/feature.rb
+++ b/lib/flipper/feature.rb
@@ -340,20 +340,24 @@ module Flipper
     #
     # Returns an array of gates
     def gates
-      @gates ||= [
-        Gates::Boolean.new,
-        Gates::Actor.new,
-        Gates::PercentageOfActors.new,
-        Gates::PercentageOfTime.new,
-        Gates::Group.new,
-      ]
+      @gates ||= gates_hash.values.freeze
+    end
+
+    def gates_hash
+      @gates_hash ||= {
+        boolean: Gates::Boolean.new,
+        actor: Gates::Actor.new,
+        percentage_of_actors: Gates::PercentageOfActors.new,
+        percentage_of_time: Gates::PercentageOfTime.new,
+        group: Gates::Group.new,
+      }.freeze
     end
 
     # Public: Find a gate by name.
     #
     # Returns a Flipper::Gate if found, nil if not.
     def gate(name)
-      gates.detect { |gate| gate.name == name.to_sym }
+      gates_hash[name.to_sym]
     end
 
     # Public: Find the gate that protects a thing.

--- a/lib/flipper/feature.rb
+++ b/lib/flipper/feature.rb
@@ -232,7 +232,8 @@ module Flipper
 
     # Public: Returns the raw gate values stored by the adapter.
     def gate_values
-      GateValues.new(adapter.get(self))
+      adapter_values = adapter.get(self)
+      GateValues.new(adapter_values)
     end
 
     # Public: Get groups enabled for this feature.

--- a/lib/flipper/feature_check_context.rb
+++ b/lib/flipper/feature_check_context.rb
@@ -10,10 +10,10 @@ module Flipper
     # Public: The thing we want to know if a feature is enabled for.
     attr_reader :thing
 
-    def initialize(options = {})
-      @feature_name = options.fetch(:feature_name)
-      @values = options.fetch(:values)
-      @thing = options.fetch(:thing)
+    def initialize(feature_name:, values:, thing:)
+      @feature_name = feature_name
+      @values = values
+      @thing = thing
     end
 
     # Public: Convenience method for groups value like Feature has.

--- a/lib/flipper/gate_values.rb
+++ b/lib/flipper/gate_values.rb
@@ -3,16 +3,6 @@ require 'flipper/typecast'
 
 module Flipper
   class GateValues
-    # Private: Array of instance variables that are readable through the []
-    # instance method.
-    LegitIvars = {
-      'boolean' => '@boolean',
-      'actors' => '@actors',
-      'groups' => '@groups',
-      'percentage_of_time' => '@percentage_of_time',
-      'percentage_of_actors' => '@percentage_of_actors',
-    }.freeze
-
     attr_reader :boolean
     attr_reader :actors
     attr_reader :groups
@@ -25,12 +15,6 @@ module Flipper
       @groups = Typecast.to_set(adapter_values[:groups])
       @percentage_of_actors = Typecast.to_percentage(adapter_values[:percentage_of_actors])
       @percentage_of_time = Typecast.to_percentage(adapter_values[:percentage_of_time])
-    end
-
-    def [](key)
-      if ivar = LegitIvars[key.to_s]
-        instance_variable_get(ivar)
-      end
     end
 
     def eql?(other)

--- a/lib/flipper/gates/actor.rb
+++ b/lib/flipper/gates/actor.rb
@@ -23,7 +23,7 @@ module Flipper
       #
       # Returns true if gate open for thing, false if not.
       def open?(context)
-        value = context.values[key]
+        value = context.values.send(key)
         if context.thing.nil?
           false
         else

--- a/lib/flipper/gates/actor.rb
+++ b/lib/flipper/gates/actor.rb
@@ -23,18 +23,8 @@ module Flipper
       #
       # Returns true if gate open for thing, false if not.
       def open?(context)
-        value = context.values.send(key)
-        if context.thing.nil?
-          false
-        else
-          if protects?(context.thing)
-            actor = wrap(context.thing)
-            enabled_actor_ids = value
-            enabled_actor_ids.include?(actor.value)
-          else
-            false
-          end
-        end
+        return false if context.thing.nil?
+        context.values.actors.include?(context.thing.value)
       end
 
       def wrap(thing)

--- a/lib/flipper/gates/boolean.rb
+++ b/lib/flipper/gates/boolean.rb
@@ -24,7 +24,7 @@ module Flipper
       # Returns true if explicitly set to true, false if explicitly set to false
       # or nil if not explicitly set.
       def open?(context)
-        context.values.send(key)
+        context.values.boolean
       end
 
       def wrap(thing)

--- a/lib/flipper/gates/boolean.rb
+++ b/lib/flipper/gates/boolean.rb
@@ -24,7 +24,7 @@ module Flipper
       # Returns true if explicitly set to true, false if explicitly set to false
       # or nil if not explicitly set.
       def open?(context)
-        context.values[key]
+        context.values.send(key)
       end
 
       def wrap(thing)

--- a/lib/flipper/gates/group.rb
+++ b/lib/flipper/gates/group.rb
@@ -23,7 +23,7 @@ module Flipper
       #
       # Returns true if gate open for thing, false if not.
       def open?(context)
-        value = context.values[key]
+        value = context.values.send(key)
         if context.thing.nil?
           false
         else

--- a/lib/flipper/gates/group.rb
+++ b/lib/flipper/gates/group.rb
@@ -23,14 +23,10 @@ module Flipper
       #
       # Returns true if gate open for thing, false if not.
       def open?(context)
-        value = context.values.send(key)
-        if context.thing.nil?
-          false
-        else
-          value.any? do |name|
-            group = Flipper.group(name)
-            group.match?(context.thing, context)
-          end
+        return false if context.thing.nil?
+
+        context.values.groups.any? do |name|
+          Flipper.group(name).match?(context.thing, context)
         end
       end
 

--- a/lib/flipper/gates/percentage_of_actors.rb
+++ b/lib/flipper/gates/percentage_of_actors.rb
@@ -25,7 +25,7 @@ module Flipper
       #
       # Returns true if gate open for thing, false if not.
       def open?(context)
-        percentage = context.values[key]
+        percentage = context.values.send(key)
 
         if Types::Actor.wrappable?(context.thing)
           actor = Types::Actor.wrap(context.thing)

--- a/lib/flipper/gates/percentage_of_actors.rb
+++ b/lib/flipper/gates/percentage_of_actors.rb
@@ -21,15 +21,18 @@ module Flipper
         value > 0
       end
 
+      # Private: this constant is used to support up to 3 decimal places
+      # in percentages.
       SCALING_FACTOR = 1_000
+      private_constant :SCALING_FACTOR
 
       # Internal: Checks if the gate is open for a thing.
       #
       # Returns true if gate open for thing, false if not.
       def open?(context)
         return false if context.thing.nil?
+
         id = "#{context.feature_name}#{context.thing.value}"
-        # this is to support up to 3 decimal places in percentages
         Zlib.crc32(id) % (100 * SCALING_FACTOR) < context.values.percentage_of_actors * SCALING_FACTOR
       end
 

--- a/lib/flipper/gates/percentage_of_actors.rb
+++ b/lib/flipper/gates/percentage_of_actors.rb
@@ -21,21 +21,16 @@ module Flipper
         value > 0
       end
 
+      SCALING_FACTOR = 1_000
+
       # Internal: Checks if the gate is open for a thing.
       #
       # Returns true if gate open for thing, false if not.
       def open?(context)
-        percentage = context.values.send(key)
-
-        if Types::Actor.wrappable?(context.thing)
-          actor = Types::Actor.wrap(context.thing)
-          id = "#{context.feature_name}#{actor.value}"
-          # this is to support up to 3 decimal places in percentages
-          scaling_factor = 1_000
-          Zlib.crc32(id) % (100 * scaling_factor) < percentage * scaling_factor
-        else
-          false
-        end
+        return false if context.thing.nil?
+        id = "#{context.feature_name}#{context.thing.value}"
+        # this is to support up to 3 decimal places in percentages
+        Zlib.crc32(id) % (100 * SCALING_FACTOR) < context.values.percentage_of_actors * SCALING_FACTOR
       end
 
       def protects?(thing)

--- a/lib/flipper/gates/percentage_of_time.rb
+++ b/lib/flipper/gates/percentage_of_time.rb
@@ -23,8 +23,7 @@ module Flipper
       #
       # Returns true if gate open for thing, false if not.
       def open?(context)
-        value = context.values.send(key)
-        rand < (value / 100.0)
+        rand < (context.values.percentage_of_time / 100.0)
       end
 
       def protects?(thing)

--- a/lib/flipper/gates/percentage_of_time.rb
+++ b/lib/flipper/gates/percentage_of_time.rb
@@ -23,7 +23,7 @@ module Flipper
       #
       # Returns true if gate open for thing, false if not.
       def open?(context)
-        value = context.values[key]
+        value = context.values.send(key)
         rand < (value / 100.0)
       end
 

--- a/lib/flipper/typecast.rb
+++ b/lib/flipper/typecast.rb
@@ -21,11 +21,9 @@ module Flipper
     # Returns an Integer representation of the value.
     # Raises ArgumentError if conversion is not possible.
     def self.to_integer(value)
-      if value.respond_to?(:to_i)
-        value.to_i
-      else
-        raise ArgumentError, "#{value.inspect} cannot be converted to an integer"
-      end
+      value.to_i
+    rescue NoMethodError
+      raise ArgumentError, "#{value.inspect} cannot be converted to an integer"
     end
 
     # Internal: Convert value to a float.
@@ -33,11 +31,9 @@ module Flipper
     # Returns a Float representation of the value.
     # Raises ArgumentError if conversion is not possible.
     def self.to_float(value)
-      if value.respond_to?(:to_f)
-        value.to_f
-      else
-        raise ArgumentError, "#{value.inspect} cannot be converted to a float"
-      end
+      value.to_f
+    rescue NoMethodError
+      raise ArgumentError, "#{value.inspect} cannot be converted to a float"
     end
 
     # Internal: Convert value to a percentage.
@@ -45,11 +41,11 @@ module Flipper
     # Returns a Integer or Float representation of the value.
     # Raises ArgumentError if conversion is not possible.
     def self.to_percentage(value)
-      if value.to_s.include?('.'.freeze)
-        to_float(value)
-      else
-        to_integer(value)
-      end
+      result_to_f = value.to_f
+      result_to_i = result_to_f.to_i
+      result_to_f == result_to_i ? result_to_i : result_to_f
+    rescue NoMethodError
+      raise ArgumentError, "#{value.inspect} cannot be converted to a percentage"
     end
 
     # Internal: Convert value to a set.

--- a/spec/flipper/adapters/rollout_spec.rb
+++ b/spec/flipper/adapters/rollout_spec.rb
@@ -117,7 +117,7 @@ RSpec.describe Flipper::Adapters::Rollout do
     expect(feature.boolean_value).to eq(false)
     expect(feature.actors_value).to eq(Set.new)
     expect(feature.groups_value).to eq(Set.new)
-    expect(feature.percentage_of_actors_value).to be(25.0)
+    expect(feature.percentage_of_actors_value).to be(25)
 
     feature = destination_flipper[:verbose_logging]
     expect(feature.boolean_value).to eq(false)

--- a/spec/flipper/feature_check_context_spec.rb
+++ b/spec/flipper/feature_check_context_spec.rb
@@ -11,7 +11,7 @@ RSpec.describe Flipper::FeatureCheckContext do
   end
 
   it 'initializes just fine' do
-    instance = described_class.new(options)
+    instance = described_class.new(**options)
     expect(instance.feature_name).to eq(feature_name)
     expect(instance.values).to eq(values)
     expect(instance.thing).to eq(thing)
@@ -20,46 +20,46 @@ RSpec.describe Flipper::FeatureCheckContext do
   it 'requires feature_name' do
     options.delete(:feature_name)
     expect do
-      described_class.new(options)
-    end.to raise_error(KeyError)
+      described_class.new(**options)
+    end.to raise_error(ArgumentError)
   end
 
   it 'requires values' do
     options.delete(:values)
     expect do
-      described_class.new(options)
-    end.to raise_error(KeyError)
+      described_class.new(**options)
+    end.to raise_error(ArgumentError)
   end
 
   it 'requires thing' do
     options.delete(:thing)
     expect do
-      described_class.new(options)
-    end.to raise_error(KeyError)
+      described_class.new(**options)
+    end.to raise_error(ArgumentError)
   end
 
   it 'knows actors_value' do
     args = options.merge(values: Flipper::GateValues.new(actors: Set['User;1']))
-    expect(described_class.new(args).actors_value).to eq(Set['User;1'])
+    expect(described_class.new(**args).actors_value).to eq(Set['User;1'])
   end
 
   it 'knows groups_value' do
     args = options.merge(values: Flipper::GateValues.new(groups: Set['admins']))
-    expect(described_class.new(args).groups_value).to eq(Set['admins'])
+    expect(described_class.new(**args).groups_value).to eq(Set['admins'])
   end
 
   it 'knows boolean_value' do
-    instance = described_class.new(options.merge(values: Flipper::GateValues.new(boolean: true)))
+    instance = described_class.new(**options.merge(values: Flipper::GateValues.new(boolean: true)))
     expect(instance.boolean_value).to eq(true)
   end
 
   it 'knows percentage_of_actors_value' do
     args = options.merge(values: Flipper::GateValues.new(percentage_of_actors: 14))
-    expect(described_class.new(args).percentage_of_actors_value).to eq(14)
+    expect(described_class.new(**args).percentage_of_actors_value).to eq(14)
   end
 
   it 'knows percentage_of_time_value' do
     args = options.merge(values: Flipper::GateValues.new(percentage_of_time: 41))
-    expect(described_class.new(args).percentage_of_time_value).to eq(41)
+    expect(described_class.new(**args).percentage_of_time_value).to eq(41)
   end
 end

--- a/spec/flipper/gate_values_spec.rb
+++ b/spec/flipper/gate_values_spec.rb
@@ -80,13 +80,13 @@ RSpec.describe Flipper::GateValues do
   it 'raises argument error for percentage of time value that cannot be converted to an integer' do
     expect do
       described_class.new(percentage_of_time: ['asdf'])
-    end.to raise_error(ArgumentError, %(["asdf"] cannot be converted to an integer))
+    end.to raise_error(ArgumentError, %(["asdf"] cannot be converted to a percentage))
   end
 
   it 'raises argument error for percentage of actors value that cannot be converted to an int' do
     expect do
       described_class.new(percentage_of_actors: ['asdf'])
-    end.to raise_error(ArgumentError, %(["asdf"] cannot be converted to an integer))
+    end.to raise_error(ArgumentError, %(["asdf"] cannot be converted to a percentage))
   end
 
   it 'raises argument error for actors value that cannot be converted to a set' do
@@ -99,36 +99,5 @@ RSpec.describe Flipper::GateValues do
     expect do
       described_class.new(groups: 'asdf')
     end.to raise_error(ArgumentError, %("asdf" cannot be converted to a set))
-  end
-
-  describe '#[]' do
-    it 'can read the boolean value' do
-      expect(described_class.new(boolean: true)[:boolean]).to be(true)
-      expect(described_class.new(boolean: true)['boolean']).to be(true)
-    end
-
-    it 'can read the actors value' do
-      expect(described_class.new(actors: Set[1, 2])[:actors]).to eq(Set[1, 2])
-      expect(described_class.new(actors: Set[1, 2])['actors']).to eq(Set[1, 2])
-    end
-
-    it 'can read the groups value' do
-      expect(described_class.new(groups: Set[:admins])[:groups]).to eq(Set[:admins])
-      expect(described_class.new(groups: Set[:admins])['groups']).to eq(Set[:admins])
-    end
-
-    it 'can read the percentage of time value' do
-      expect(described_class.new(percentage_of_time: 15)[:percentage_of_time]).to eq(15)
-      expect(described_class.new(percentage_of_time: 15)['percentage_of_time']).to eq(15)
-    end
-
-    it 'can read the percentage of actors value' do
-      expect(described_class.new(percentage_of_actors: 15)[:percentage_of_actors]).to eq(15)
-      expect(described_class.new(percentage_of_actors: 15)['percentage_of_actors']).to eq(15)
-    end
-
-    it 'returns nil for value that is not present' do
-      expect(described_class.new({})['not legit']).to be(nil)
-    end
   end
 end

--- a/spec/flipper/gates/percentage_of_actors_spec.rb
+++ b/spec/flipper/gates/percentage_of_actors_spec.rb
@@ -9,7 +9,7 @@ RSpec.describe Flipper::Gates::PercentageOfActors do
     Flipper::FeatureCheckContext.new(
       feature_name: feature,
       values: Flipper::GateValues.new(percentage_of_actors: percentage_of_actors_value),
-      thing: thing || Flipper::Types::Actor.new(Flipper::Actor.new(1))
+      thing: Flipper::Types::Actor.new(thing || Flipper::Actor.new(1))
     )
   end
 

--- a/spec/flipper/typecast_spec.rb
+++ b/spec/flipper/typecast_spec.rb
@@ -56,7 +56,7 @@ RSpec.describe Flipper::Typecast do
     nil => 0,
     '' => 0,
     0 => 0,
-    0.0 => 0.0,
+    0.0 => 0,
     1 => 1,
     1.1 => 1.1,
     '0.01' => 0.01,
@@ -100,13 +100,13 @@ RSpec.describe Flipper::Typecast do
   it 'raises argument error for bad integer percentage' do
     expect do
       described_class.to_percentage(['asdf'])
-    end.to raise_error(ArgumentError, %(["asdf"] cannot be converted to an integer))
+    end.to raise_error(ArgumentError, %(["asdf"] cannot be converted to a percentage))
   end
 
   it 'raises argument error for bad float percentage' do
     expect do
       described_class.to_percentage(['asdf.0'])
-    end.to raise_error(ArgumentError, %(["asdf.0"] cannot be converted to a float))
+    end.to raise_error(ArgumentError, %(["asdf.0"] cannot be converted to a percentage))
   end
 
   it 'raises argument error for set value that cannot be converted to a set' do


### PR DESCRIPTION
@bkeepers and I paired on some Flipper#enabled? performance. 

When we started:

```
          with actor    164.802k (± 0.6%) i/s -    832.116k in   5.049373s
       without actor    259.654k (± 0.3%) i/s -      1.307M in   5.034628s
```

When we finished:

```
          with actor    255.295k (± 0.9%) i/s -      1.300M in   5.092099s
       without actor    356.474k (± 0.9%) i/s -      1.787M in   5.013634s
```

~55% for with actor. ~37% without an actor.