### PR TITLE
Speed up skipped adapter specs

### DIFF
--- a/spec/flipper/adapters/dalli_spec.rb
+++ b/spec/flipper/adapters/dalli_spec.rb
@@ -14,10 +14,8 @@ RSpec.describe Flipper::Adapters::Dalli do
 
   before do
     Dalli.logger = Logger.new('/dev/null')
-    begin
+    skip_on_error(Dalli::NetworkError, 'Memcached not available') do
       cache.flush
-    rescue Dalli::NetworkError
-      ENV['CI'] ? raise : skip('Memcached not available')
     end
   end
 

--- a/spec/flipper/adapters/mongo_spec.rb
+++ b/spec/flipper/adapters/mongo_spec.rb
@@ -15,11 +15,11 @@ RSpec.describe Flipper::Adapters::Mongo do
   let(:collection) { client['testing'] }
 
   before do
-    begin
-      collection.drop
-    rescue Mongo::Error::NoServerAvailable
-      ENV['CI'] ? raise : skip('Mongo not available')
-    rescue Mongo::Error::OperationFailure
+    skip_on_error(Mongo::Error::NoServerAvailable, 'Mongo not available') do
+      begin
+        collection.drop
+      rescue Mongo::Error::OperationFailure
+      end
     end
     collection.create
   end

--- a/spec/flipper/adapters/redis_cache_spec.rb
+++ b/spec/flipper/adapters/redis_cache_spec.rb
@@ -17,10 +17,8 @@ RSpec.describe Flipper::Adapters::RedisCache do
   subject { adapter }
 
   before do
-    begin
+    skip_on_error(Redis::CannotConnectError, 'Redis not available') do
       client.flushdb
-    rescue Redis::CannotConnectError
-      ENV['CI'] ? raise : skip('Redis not available')
     end
   end
 

--- a/spec/flipper/adapters/redis_spec.rb
+++ b/spec/flipper/adapters/redis_spec.rb
@@ -13,10 +13,8 @@ RSpec.describe Flipper::Adapters::Redis do
   subject { described_class.new(client) }
 
   before do
-    begin
+    skip_on_error(Redis::CannotConnectError, 'Redis not available') do
       client.flushdb
-    rescue Redis::CannotConnectError
-      ENV['CI'] ? raise : skip('Redis not available')
     end
   end
 

--- a/spec/flipper/adapters/rollout_spec.rb
+++ b/spec/flipper/adapters/rollout_spec.rb
@@ -11,10 +11,8 @@ RSpec.describe Flipper::Adapters::Rollout do
   let(:destination_flipper) { Flipper.new(destination_adapter) }
 
   before do
-    begin
+    skip_on_error(Redis::CannotConnectError, 'Redis not available') do
       redis.flushdb
-    rescue Redis::CannotConnectError
-      ENV['CI'] ? raise : skip('Redis not available')
     end
   end
 

--- a/spec/support/skippable.rb
+++ b/spec/support/skippable.rb
@@ -1,0 +1,18 @@
+RSpec.configure do |config|
+  config.before(:all) do
+    $skip = false
+  end
+
+  def skip_on_error(error, message, &block)
+    # Premptively skip if we've already skipped
+    skip(message) if $skip
+    block.call
+  rescue error
+    if ENV["CI"]
+      raise
+    else
+      $skip = true
+      skip(message)
+    end
+  end
+end


### PR DESCRIPTION
Minor tweak to speed up skipping of adapter specs in local dev if underlying sever is not available. Currently each example has to wait for the error, which could be ~1 second per example. This sets a global and just short-circuits the skip if one of the pervious examples in the example group fail.

Before:
```
Finished in 50.18 seconds (files took 5.08 seconds to load)
1719 examples, 0 failures, 69 pending
```

After:
```
Finished in 10.86 seconds (files took 2.63 seconds to load)
1719 examples, 0 failures, 69 pending
```