### PR TITLE
Easy Import/Export

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -10,10 +10,10 @@ gem 'debug'
 gem 'rake', '~> 12.3.3'
 gem 'statsd-ruby', '~> 1.2.1'
 gem 'rspec', '~> 3.0'
-gem 'rack-test', '~> 0.6.3'
+gem 'rack-test'
 gem 'sqlite3', "~> #{ENV['SQLITE3_VERSION'] || '1.4.1'}"
 gem 'rails', "~> #{ENV['RAILS_VERSION'] || '7.0.0'}"
-gem 'minitest', '~> 5.8'
+gem 'minitest', '~> 5.18'
 gem 'minitest-documentation'
 gem 'webmock', '~> 3.0'
 gem 'ice_age'

--- a/Gemfile
+++ b/Gemfile
@@ -8,7 +8,6 @@ end
 
 gem 'debug'
 gem 'rake', '~> 12.3.3'
-gem 'shotgun', '~> 0.9'
 gem 'statsd-ruby', '~> 1.2.1'
 gem 'rspec', '~> 3.0'
 gem 'rack-test', '~> 0.6.3'

--- a/examples/api/basic.ru
+++ b/examples/api/basic.ru
@@ -1,19 +1,18 @@
 #
 # Usage:
-#   # if you want it to not reload and be really fast
 #   bin/rackup examples/api/basic.ru -p 9999
-#
-#   # if you want reloading
-#   bin/shotgun examples/api/basic.ru -p 9999
 #
 #   http://localhost:9999/
 #
 
 require 'bundler/setup'
+require 'rack/reloader'
 require "flipper/api"
 require "flipper/adapters/pstore"
 
 # You can uncomment this to get some default data:
 # Flipper.enable :logging
+
+use Rack::Reloader
 
 run Flipper::Api.app

--- a/examples/api/custom_memoized.ru
+++ b/examples/api/custom_memoized.ru
@@ -1,15 +1,12 @@
 #
 # Usage:
-#   # if you want it to not reload and be really fast
 #   bin/rackup examples/api/custom_memoized.ru -p 9999
-#
-#   # if you want reloading
-#   bin/shotgun examples/api/custom_memoized.ru -p 9999
 #
 #   http://localhost:9999/
 #
 
 require 'bundler/setup'
+require 'rack/reloader'
 require "active_support/notifications"
 require "flipper/api"
 require "flipper/adapters/pstore"
@@ -30,6 +27,8 @@ ActiveSupport::Notifications.subscribe(/.*/, ->(*args) {
 
 # You can uncomment this to get some default data:
 # flipper[:logging].enable_percentage_of_time 5
+
+use Rack::Reloader
 
 run Flipper::Api.app(flipper) { |builder|
   builder.use Flipper::Middleware::SetupEnv, flipper

--- a/examples/api/memoized.ru
+++ b/examples/api/memoized.ru
@@ -1,15 +1,12 @@
 #
 # Usage:
-#   # if you want it to not reload and be really fast
 #   bin/rackup examples/api/memoized.ru -p 9999
-#
-#   # if you want reloading
-#   bin/shotgun examples/api/memoized.ru -p 9999
 #
 #   http://localhost:9999/
 #
 
 require 'bundler/setup'
+require 'rack/reloader'
 require "active_support/notifications"
 require "flipper/api"
 require "flipper/adapters/pstore"
@@ -37,6 +34,8 @@ Flipper.register(:admins) { |actor|
 
 # You can uncomment this to get some default data:
 # Flipper.enable :logging
+
+use Rack::Reloader
 
 run Flipper::Api.app { |builder|
   builder.use Flipper::Middleware::Memoizer, preload: true

--- a/examples/ui/authorization.ru
+++ b/examples/ui/authorization.ru
@@ -5,6 +5,7 @@
 #   http://localhost:9999/
 #
 require 'bundler/setup'
+require 'rack/reloader'
 require "flipper/ui"
 require "flipper/adapters/pstore"
 
@@ -39,6 +40,8 @@ end
 # Flipper.enable_percentage_of_time(:logging, 5)
 # Flipper.enable_percentage_of_actors(:new_cache, 15)
 # Flipper.add("a/b")
+
+use Rack::Reloader
 
 run Flipper::UI.app { |builder|
   builder.use Rack::Session::Cookie, secret: "_super_secret"

--- a/examples/ui/basic.ru
+++ b/examples/ui/basic.ru
@@ -9,6 +9,7 @@
 #   http://localhost:9999/
 #
 require 'bundler/setup'
+require 'rack/reloader'
 require "flipper/ui"
 require "flipper/adapters/pstore"
 
@@ -53,6 +54,8 @@ end
 # Flipper.enable_percentage_of_time(:logging, 5)
 # Flipper.enable_percentage_of_actors(:new_cache, 15)
 # Flipper.add("a/b")
+
+use Rack::Reloader
 
 run Flipper::UI.app { |builder|
   builder.use Rack::Session::Cookie, secret: "_super_secret"

--- a/examples/ui/basic.ru
+++ b/examples/ui/basic.ru
@@ -27,7 +27,7 @@ Flipper::UI.configure do |config|
   config.feature_creation_enabled = true
   config.feature_removal_enabled = true
   config.cloud_recommendation = true
-  config.confirm_fully_enable = true
+  config.confirm_fully_enable = false
   # config.show_feature_description_in_list = true
   config.descriptions_source = lambda do |_keys|
     {

--- a/examples/ui/read_only.ru
+++ b/examples/ui/read_only.ru
@@ -9,6 +9,7 @@
 #   http://localhost:9999/
 #
 require 'bundler/setup'
+require 'rack/reloader'
 require "flipper/ui"
 require "flipper/adapters/pstore"
 
@@ -37,6 +38,8 @@ end
 # Flipper.enable_percentage_of_time(:logging, 5)
 # Flipper.enable_percentage_of_actors(:new_cache, 15)
 # Flipper.add("a/b")
+
+use Rack::Reloader
 
 run Flipper::UI.app { |builder|
   builder.use Rack::Session::Cookie, secret: "_super_secret"

--- a/lib/flipper.rb
+++ b/lib/flipper.rb
@@ -64,7 +64,7 @@ module Flipper
                  :enable_percentage_of_time, :disable_percentage_of_time,
                  :time, :percentage_of_time,
                  :features, :feature, :[], :preload, :preload_all,
-                 :adapter, :add, :exist?, :remove, :import,
+                 :adapter, :add, :exist?, :remove, :import, :export,
                  :memoize=, :memoizing?,
                  :sync, :sync_secret # For Flipper::Cloud. Will error for OSS Flipper.
 

--- a/lib/flipper/adapter.rb
+++ b/lib/flipper/adapter.rb
@@ -44,9 +44,11 @@ module Flipper
 
     # Public: Ensure that adapter is in sync with source adapter provided.
     #
+    # source - The source adapter or export to import.
+    #
     # Returns result of Synchronizer#call.
-    def import(source_adapter)
-      Adapters::Sync::Synchronizer.new(self, source_adapter, raise: true).call
+    def import(source)
+      Adapters::Sync::Synchronizer.new(self, source, raise: true).call
     end
 
     def export(format: :json, version: 1)

--- a/lib/flipper/adapter.rb
+++ b/lib/flipper/adapter.rb
@@ -1,5 +1,6 @@
 require "set"
 require "flipper/feature"
+require "flipper/exporter"
 require "flipper/adapters/sync/synchronizer"
 
 module Flipper
@@ -46,6 +47,10 @@ module Flipper
     # Returns result of Synchronizer#call.
     def import(source_adapter)
       Adapters::Sync::Synchronizer.new(self, source_adapter, raise: true).call
+    end
+
+    def export(format: :json, version: 1)
+      Flipper::Exporter.build(format: format, version: version).call(self)
     end
 
     # Public: Default config for a feature's gate values.

--- a/lib/flipper/adapter.rb
+++ b/lib/flipper/adapter.rb
@@ -44,13 +44,21 @@ module Flipper
 
     # Public: Ensure that adapter is in sync with source adapter provided.
     #
-    # source - The source adapter or export to import.
+    # source - The source dsl, adapter or export to import.
     #
     # Returns result of Synchronizer#call.
     def import(source)
-      Adapters::Sync::Synchronizer.new(self, source, raise: true).call
+      case source
+      when Flipper::Adapter
+        Adapters::Sync::Synchronizer.new(self, source, raise: true).call
+      when Flipper::DSL
+        Adapters::Sync::Synchronizer.new(self, source.adapter, raise: true).call
+      end
     end
 
+    # Public: Exports the adapter in a given format for a given format version.
+    #
+    # Returns a Flipper::Export instance.
     def export(format: :json, version: 1)
       Flipper::Exporter.build(format: format, version: version).call(self)
     end

--- a/lib/flipper/adapter.rb
+++ b/lib/flipper/adapter.rb
@@ -16,6 +16,11 @@ module Flipper
           percentage_of_time: nil,
         }
       end
+
+      def from(source)
+        return source if source.is_a?(Flipper::Adapter)
+        source.adapter
+      end
     end
 
     # Public: Get all features and gate values in one call. Defaults to one call
@@ -41,14 +46,10 @@ module Flipper
     #
     # source - The source dsl, adapter or export to import.
     #
-    # Returns result of Synchronizer#call.
+    # Returns true if successful.
     def import(source)
-      case source
-      when Flipper::Adapter
-        Adapters::Sync::Synchronizer.new(self, source, raise: true).call
-      else
-        Adapters::Sync::Synchronizer.new(self, source.adapter, raise: true).call
-      end
+      Adapters::Sync::Synchronizer.new(self, self.class.from(source), raise: true).call
+      true
     end
 
     # Public: Exports the adapter in a given format for a given format version.

--- a/lib/flipper/adapter.rb
+++ b/lib/flipper/adapter.rb
@@ -1,8 +1,3 @@
-require "set"
-require "flipper/feature"
-require "flipper/exporter"
-require "flipper/adapters/sync/synchronizer"
-
 module Flipper
   # Adding a module include so we have some hooks for stuff down the road
   module Adapter
@@ -51,7 +46,7 @@ module Flipper
       case source
       when Flipper::Adapter
         Adapters::Sync::Synchronizer.new(self, source, raise: true).call
-      when Flipper::DSL
+      else
         Adapters::Sync::Synchronizer.new(self, source.adapter, raise: true).call
       end
     end
@@ -69,3 +64,8 @@ module Flipper
     end
   end
 end
+
+require "set"
+require "flipper/exporter"
+require "flipper/feature"
+require "flipper/adapters/sync/synchronizer"

--- a/lib/flipper/adapters/active_support_cache_store.rb
+++ b/lib/flipper/adapters/active_support_cache_store.rb
@@ -1,4 +1,5 @@
 require 'flipper'
+require 'active_support/notifications'
 
 module Flipper
   module Adapters

--- a/lib/flipper/adapters/http.rb
+++ b/lib/flipper/adapters/http.rb
@@ -123,6 +123,14 @@ module Flipper
         true
       end
 
+      def import(source)
+        adapter = self.class.from(source)
+        export = adapter.export(format: :json, version: 1)
+        response = @client.post("/import", export.contents)
+        raise Error, response unless response.is_a?(Net::HTTPNoContent)
+        true
+      end
+
       private
 
       def request_body_for_gate(gate, value)

--- a/lib/flipper/adapters/http.rb
+++ b/lib/flipper/adapters/http.rb
@@ -39,7 +39,7 @@ module Flipper
 
       def get_multi(features)
         csv_keys = features.map(&:key).join(',')
-        response = @client.get("/features?keys=#{csv_keys}")
+        response = @client.get("/features?keys=#{csv_keys}&exclude_gate_names=true")
         raise Error, response unless response.is_a?(Net::HTTPOK)
 
         parsed_response = JSON.parse(response.body)
@@ -57,7 +57,7 @@ module Flipper
       end
 
       def get_all
-        response = @client.get("/features")
+        response = @client.get("/features?exclude_gate_names=true")
         raise Error, response unless response.is_a?(Net::HTTPOK)
 
         parsed_response = JSON.parse(response.body)
@@ -76,7 +76,7 @@ module Flipper
       end
 
       def features
-        response = @client.get('/features')
+        response = @client.get('/features?exclude_gate_names=true')
         raise Error, response unless response.is_a?(Net::HTTPOK)
 
         parsed_response = JSON.parse(response.body)

--- a/lib/flipper/adapters/memoizable.rb
+++ b/lib/flipper/adapters/memoizable.rb
@@ -127,6 +127,14 @@ module Flipper
         @adapter.disable(feature, gate, thing).tap { expire_feature(feature) }
       end
 
+      def import(source)
+        @adapter.import(source).tap { cache.clear if memoizing? }
+      end
+
+      def export(format: :json, version: 1)
+        @adapter.export(format: format, version: version)
+      end
+
       # Internal: Turns local caching on/off.
       #
       # value - The Boolean that decides if local caching is on.
@@ -138,6 +146,16 @@ module Flipper
       # Internal: Returns true for using local cache, false for not.
       def memoizing?
         !!@memoize
+      end
+
+      if RUBY_VERSION >= '3.0'
+        def method_missing(name, *args, **kwargs, &block)
+          @adapter.send name, *args, **kwargs, &block
+        end
+      else
+        def method_missing(name, *args, &block)
+          @adapter.send name, *args, &block
+        end
       end
 
       private

--- a/lib/flipper/adapters/memoizable.rb
+++ b/lib/flipper/adapters/memoizable.rb
@@ -5,7 +5,7 @@ module Flipper
     # Internal: Adapter that wraps another adapter with the ability to memoize
     # adapter calls in memory. Used by flipper dsl and the memoizer middleware
     # to make it possible to memoize adapter calls for the duration of a request.
-    class Memoizable < SimpleDelegator
+    class Memoizable
       include ::Flipper::Adapter
 
       FeaturesKey = :flipper_features
@@ -27,7 +27,6 @@ module Flipper
 
       # Public
       def initialize(adapter, cache = nil)
-        super(adapter)
         @adapter = adapter
         @name = :memoizable
         @cache = cache || {}

--- a/lib/flipper/adapters/memory.rb
+++ b/lib/flipper/adapters/memory.rb
@@ -1,3 +1,4 @@
+require "flipper/adapter"
 require 'concurrent/atomic/read_write_lock'
 
 module Flipper

--- a/lib/flipper/adapters/memory.rb
+++ b/lib/flipper/adapters/memory.rb
@@ -16,7 +16,7 @@ module Flipper
 
       # Public
       def initialize(source = nil)
-        @source = Typecast.to_get_all(source)
+        @source = Typecast.features_hash(source)
         @name = :memory
         @lock = Concurrent::ReadWriteLock.new
       end
@@ -61,7 +61,7 @@ module Flipper
       end
 
       def get_all
-        @lock.with_read_lock { Typecast.to_get_all(@source) }
+        @lock.with_read_lock { Typecast.features_hash(@source) }
       end
 
       # Public
@@ -117,7 +117,7 @@ module Flipper
       # Public: a more efficient implementation of import for this adapter
       def import(source)
         adapter = self.class.from(source)
-        get_all = Typecast.to_get_all(adapter.get_all)
+        get_all = Typecast.features_hash(adapter.get_all)
         @lock.with_write_lock { @source.replace(get_all) }
         true
       end

--- a/lib/flipper/adapters/operation_logger.rb
+++ b/lib/flipper/adapters/operation_logger.rb
@@ -5,8 +5,8 @@ module Flipper
     # Public: Adapter that wraps another adapter and stores the operations.
     #
     # Useful in tests to verify calls and such. Never use outside of testing.
-    class OperationLogger < SimpleDelegator
-      include ::Flipper::Adapter
+    class OperationLogger
+      include Flipper::Adapter
 
       class Operation
         attr_reader :type, :args
@@ -18,6 +18,8 @@ module Flipper
       end
 
       OperationTypes = [
+        :import,
+        :export,
         :features,
         :add,
         :remove,
@@ -37,7 +39,6 @@ module Flipper
 
       # Public
       def initialize(adapter, operations = nil)
-        super(adapter)
         @adapter = adapter
         @name = :operation_logger
         @operations = operations || []
@@ -96,6 +97,18 @@ module Flipper
       def disable(feature, gate, thing)
         @operations << Operation.new(:disable, [feature, gate, thing])
         @adapter.disable(feature, gate, thing)
+      end
+
+      # Public
+      def import(source)
+        @operations << Operation.new(:import, [source])
+        @adapter.import(source)
+      end
+
+      # Public
+      def export(format: :json, version: 1)
+        @operations << Operation.new(:export, [format, version])
+        @adapter.export(format: format, version: version)
       end
 
       # Public: Count the number of times a certain operation happened.

--- a/lib/flipper/adapters/rollout.rb
+++ b/lib/flipper/adapters/rollout.rb
@@ -32,7 +32,7 @@ module Flipper
         return default_config if rollout_feature.nil?
 
         boolean = nil
-        groups = Set.new(rollout_feature.groups)
+        groups = Set.new(rollout_feature.groups.map(&:to_s))
         actors = Set.new(rollout_feature.users)
 
         percentage_of_actors = case rollout_feature.percentage

--- a/lib/flipper/api/error_response.rb
+++ b/lib/flipper/api/error_response.rb
@@ -24,10 +24,10 @@ module Flipper
       ERRORS = {
         feature_not_found: Error.new(1, 'Feature not found.', 404),
         group_not_registered: Error.new(2, 'Group not registered.', 404),
-        percentage_invalid:
-          Error.new(3, 'Percentage must be a positive number less than or equal to 100.', 422),
+        percentage_invalid: Error.new(3, 'Percentage must be a positive number less than or equal to 100.', 422),
         flipper_id_invalid: Error.new(4, 'Required parameter flipper_id is missing.', 422),
         name_invalid: Error.new(5, 'Required parameter name is missing.', 422),
+        import_invalid: Error.new(6, 'Import invalid.', 422),
       }.freeze
     end
   end

--- a/lib/flipper/api/middleware.rb
+++ b/lib/flipper/api/middleware.rb
@@ -23,6 +23,7 @@ module Flipper
         @action_collection.add Api::V1::Actions::Actors
         @action_collection.add Api::V1::Actions::Feature
         @action_collection.add Api::V1::Actions::Features
+        @action_collection.add Api::V1::Actions::Import
       end
 
       def call(env)

--- a/lib/flipper/api/v1/actions/features.rb
+++ b/lib/flipper/api/v1/actions/features.rb
@@ -11,6 +11,8 @@ module Flipper
           def get
             keys = params['keys']
             exclude_gates = params['exclude_gates']&.downcase == "true"
+            exclude_gate_names = params['exclude_gate_names']&.downcase == "true"
+
             features = if keys
               names = keys.split(',')
               if names.empty?
@@ -27,7 +29,10 @@ module Flipper
             end
 
             decorated_features = features.map do |feature|
-              Decorators::Feature.new(feature).as_json(exclude_gates: exclude_gates)
+              Decorators::Feature.new(feature).as_json(
+                exclude_gates: exclude_gates,
+                exclude_gate_names: exclude_gate_names
+              )
             end
 
             json_response(features: decorated_features)

--- a/lib/flipper/api/v1/actions/import.rb
+++ b/lib/flipper/api/v1/actions/import.rb
@@ -12,10 +12,10 @@ module Flipper
           def post
             body = request.body.read
             request.body.rewind
-            export = Flipper::Exporters::Json::Export.new(input: body)
+            export = Flipper::Exporters::Json::Export.new(contents: body)
             flipper.import(export)
-            json_response({}, 200)
-          rescue JSON::ParserError
+            json_response({}, 204)
+          rescue Flipper::Exporters::Json::InvalidError
             json_error_response(:import_invalid)
           end
         end

--- a/lib/flipper/api/v1/actions/import.rb
+++ b/lib/flipper/api/v1/actions/import.rb
@@ -1,0 +1,25 @@
+require 'flipper/exporters/json/export'
+require 'flipper/api/action'
+require 'flipper/api/v1/decorators/feature'
+
+module Flipper
+  module Api
+    module V1
+      module Actions
+        class Import < Api::Action
+          route %r{\A/import/?\Z}
+
+          def post
+            body = request.body.read
+            request.body.rewind
+            export = Flipper::Exporters::Json::Export.new(input: body)
+            flipper.import(export)
+            json_response({}, 200)
+          rescue JSON::ParserError
+            json_error_response(:import_invalid)
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/flipper/api/v1/decorators/feature.rb
+++ b/lib/flipper/api/v1/decorators/feature.rb
@@ -10,7 +10,7 @@ module Flipper
           alias_method :feature, :__getobj__
 
           # Public: Returns instance as hash that is ready to be json dumped.
-          def as_json(exclude_gates: false)
+          def as_json(exclude_gates: false, exclude_gate_names: false)
             result = {
               'key' => key,
               'state' => state.to_s,
@@ -19,7 +19,7 @@ module Flipper
             unless exclude_gates
               gate_values = feature.adapter.get(self)
               result['gates'] = gates.map do |gate|
-                Decorators::Gate.new(gate, gate_values[gate.key]).as_json
+                Decorators::Gate.new(gate, gate_values[gate.key]).as_json(exclude_name: exclude_gate_names)
               end
             end
 

--- a/lib/flipper/api/v1/decorators/gate.rb
+++ b/lib/flipper/api/v1/decorators/gate.rb
@@ -14,12 +14,13 @@ module Flipper
             @value = value
           end
 
-          def as_json
-            {
+          def as_json(exclude_name: false)
+            as_json = {
               'key' => gate.key.to_s,
-              'name' => gate.name.to_s,
               'value' => value_as_json,
             }
+            as_json['name'] = gate.name.to_s unless exclude_name
+            as_json
           end
 
           private

--- a/lib/flipper/dsl.rb
+++ b/lib/flipper/dsl.rb
@@ -10,7 +10,7 @@ module Flipper
     # Private: What is being used to instrument all the things.
     attr_reader :instrumenter
 
-    def_delegators :@adapter, :memoize=, :memoizing?
+    def_delegators :@adapter, :memoize=, :memoizing?, :export
 
     # Public: Returns a new instance of the DSL.
     #

--- a/lib/flipper/dsl.rb
+++ b/lib/flipper/dsl.rb
@@ -272,6 +272,11 @@ module Flipper
       adapter.features.map { |name| feature(name) }.to_set
     end
 
+    # Public: Imports another flipper instance into this one making them identical.
+    #
+    # flipper - The Flipper instance to import.
+    #
+    # Returns result of Adapter#import.
     def import(flipper)
       adapter.import(flipper.adapter)
     end

--- a/lib/flipper/dsl.rb
+++ b/lib/flipper/dsl.rb
@@ -10,7 +10,7 @@ module Flipper
     # Private: What is being used to instrument all the things.
     attr_reader :instrumenter
 
-    def_delegators :@adapter, :memoize=, :memoizing?, :export
+    def_delegators :@adapter, :memoize=, :memoizing?, :import, :export
 
     # Public: Returns a new instance of the DSL.
     #
@@ -270,15 +270,6 @@ module Flipper
     # Returns Set of Flipper::Feature instances.
     def features
       adapter.features.map { |name| feature(name) }.to_set
-    end
-
-    # Public: Imports another flipper instance into this one making them identical.
-    #
-    # flipper - The Flipper instance to import.
-    #
-    # Returns result of Adapter#import.
-    def import(flipper)
-      adapter.import(flipper.adapter)
     end
 
     # Cloud DSL method that does nothing for open source version.

--- a/lib/flipper/export.rb
+++ b/lib/flipper/export.rb
@@ -1,3 +1,5 @@
+require "flipper/adapters/memory"
+
 module Flipper
   class Export
     attr_reader :input, :format, :version
@@ -6,6 +8,14 @@ module Flipper
       @input = input
       @format = format
       @version = version
+    end
+
+    def features
+      raise NotImplementedError
+    end
+
+    def adapter
+      @adapter ||= Flipper::Adapters::Memory.new(features)
     end
 
     def eql?(other)

--- a/lib/flipper/export.rb
+++ b/lib/flipper/export.rb
@@ -2,10 +2,10 @@ require "flipper/adapters/memory"
 
 module Flipper
   class Export
-    attr_reader :input, :format, :version
+    attr_reader :contents, :format, :version
 
-    def initialize(input:, format: :json, version: 1)
-      @input = input
+    def initialize(contents:, format: :json, version: 1)
+      @contents = contents
       @format = format
       @version = version
     end
@@ -19,7 +19,7 @@ module Flipper
     end
 
     def eql?(other)
-      self.class.eql?(other.class) && @input == other.input && @format == other.format && @version == other.version
+      self.class.eql?(other.class) && @contents == other.contents && @format == other.format && @version == other.version
     end
     alias_method :==, :eql?
   end

--- a/lib/flipper/export.rb
+++ b/lib/flipper/export.rb
@@ -1,0 +1,16 @@
+module Flipper
+  class Export
+    attr_reader :input, :format, :version
+
+    def initialize(input:, format: :json, version: 1)
+      @input = input
+      @format = format
+      @version = version
+    end
+
+    def eql?(other)
+      self.class.eql?(other.class) && @input == other.input && @format == other.format && @version == other.version
+    end
+    alias_method :==, :eql?
+  end
+end

--- a/lib/flipper/exporter.rb
+++ b/lib/flipper/exporter.rb
@@ -1,0 +1,17 @@
+require "flipper/exporters/json/v1"
+
+module Flipper
+  module Exporter
+    extend self
+
+    FORMATTERS = {
+      json: {
+        1 => Flipper::Exporters::Json::V1,
+      }
+    }.freeze
+
+    def build(format: :json, version: 1)
+      FORMATTERS.fetch(format).fetch(version).new
+    end
+  end
+end

--- a/lib/flipper/exporters/json/export.rb
+++ b/lib/flipper/exporters/json/export.rb
@@ -1,0 +1,32 @@
+require "flipper/export"
+
+module Flipper
+  module Exporters
+    module Json
+      # Internal: JSON export class that knows how to build features hash
+      # from input.
+      class Export < ::Flipper::Export
+        def initialize(input:, version: 1)
+          super input: input, version: version, format: :json
+        end
+
+        # Public: The features hash identical to calling get_all on adapter.
+        def features
+          @features ||= begin
+            features = JSON.parse(input).fetch("features")
+
+            result = {}
+            features.each do |feature_key, gates|
+              result[feature_key] = {}
+              gates.each do |gate_key, value|
+                result[feature_key][gate_key.to_sym] = value
+              end
+            end
+
+            result
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/flipper/exporters/json/export.rb
+++ b/lib/flipper/exporters/json/export.rb
@@ -19,7 +19,7 @@ module Flipper
         def features
           @features ||= begin
             features = JSON.parse(contents).fetch("features")
-            Typecast.to_get_all(features)
+            Typecast.features_hash(features)
           rescue JSON::ParserError
             raise JsonError
           rescue

--- a/lib/flipper/exporters/json/v1.rb
+++ b/lib/flipper/exporters/json/v1.rb
@@ -1,0 +1,29 @@
+require "json"
+
+module Flipper
+  module Exporters
+    module Json
+      class V1
+        VERSION = 1
+
+        def call(adapter)
+          features = adapter.get_all
+
+          features.each do |feature_key, gates|
+            gates.each do |key, value|
+              case value
+              when Set
+                features[feature_key][key] = value.to_a
+              end
+            end
+          end
+
+          JSON.dump({
+            version: VERSION,
+            features: features,
+          })
+        end
+      end
+    end
+  end
+end

--- a/lib/flipper/exporters/json/v1.rb
+++ b/lib/flipper/exporters/json/v1.rb
@@ -1,4 +1,5 @@
 require "json"
+require "flipper/export"
 
 module Flipper
   module Exporters
@@ -18,10 +19,12 @@ module Flipper
             end
           end
 
-          JSON.dump({
+          json = JSON.dump({
             version: VERSION,
             features: features,
           })
+
+          Export.new(input: json, format: :json, version: VERSION)
         end
       end
     end

--- a/lib/flipper/exporters/json/v1.rb
+++ b/lib/flipper/exporters/json/v1.rb
@@ -1,5 +1,5 @@
 require "json"
-require "flipper/export"
+require "flipper/exporters/json/export"
 
 module Flipper
   module Exporters
@@ -10,6 +10,7 @@ module Flipper
         def call(adapter)
           features = adapter.get_all
 
+          # Convert sets to arrays for json
           features.each do |feature_key, gates|
             gates.each do |key, value|
               case value
@@ -24,7 +25,7 @@ module Flipper
             features: features,
           })
 
-          Export.new(input: json, format: :json, version: VERSION)
+          Json::Export.new(input: json, version: VERSION)
         end
       end
     end

--- a/lib/flipper/exporters/json/v1.rb
+++ b/lib/flipper/exporters/json/v1.rb
@@ -25,7 +25,7 @@ module Flipper
             features: features,
           })
 
-          Json::Export.new(input: json, version: VERSION)
+          Json::Export.new(contents: json, version: VERSION)
         end
       end
     end

--- a/lib/flipper/instrumentation/subscriber.rb
+++ b/lib/flipper/instrumentation/subscriber.rb
@@ -72,6 +72,14 @@ module Flipper
         update_timer "flipper.adapter.#{adapter_name}.#{operation}"
       end
 
+      def update_poller_metrics
+        # noop
+      end
+
+      def update_synchronizer_call_metrics
+        # noop
+      end
+
       QUESTION_MARK = '?'.freeze
 
       # Private

--- a/lib/flipper/spec/shared_adapter_specs.rb
+++ b/lib/flipper/spec/shared_adapter_specs.rb
@@ -33,7 +33,15 @@ RSpec.shared_examples_for 'a flipper adapter' do
     expect(subject.class.ancestors).to include(Flipper::Adapter)
   end
 
+  it 'knows how to get adapter from source' do
+    adapter = Flipper::Adapters::Memory.new
+    flipper = Flipper.new(adapter)
+    expect(subject.class.from(adapter).class.ancestors).to include(Flipper::Adapter)
+    expect(subject.class.from(flipper).class.ancestors).to include(Flipper::Adapter)
+  end
+
   it 'returns correct default values for the gates if none are enabled' do
+    expect(subject.get(feature)).to eq(subject.class.default_config)
     expect(subject.get(feature)).to eq(subject.default_config)
   end
 
@@ -303,5 +311,20 @@ RSpec.shared_examples_for 'a flipper adapter' do
     subject.enable(feature, actor_gate, flipper.actor(actor))
     subject.enable(feature, boolean_gate, flipper.boolean(true))
     expect(subject.get(feature)).to eq(subject.default_config.merge(boolean: "true"))
+  end
+
+  it 'can import and export' do
+    adapter = Flipper::Adapters::Memory.new
+    source_flipper = Flipper.new(adapter)
+    source_flipper.enable(:stats)
+    export = adapter.export
+
+    # some adapters cannot import so if they return false lets assert it
+    # didn't happen
+    if subject.import(export)
+      expect(flipper[:stats]).to be_enabled
+    else
+      expect(flipper[:stats]).not_to be_enabled
+    end
   end
 end

--- a/lib/flipper/test/shared_adapter_test.rb
+++ b/lib/flipper/test/shared_adapter_test.rb
@@ -34,7 +34,15 @@ module Flipper
         assert_includes @adapter.class.ancestors, Flipper::Adapter
       end
 
+      def test_knows_how_to_get_adapter_from_source
+        adapter = Flipper::Adapters::Memory.new
+        flipper = Flipper.new(adapter)
+        assert_equal adapter, @adapter.class.from(adapter)
+        assert_equal adapter, @adapter.class.from(flipper)
+      end
+
       def test_returns_correct_default_values_for_gates_if_none_are_enabled
+        assert_equal @adapter.class.default_config, @adapter.get(@feature)
         assert_equal @adapter.default_config, @adapter.get(@feature)
       end
 
@@ -299,6 +307,21 @@ module Flipper
         assert_equal true, @adapter.enable(@feature, @actor_gate, @flipper.actor(actor))
         assert_equal true, @adapter.enable(@feature, @boolean_gate, @flipper.boolean(true))
         assert_equal @adapter.default_config.merge(boolean: "true"), @adapter.get(@feature)
+      end
+
+      def test_can_import_and_export
+        adapter = Flipper::Adapters::Memory.new
+        source_flipper = Flipper.new(adapter)
+        source_flipper.enable(:stats)
+        export = adapter.export
+
+        # some adapters cannot import so if they return false lets assert it
+        # didn't happen
+        if @adapter.import(export)
+          assert @flipper[:stats].enabled?
+        else
+          refute @flipper[:stats].enabled?
+        end
       end
     end
   end

--- a/lib/flipper/test/shared_adapter_test.rb
+++ b/lib/flipper/test/shared_adapter_test.rb
@@ -37,8 +37,9 @@ module Flipper
       def test_knows_how_to_get_adapter_from_source
         adapter = Flipper::Adapters::Memory.new
         flipper = Flipper.new(adapter)
-        assert_equal adapter, @adapter.class.from(adapter)
-        assert_equal adapter, @adapter.class.from(flipper)
+
+        assert_includes adapter.class.from(adapter).class.ancestors, Flipper::Adapter
+        assert_includes adapter.class.from(flipper).class.ancestors, Flipper::Adapter
       end
 
       def test_returns_correct_default_values_for_gates_if_none_are_enabled

--- a/lib/flipper/typecast.rb
+++ b/lib/flipper/typecast.rb
@@ -63,7 +63,7 @@ module Flipper
       end
     end
 
-    def self.to_get_all(source)
+    def self.features_hash(source)
       normalized_source = {}
       (source || {}).each do |feature_key, gates|
         normalized_source[feature_key] ||= {}

--- a/lib/flipper/typecast.rb
+++ b/lib/flipper/typecast.rb
@@ -62,5 +62,22 @@ module Flipper
         raise ArgumentError, "#{value.inspect} cannot be converted to a set"
       end
     end
+
+    def self.to_get_all(source)
+      normalized_source = {}
+      (source || {}).each do |feature_key, gates|
+        normalized_source[feature_key] ||= {}
+        gates.each do |gate_key, value|
+          normalized_value = case value
+          when Array, Set
+            value.to_set
+          else
+            value ? value.to_s : value
+          end
+          normalized_source[feature_key][gate_key.to_sym] = normalized_value
+        end
+      end
+      normalized_source
+    end
   end
 end

--- a/lib/flipper/ui/action.rb
+++ b/lib/flipper/ui/action.rb
@@ -174,7 +174,12 @@ module Flipper
       # Returns a response.
       def json_response(object)
         header 'Content-Type', 'application/json'
-        body = JSON.dump(object)
+        body = case object
+        when String
+          object
+        else
+          JSON.dump(object)
+        end
         halt [@code, @headers, [body]]
       end
 

--- a/lib/flipper/ui/actions/backup.rb
+++ b/lib/flipper/ui/actions/backup.rb
@@ -20,7 +20,7 @@ module Flipper
           header 'Content-Disposition', "Attachment;filename=flipper_#{flipper.adapter.adapter.name}_#{Time.now.to_i}.json"
 
           export = flipper.export(format: :json, version: 1)
-          json_response export.input
+          json_response export.contents
         end
       end
     end

--- a/lib/flipper/ui/actions/backup.rb
+++ b/lib/flipper/ui/actions/backup.rb
@@ -19,7 +19,8 @@ module Flipper
         def post
           header 'Content-Disposition', "Attachment;filename=flipper_#{flipper.adapter.adapter.name}_#{Time.now.to_i}.json"
 
-          json_response flipper.export(format: :json, version: 1)
+          export = flipper.export(format: :json, version: 1)
+          json_response export.input
         end
       end
     end

--- a/lib/flipper/ui/actions/backup.rb
+++ b/lib/flipper/ui/actions/backup.rb
@@ -1,0 +1,41 @@
+require 'flipper/ui/action'
+require 'flipper/ui/util'
+
+module Flipper
+  module UI
+    module Actions
+      class Backup < UI::Action
+        route %r{\A/backup/?\Z}
+
+        def get
+          @page_title = 'Backup'
+
+          breadcrumb 'Home', '/'
+          breadcrumb 'Backup'
+
+          view_response :backup
+        end
+
+        def post
+          features = flipper.adapter.get_all
+
+          features.each do |feature_key, gates|
+            gates.each do |key, value|
+              case value
+              when Set
+                features[feature_key][key] = value.to_a
+              end
+            end
+          end
+
+          header 'Content-Disposition', "Attachment;filename=flipper_#{flipper.adapter.adapter.name}_#{Time.now.to_i}.json"
+
+          json_response({
+            version: 1,
+            features: features,
+          })
+        end
+      end
+    end
+  end
+end

--- a/lib/flipper/ui/actions/backup.rb
+++ b/lib/flipper/ui/actions/backup.rb
@@ -17,23 +17,9 @@ module Flipper
         end
 
         def post
-          features = flipper.adapter.get_all
-
-          features.each do |feature_key, gates|
-            gates.each do |key, value|
-              case value
-              when Set
-                features[feature_key][key] = value.to_a
-              end
-            end
-          end
-
           header 'Content-Disposition', "Attachment;filename=flipper_#{flipper.adapter.adapter.name}_#{Time.now.to_i}.json"
 
-          json_response({
-            version: 1,
-            features: features,
-          })
+          json_response flipper.export(format: :json, version: 1)
         end
       end
     end

--- a/lib/flipper/ui/actions/export.rb
+++ b/lib/flipper/ui/actions/export.rb
@@ -4,17 +4,8 @@ require 'flipper/ui/util'
 module Flipper
   module UI
     module Actions
-      class Backup < UI::Action
-        route %r{\A/backup/?\Z}
-
-        def get
-          @page_title = 'Backup'
-
-          breadcrumb 'Home', '/'
-          breadcrumb 'Backup'
-
-          view_response :backup
-        end
+      class Export < UI::Action
+        route %r{\A/settings\/export/?\Z}
 
         def post
           header 'Content-Disposition', "Attachment;filename=flipper_#{flipper.adapter.adapter.name}_#{Time.now.to_i}.json"

--- a/lib/flipper/ui/actions/import.rb
+++ b/lib/flipper/ui/actions/import.rb
@@ -1,0 +1,19 @@
+require 'flipper/ui/action'
+require 'flipper/ui/util'
+
+module Flipper
+  module UI
+    module Actions
+      class Import < UI::Action
+        route %r{\A/settings\/import/?\Z}
+
+        def post
+          contents = params['file'][:tempfile].read
+          export = Flipper::Exporters::Json::Export.new(contents: contents)
+          flipper.import(export)
+          redirect_to "/features"
+        end
+      end
+    end
+  end
+end

--- a/lib/flipper/ui/actions/settings.rb
+++ b/lib/flipper/ui/actions/settings.rb
@@ -1,0 +1,21 @@
+require 'flipper/ui/action'
+require 'flipper/ui/util'
+
+module Flipper
+  module UI
+    module Actions
+      class Settings < UI::Action
+        route %r{\A/settings/?\Z}
+
+        def get
+          @page_title = 'Settings'
+
+          breadcrumb 'Home', '/'
+          breadcrumb 'Settings'
+
+          view_response :settings
+        end
+      end
+    end
+  end
+end

--- a/lib/flipper/ui/middleware.rb
+++ b/lib/flipper/ui/middleware.rb
@@ -25,6 +25,7 @@ module Flipper
         @action_collection.add UI::Actions::PercentageOfActorsGate
         @action_collection.add UI::Actions::Feature
         @action_collection.add UI::Actions::Features
+        @action_collection.add UI::Actions::Backup
 
         # Static Assets/Files
         @action_collection.add UI::Actions::File

--- a/lib/flipper/ui/middleware.rb
+++ b/lib/flipper/ui/middleware.rb
@@ -25,7 +25,8 @@ module Flipper
         @action_collection.add UI::Actions::PercentageOfActorsGate
         @action_collection.add UI::Actions::Feature
         @action_collection.add UI::Actions::Features
-        @action_collection.add UI::Actions::Backup
+        @action_collection.add UI::Actions::Export
+        @action_collection.add UI::Actions::Settings
 
         # Static Assets/Files
         @action_collection.add UI::Actions::File

--- a/lib/flipper/ui/middleware.rb
+++ b/lib/flipper/ui/middleware.rb
@@ -26,6 +26,7 @@ module Flipper
         @action_collection.add UI::Actions::Feature
         @action_collection.add UI::Actions::Features
         @action_collection.add UI::Actions::Export
+        @action_collection.add UI::Actions::Import
         @action_collection.add UI::Actions::Settings
 
         # Static Assets/Files

--- a/lib/flipper/ui/views/backup.erb
+++ b/lib/flipper/ui/views/backup.erb
@@ -1,0 +1,11 @@
+<div class="card">
+  <div class="card-header">
+    <h4 class="m-0">Backup</h4>
+  </div>
+  <div class="card-body">
+    <form action="<%= script_name %>/backup" method="post" class="form-inline">
+      <%== csrf_input_tag %>
+      <input type="submit" value="Download" class="btn btn-sm btn-light">
+    </form>
+  </div>
+</div>

--- a/lib/flipper/ui/views/layout.erb
+++ b/lib/flipper/ui/views/layout.erb
@@ -17,6 +17,12 @@
         </div>
       <%- end -%>
 
+      <div class="container text-muted small mb-3">
+        <a href="https://www.flippercloud.io/docs/ui?utm_source=oss&utm_medium=ui&utm_campaign=docs">Docs</a> &bull;
+        <a href="<%= script_name %>/backup">Backup</a> &bull;
+        Version: <%= Flipper::VERSION %>
+      </div>
+
       <nav aria-label="breadcrumb">
         <ol class="breadcrumb bg-white border align-items-center mb-4">
           <% @breadcrumbs.each do |breadcrumb| %>

--- a/lib/flipper/ui/views/layout.erb
+++ b/lib/flipper/ui/views/layout.erb
@@ -19,7 +19,7 @@
 
       <div class="container text-muted small mb-3">
         <a href="https://www.flippercloud.io/docs/ui?utm_source=oss&utm_medium=ui&utm_campaign=docs">Docs</a> &bull;
-        <a href="<%= script_name %>/backup">Backup</a> &bull;
+        <a href="<%= script_name %>/settings">Settings</a> &bull;
         Version: <%= Flipper::VERSION %>
       </div>
 

--- a/lib/flipper/ui/views/settings.erb
+++ b/lib/flipper/ui/views/settings.erb
@@ -1,10 +1,11 @@
 <div class="card">
   <div class="card-header">
-    <h4 class="m-0">Backup</h4>
+    <h4 class="m-0">Export</h4>
   </div>
   <div class="card-body">
-    <form action="<%= script_name %>/backup" method="post" class="form-inline">
+    <form action="<%= script_name %>/settings/export" method="post">
       <%== csrf_input_tag %>
+      <p>Download all your feature data in a single file.</p>
       <input type="submit" value="Download" class="btn btn-sm btn-light">
     </form>
   </div>

--- a/lib/flipper/ui/views/settings.erb
+++ b/lib/flipper/ui/views/settings.erb
@@ -1,4 +1,4 @@
-<div class="card">
+<div class="card mb-4 ">
   <div class="card-header">
     <h4 class="m-0">Export</h4>
   </div>
@@ -7,6 +7,20 @@
       <%== csrf_input_tag %>
       <p>Download all your feature data in a single file.</p>
       <input type="submit" value="Download" class="btn btn-sm btn-light">
+    </form>
+  </div>
+</div>
+
+<div class="card">
+  <div class="card-header">
+    <h4 class="m-0">Import</h4>
+  </div>
+  <div class="card-body">
+    <p>Import a backup file to restore your feature data. This will overwrite any of your existing feature data so be sure you are uploading the correct export.</p>
+    <form action="<%= script_name %>/settings/import" method="post" class="form-inline" enctype="multipart/form-data">
+      <%== csrf_input_tag %>
+      <input type="file" name="file" class="form-control form-control-sm mr-sm-2 mb-2 mb-sm-0">
+      <input type="submit" value="Import" class="btn btn-sm btn-light">
     </form>
   </div>
 </div>

--- a/spec/fixtures/flipper_pstore_1679087600.json
+++ b/spec/fixtures/flipper_pstore_1679087600.json
@@ -1,0 +1,46 @@
+{
+  "version": 1,
+  "features": {
+    "search": {
+      "boolean": null,
+      "actors": [
+        "john",
+        "another",
+        "testing"
+      ],
+      "percentage_of_actors": null,
+      "percentage_of_time": null,
+      "groups": [
+        "admins"
+      ]
+    },
+    "new_pricing": {
+      "boolean": "true",
+      "actors": [],
+      "percentage_of_actors": null,
+      "percentage_of_time": null,
+      "groups": []
+    },
+    "google_analytics_tag": {
+      "boolean": null,
+      "actors": [],
+      "percentage_of_actors": "100",
+      "percentage_of_time": null,
+      "groups": []
+    },
+    "help_scout_tag": {
+      "boolean": null,
+      "actors": [],
+      "percentage_of_actors": null,
+      "percentage_of_time": "50",
+      "groups": []
+    },
+    "nope": {
+      "boolean": null,
+      "actors": [],
+      "percentage_of_actors": null,
+      "percentage_of_time": null,
+      "groups": []
+    }
+  }
+}

--- a/spec/flipper/adapter_spec.rb
+++ b/spec/flipper/adapter_spec.rb
@@ -30,9 +30,9 @@ RSpec.describe Flipper::Adapter do
   end
 
   describe '#import' do
-    it 'returns nothing' do
+    it 'returns true' do
       result = destination_flipper.import(source_flipper)
-      expect(result).to be(nil)
+      expect(result).to be(true)
     end
 
     it 'can import from one adapter to another' do
@@ -133,15 +133,13 @@ RSpec.describe Flipper::Adapter do
     it "exports features" do
       source_flipper.enable(:search)
       export = source_flipper.export
-      data = JSON.parse(export.input)
-      expect(data.dig("features", "search", "boolean")).to eq("true")
+      expect(export.features.dig("search", :boolean)).to eq("true")
     end
 
     it "exports with arguments" do
       source_flipper.enable(:search)
       export = source_flipper.export(format: :json, version: 1)
-      data = JSON.parse(export.input)
-      expect(data.dig("features", "search", "boolean")).to eq("true")
+      expect(export.features.dig("search", :boolean)).to eq("true")
     end
   end
 end

--- a/spec/flipper/adapter_spec.rb
+++ b/spec/flipper/adapter_spec.rb
@@ -114,6 +114,19 @@ RSpec.describe Flipper::Adapter do
       destination_flipper.import(source_flipper)
       expect(destination_flipper.features.map(&:key)).to eq([])
     end
+
+    it 'can import an export' do
+      source_flipper.enable(:search)
+      source_flipper.enable(:google_analytics, Flipper::Actor.new("User;1"))
+
+      destination_flipper.import(source_flipper.export)
+
+      feature = destination_flipper[:search]
+      expect(feature.boolean_value).to be(true)
+
+      feature = destination_flipper[:google_analytics]
+      expect(feature.actors_value).to eq(Set["User;1"])
+    end
   end
 
   describe "#export" do

--- a/spec/flipper/adapter_spec.rb
+++ b/spec/flipper/adapter_spec.rb
@@ -119,15 +119,15 @@ RSpec.describe Flipper::Adapter do
   describe "#export" do
     it "exports features" do
       source_flipper.enable(:search)
-      result = source_flipper.export
-      data = JSON.parse(result)
+      export = source_flipper.export
+      data = JSON.parse(export.input)
       expect(data.dig("features", "search", "boolean")).to eq("true")
     end
 
     it "exports with arguments" do
       source_flipper.enable(:search)
-      result = source_flipper.export(format: :json, version: 1)
-      data = JSON.parse(result)
+      export = source_flipper.export(format: :json, version: 1)
+      data = JSON.parse(export.input)
       expect(data.dig("features", "search", "boolean")).to eq("true")
     end
   end

--- a/spec/flipper/adapter_spec.rb
+++ b/spec/flipper/adapter_spec.rb
@@ -115,4 +115,20 @@ RSpec.describe Flipper::Adapter do
       expect(destination_flipper.features.map(&:key)).to eq([])
     end
   end
+
+  describe "#export" do
+    it "exports features" do
+      source_flipper.enable(:search)
+      result = source_flipper.export
+      data = JSON.parse(result)
+      expect(data.dig("features", "search", "boolean")).to eq("true")
+    end
+
+    it "exports with arguments" do
+      source_flipper.enable(:search)
+      result = source_flipper.export(format: :json, version: 1)
+      data = JSON.parse(result)
+      expect(data.dig("features", "search", "boolean")).to eq("true")
+    end
+  end
 end

--- a/spec/flipper/adapters/http_spec.rb
+++ b/spec/flipper/adapters/http_spec.rb
@@ -104,7 +104,7 @@ RSpec.describe Flipper::Adapters::Http do
 
   describe "#get_multi" do
     it "raises error when not successful response" do
-      stub_request(:get, "http://app.com/flipper/features?keys=feature_panel")
+      stub_request(:get, "http://app.com/flipper/features?keys=feature_panel&exclude_gate_names=true")
         .to_return(status: 503, body: "", headers: {})
 
       adapter = described_class.new(url: 'http://app.com/flipper')
@@ -116,7 +116,7 @@ RSpec.describe Flipper::Adapters::Http do
 
   describe "#get_all" do
     it "raises error when not successful response" do
-      stub_request(:get, "http://app.com/flipper/features")
+      stub_request(:get, "http://app.com/flipper/features?exclude_gate_names=true")
         .to_return(status: 503, body: "", headers: {})
 
       adapter = described_class.new(url: 'http://app.com/flipper')
@@ -128,7 +128,7 @@ RSpec.describe Flipper::Adapters::Http do
 
   describe "#features" do
     it "raises error when not successful response" do
-      stub_request(:get, "http://app.com/flipper/features")
+      stub_request(:get, "http://app.com/flipper/features?exclude_gate_names=true")
         .to_return(status: 503, body: "", headers: {})
 
       adapter = described_class.new(url: 'http://app.com/flipper')

--- a/spec/flipper/adapters/instrumented_spec.rb
+++ b/spec/flipper/adapters/instrumented_spec.rb
@@ -16,16 +16,6 @@ RSpec.describe Flipper::Adapters::Instrumented do
 
   it_should_behave_like 'a flipper adapter'
 
-  it 'forwards missing methods to underlying adapter' do
-    adapter = Class.new do
-      def foo
-        :foo
-      end
-    end.new
-    instrumented = described_class.new(adapter)
-    expect(instrumented.foo).to eq(:foo)
-  end
-
   describe '#name' do
     it 'is instrumented' do
       expect(subject.name).to be(:instrumented)
@@ -143,6 +133,34 @@ RSpec.describe Flipper::Adapters::Instrumented do
       expect(event.name).to eq('adapter_operation.flipper')
       expect(event.payload[:operation]).to eq(:features)
       expect(event.payload[:adapter_name]).to eq(:memory)
+      expect(event.payload[:result]).to be(result)
+    end
+  end
+
+  describe '#import' do
+    it 'records instrumentation' do
+      result = subject.import(Flipper::Adapters::Memory.new)
+
+      event = instrumenter.events.last
+      expect(event).not_to be_nil
+      expect(event.name).to eq('adapter_operation.flipper')
+      expect(event.payload[:operation]).to eq(:import)
+      expect(event.payload[:adapter_name]).to eq(:memory)
+      expect(event.payload[:result]).to be(result)
+    end
+  end
+
+  describe '#export' do
+    it 'records instrumentation' do
+      result = subject.export(format: :json, version: 1)
+
+      event = instrumenter.events.last
+      expect(event).not_to be_nil
+      expect(event.name).to eq('adapter_operation.flipper')
+      expect(event.payload[:operation]).to eq(:export)
+      expect(event.payload[:adapter_name]).to eq(:memory)
+      expect(event.payload[:format]).to be(:json)
+      expect(event.payload[:version]).to be(1)
       expect(event.payload[:result]).to be(result)
     end
   end

--- a/spec/flipper/adapters/memoizable_spec.rb
+++ b/spec/flipper/adapters/memoizable_spec.rb
@@ -239,6 +239,36 @@ RSpec.describe Flipper::Adapters::Memoizable do
     end
   end
 
+  describe "#import" do
+    context "with memoization enabled" do
+      before do
+        subject.memoize = true
+      end
+
+      it "unmemoizes features" do
+        cache[:foo] = "bar"
+        flipper[:stats].enable
+        flipper[:search].disable
+        subject.import(Flipper::Adapters::Memory.new)
+        expect(cache).to be_empty
+      end
+    end
+
+    context "with memoization disabled" do
+      before do
+        subject.memoize = false
+      end
+
+      it "does not unmemoize features" do
+        cache[:foo] = "bar"
+        flipper[:stats].enable
+        flipper[:search].disable
+        subject.import(Flipper::Adapters::Memory.new)
+        expect(cache).not_to be_empty
+      end
+    end
+  end
+
   describe '#features' do
     context 'with memoization enabled' do
       before do

--- a/spec/flipper/adapters/memoizable_spec.rb
+++ b/spec/flipper/adapters/memoizable_spec.rb
@@ -11,16 +11,6 @@ RSpec.describe Flipper::Adapters::Memoizable do
 
   it_should_behave_like 'a flipper adapter'
 
-  it 'forwards missing methods to underlying adapter' do
-    adapter = Class.new do
-      def foo
-        :foo
-      end
-    end.new
-    memoizable = described_class.new(adapter)
-    expect(memoizable.foo).to eq(:foo)
-  end
-
   describe '#name' do
     it 'is instrumented' do
       expect(subject.name).to be(:memoizable)

--- a/spec/flipper/adapters/operation_logger_spec.rb
+++ b/spec/flipper/adapters/operation_logger_spec.rb
@@ -18,16 +18,6 @@ RSpec.describe Flipper::Adapters::OperationLogger do
     expect(output).to match(/@adapter=#<Flipper::Adapters::Memory/)
   end
 
-  it 'forwards missing methods to underlying adapter' do
-    adapter = Class.new do
-      def foo
-        :foo
-      end
-    end.new
-    operation_logger = described_class.new(adapter)
-    expect(operation_logger.foo).to eq(:foo)
-  end
-
   describe '#get' do
     before do
       @feature = flipper[:stats]
@@ -104,6 +94,35 @@ RSpec.describe Flipper::Adapters::OperationLogger do
 
     it 'returns result' do
       expect(@result).to eq(adapter.add(@feature))
+    end
+  end
+
+  describe '#import' do
+    before do
+      @source = Flipper::Adapters::Memory.new
+      @result = subject.import(@source)
+    end
+
+    it 'logs operation' do
+      expect(subject.count(:import)).to be(1)
+    end
+
+    it 'returns result' do
+      expect(@result).to eq(adapter.import(@source))
+    end
+  end
+
+  describe '#export' do
+    before do
+      @result = subject.export(format: :json, version: 1)
+    end
+
+    it 'logs operation' do
+      expect(subject.count(:export)).to be(1)
+    end
+
+    it 'returns result' do
+      expect(@result).to eq(adapter.export(format: :json, version: 1))
     end
   end
 end

--- a/spec/flipper/adapters/rollout_spec.rb
+++ b/spec/flipper/adapters/rollout_spec.rb
@@ -31,7 +31,7 @@ RSpec.describe Flipper::Adapters::Rollout do
       feature = source_flipper[:chat]
       expected = {
         boolean: nil,
-        groups: Set.new([:admins]),
+        groups: Set.new(["admins"]),
         actors: Set.new(["1"]),
         percentage_of_actors: 20.0,
         percentage_of_time: nil,

--- a/spec/flipper/api/v1/actions/features_spec.rb
+++ b/spec/flipper/api/v1/actions/features_spec.rb
@@ -8,10 +8,11 @@ RSpec.describe Flipper::Api::V1::Actions::Features do
       before do
         flipper[:my_feature].enable
         flipper[:my_feature].enable(admin)
-        get '/features'
       end
 
       it 'responds with correct attributes' do
+        get '/features'
+
         expected_response = {
           'features' => [
             {
@@ -47,6 +48,28 @@ RSpec.describe Flipper::Api::V1::Actions::Features do
             },
           ],
         }
+        expect(last_response.status).to eq(200)
+        expect(json_response).to eq(expected_response)
+      end
+
+      it 'responds without names when instructed by param' do
+        expected_response = {
+          'features' => [
+            {
+              'key' => 'my_feature',
+              'state' => 'on',
+              'gates' => [
+                { 'key' => 'boolean', 'value' => 'true'},
+                { 'key' => 'actors', 'value' => ['10']},
+                {'key' => 'percentage_of_actors', 'value' => nil},
+                { 'key' => 'percentage_of_time', 'value' => nil},
+                { 'key' => 'groups', 'value' => []},
+              ],
+            },
+          ],
+        }
+
+        get '/features', 'exclude_gate_names' => 'true'
         expect(last_response.status).to eq(200)
         expect(json_response).to eq(expected_response)
       end
@@ -109,7 +132,6 @@ RSpec.describe Flipper::Api::V1::Actions::Features do
 
       it 'returns decorated feature' do
         expected_response = {
-
           'key' => 'my_feature',
           'state' => 'off',
           'gates' => [

--- a/spec/flipper/api/v1/actions/groups_gate_spec.rb
+++ b/spec/flipper/api/v1/actions/groups_gate_spec.rb
@@ -19,7 +19,7 @@ RSpec.describe Flipper::Api::V1::Actions::GroupsGate do
     end
 
     it 'returns decorated feature with group enabled' do
-      group_gate = json_response['gates'].find { |m| m['name'] == 'group' }
+      group_gate = json_response['gates'].find { |m| m['key'] == 'groups' }
       expect(group_gate['value']).to eq(['admins'])
     end
   end
@@ -42,7 +42,7 @@ RSpec.describe Flipper::Api::V1::Actions::GroupsGate do
     end
 
     it 'returns decorated feature with group enabled' do
-      group_gate = json_response['gates'].find { |m| m['name'] == 'group' }
+      group_gate = json_response['gates'].find { |m| m['key'] == 'groups' }
       expect(group_gate['value']).to eq(['admins'])
     end
   end
@@ -89,7 +89,7 @@ RSpec.describe Flipper::Api::V1::Actions::GroupsGate do
     end
 
     it 'returns decorated feature with group disabled' do
-      group_gate = json_response['gates'].find { |m| m['name'] == 'group' }
+      group_gate = json_response['gates'].find { |m| m['key'] == 'groups' }
       expect(group_gate['value']).to eq([])
     end
   end
@@ -111,7 +111,7 @@ RSpec.describe Flipper::Api::V1::Actions::GroupsGate do
     end
 
     it 'returns decorated feature with group disabled' do
-      group_gate = json_response['gates'].find { |m| m['name'] == 'group' }
+      group_gate = json_response['gates'].find { |m| m['key'] == 'groups' }
       expect(group_gate['value']).to eq([])
     end
   end
@@ -145,7 +145,7 @@ RSpec.describe Flipper::Api::V1::Actions::GroupsGate do
     end
 
     it 'returns decorated feature with group in groups set' do
-      group_gate = json_response['gates'].find { |m| m['name'] == 'group' }
+      group_gate = json_response['gates'].find { |m| m['key'] == 'groups' }
       expect(group_gate['value']).to eq(['admins'])
     end
 
@@ -167,7 +167,7 @@ RSpec.describe Flipper::Api::V1::Actions::GroupsGate do
     end
 
     it 'returns decorated feature with group not in groups set' do
-      group_gate = json_response['gates'].find { |m| m['name'] == 'group' }
+      group_gate = json_response['gates'].find { |m| m['key'] == 'groups' }
       expect(group_gate['value']).to eq([])
     end
 

--- a/spec/flipper/api/v1/actions/import_spec.rb
+++ b/spec/flipper/api/v1/actions/import_spec.rb
@@ -1,0 +1,69 @@
+RSpec.describe Flipper::Api::V1::Actions::Import do
+  let(:app) { build_api(flipper) }
+
+  describe 'post' do
+    context 'succesful request' do
+      before do
+        flipper.enable(:search)
+        flipper.disable(:adios)
+
+        source_flipper = build_flipper
+        source_flipper.disable(:search)
+        source_flipper.enable_actor(:google_analytics, Flipper::Actor.new("User;1"))
+
+        export = source_flipper.export
+
+        post '/import', export.input, 'CONTENT_TYPE' => 'application/json'
+      end
+
+      it 'responds 200 ' do
+        expect(last_response.status).to eq(200)
+      end
+
+      it 'imports features' do
+        expect(flipper[:search].boolean_value).to be(false)
+        expect(flipper[:google_analytics].actors_value).to eq(Set["User;1"])
+        expect(flipper.features.map(&:key)).to eq(["search", "google_analytics"])
+      end
+    end
+
+    context 'empty request' do
+      before do
+        flipper.enable(:search)
+        flipper.disable(:adios)
+
+        source_flipper = build_flipper
+        export = source_flipper.export
+
+        post '/import', export.input, 'CONTENT_TYPE' => 'application/json'
+      end
+
+      it 'responds 200 ' do
+        expect(last_response.status).to eq(200)
+      end
+
+      it 'removes all features' do
+        expect(flipper.features.map(&:key)).to eq([])
+      end
+    end
+
+    context 'bad request' do
+      before do
+        post '/import'
+      end
+
+      it 'returns correct status code' do
+        expect(last_response.status).to eq(422)
+      end
+
+      it 'returns formatted error' do
+        expected = {
+          'code' => 6,
+          'message' => 'Import invalid.',
+          'more_info' => api_error_code_reference_url,
+        }
+        expect(json_response).to eq(expected)
+      end
+    end
+  end
+end

--- a/spec/flipper/api/v1/actions/import_spec.rb
+++ b/spec/flipper/api/v1/actions/import_spec.rb
@@ -13,11 +13,11 @@ RSpec.describe Flipper::Api::V1::Actions::Import do
 
         export = source_flipper.export
 
-        post '/import', export.input, 'CONTENT_TYPE' => 'application/json'
+        post '/import', export.contents, 'CONTENT_TYPE' => 'application/json'
       end
 
-      it 'responds 200 ' do
-        expect(last_response.status).to eq(200)
+      it 'responds 204 ' do
+        expect(last_response.status).to eq(204)
       end
 
       it 'imports features' do
@@ -35,11 +35,11 @@ RSpec.describe Flipper::Api::V1::Actions::Import do
         source_flipper = build_flipper
         export = source_flipper.export
 
-        post '/import', export.input, 'CONTENT_TYPE' => 'application/json'
+        post '/import', export.contents, 'CONTENT_TYPE' => 'application/json'
       end
 
-      it 'responds 200 ' do
-        expect(last_response.status).to eq(200)
+      it 'responds 204' do
+        expect(last_response.status).to eq(204)
       end
 
       it 'removes all features' do

--- a/spec/flipper/api/v1/actions/percentage_of_actors_gate_spec.rb
+++ b/spec/flipper/api/v1/actions/percentage_of_actors_gate_spec.rb
@@ -8,7 +8,7 @@ RSpec.describe Flipper::Api::V1::Actions::PercentageOfActorsGate do
       end
 
       it 'returns decorated feature with gate enabled for a percent of actors' do
-        gate = json_response['gates'].find { |gate| gate['name'] == 'percentage_of_actors' }
+        gate = json_response['gates'].find { |gate| gate['key'] == 'percentage_of_actors' }
         expect(gate['value']).to eq(percentage)
       end
     end
@@ -90,7 +90,7 @@ RSpec.describe Flipper::Api::V1::Actions::PercentageOfActorsGate do
     end
 
     it 'returns decorated feature with gate disabled' do
-      gate = json_response['gates'].find { |gate| gate['name'] == 'percentage_of_actors' }
+      gate = json_response['gates'].find { |gate| gate['key'] == 'percentage_of_actors' }
       expect(gate['value']).to eq('0')
     end
   end
@@ -104,7 +104,7 @@ RSpec.describe Flipper::Api::V1::Actions::PercentageOfActorsGate do
     end
 
     it 'returns decorated feature with gate value set to 0 regardless of percentage requested' do
-      gate = json_response['gates'].find { |gate| gate['name'] == 'percentage_of_actors' }
+      gate = json_response['gates'].find { |gate| gate['key'] == 'percentage_of_actors' }
       expect(gate['value']).to eq('0')
     end
   end
@@ -120,7 +120,7 @@ RSpec.describe Flipper::Api::V1::Actions::PercentageOfActorsGate do
 
     it 'returns decorated feature with gate disabled' do
       expect(last_response.status).to eq(200)
-      gate = json_response['gates'].find { |gate| gate['name'] == 'percentage_of_actors' }
+      gate = json_response['gates'].find { |gate| gate['key'] == 'percentage_of_actors' }
       expect(gate['value']).to eq('0')
     end
   end

--- a/spec/flipper/api/v1/actions/percentage_of_time_gate_spec.rb
+++ b/spec/flipper/api/v1/actions/percentage_of_time_gate_spec.rb
@@ -8,7 +8,7 @@ RSpec.describe Flipper::Api::V1::Actions::PercentageOfTimeGate do
       end
 
       it 'returns decorated feature with gate enabled for a percent of times' do
-        gate = json_response['gates'].find { |gate| gate['name'] == 'percentage_of_time' }
+        gate = json_response['gates'].find { |gate| gate['key'] == 'percentage_of_time' }
         expect(gate['value']).to eq(percentage)
       end
     end
@@ -90,7 +90,7 @@ RSpec.describe Flipper::Api::V1::Actions::PercentageOfTimeGate do
     end
 
     it 'returns decorated feature with gate disabled' do
-      gate = json_response['gates'].find { |gate| gate['name'] == 'percentage_of_time' }
+      gate = json_response['gates'].find { |gate| gate['key'] == 'percentage_of_time' }
       expect(gate['value']).to eq('0')
     end
   end
@@ -105,7 +105,7 @@ RSpec.describe Flipper::Api::V1::Actions::PercentageOfTimeGate do
 
     it 'returns decorated feature with gate value set to 0 regardless of percentage requested' do
       expect(last_response.status).to eq(200)
-      gate = json_response['gates'].find { |gate| gate['name'] == 'percentage_of_time' }
+      gate = json_response['gates'].find { |gate| gate['key'] == 'percentage_of_time' }
       expect(gate['value']).to eq('0')
     end
   end
@@ -120,7 +120,7 @@ RSpec.describe Flipper::Api::V1::Actions::PercentageOfTimeGate do
     end
 
     it 'returns decorated feature with gate disabled' do
-      gate = json_response['gates'].find { |gate| gate['name'] == 'percentage_of_time' }
+      gate = json_response['gates'].find { |gate| gate['key'] == 'percentage_of_time' }
       expect(gate['value']).to eq('0')
     end
   end

--- a/spec/flipper/cloud/configuration_spec.rb
+++ b/spec/flipper/cloud/configuration_spec.rb
@@ -222,7 +222,7 @@ RSpec.describe Flipper::Cloud::Configuration do
         }
       ]
     })
-    stub = stub_request(:get, "https://www.flippercloud.io/adapter/features").
+    stub = stub_request(:get, "https://www.flippercloud.io/adapter/features?exclude_gate_names=true").
       with({
         headers: {
           'Flipper-Cloud-Token'=>'asdf',

--- a/spec/flipper/cloud/dsl_spec.rb
+++ b/spec/flipper/cloud/dsl_spec.rb
@@ -15,7 +15,7 @@ RSpec.describe Flipper::Cloud::DSL do
   end
 
   it 'delegates sync to cloud configuration' do
-    stub = stub_request(:get, "https://www.flippercloud.io/adapter/features").
+    stub = stub_request(:get, "https://www.flippercloud.io/adapter/features?exclude_gate_names=true").
       with({
         headers: {
           'Flipper-Cloud-Token'=>'asdf',

--- a/spec/flipper/cloud/engine_spec.rb
+++ b/spec/flipper/cloud/engine_spec.rb
@@ -60,7 +60,7 @@ RSpec.describe Flipper::Cloud::Engine do
       ENV.update(env)
       application.initialize!
 
-      stub = stub_request(:get, "https://www.flippercloud.io/adapter/features").with({
+      stub = stub_request(:get, "https://www.flippercloud.io/adapter/features?exclude_gate_names=true").with({
         headers: { "Flipper-Cloud-Token" => ENV["FLIPPER_CLOUD_TOKEN"] },
       }).to_return(status: 200, body: JSON.generate({ features: {} }), headers: {})
 

--- a/spec/flipper/cloud/middleware_spec.rb
+++ b/spec/flipper/cloud/middleware_spec.rb
@@ -274,7 +274,7 @@ RSpec.describe Flipper::Cloud::Middleware do
   private
 
   def stub_request_for_token(token, status: 200)
-    stub = stub_request(:get, "https://www.flippercloud.io/adapter/features").
+    stub = stub_request(:get, "https://www.flippercloud.io/adapter/features?exclude_gate_names=true").
       with({
         headers: {
           'Flipper-Cloud-Token' => token,

--- a/spec/flipper/dsl_spec.rb
+++ b/spec/flipper/dsl_spec.rb
@@ -342,10 +342,20 @@ RSpec.describe Flipper::DSL do
   end
 
   describe '#import' do
-    it 'delegates to adapter' do
-      destination_flipper = build_flipper
-      expect(subject.adapter).to receive(:import).with(destination_flipper.adapter)
-      subject.import(destination_flipper)
+    context "with flipper instance" do
+      it 'delegates to adapter' do
+        destination_flipper = build_flipper
+        expect(subject.adapter).to receive(:import).with(destination_flipper)
+        subject.import(destination_flipper)
+      end
+    end
+
+    context "with flipper adapter" do
+      it 'delegates to adapter' do
+        destination_flipper = build_flipper
+        expect(subject.adapter).to receive(:import).with(destination_flipper.adapter)
+        subject.import(destination_flipper.adapter)
+      end
     end
   end
 

--- a/spec/flipper/dsl_spec.rb
+++ b/spec/flipper/dsl_spec.rb
@@ -349,6 +349,13 @@ RSpec.describe Flipper::DSL do
     end
   end
 
+  describe "#export" do
+    it 'delegates to adapter' do
+      expect(subject.export).to eq(subject.adapter.export)
+      expect(subject.export(format: :json)).to eq(subject.adapter.export(format: :json))
+    end
+  end
+
   describe '#memoize=' do
     it 'delegates to adapter' do
       expect(subject.adapter).not_to be_memoizing

--- a/spec/flipper/export_spec.rb
+++ b/spec/flipper/export_spec.rb
@@ -1,13 +1,13 @@
 RSpec.describe Flipper::Export do
   it "can initialize" do
-    export = described_class.new(input: "{}", format: :json, version: 1)
-    expect(export.input).to eq("{}")
+    export = described_class.new(contents: "{}", format: :json, version: 1)
+    expect(export.contents).to eq("{}")
     expect(export.format).to eq(:json)
     expect(export.version).to eq(1)
   end
 
   it "raises not implemented for features" do
-    export = described_class.new(input: "{}", format: :json, version: 1)
+    export = described_class.new(contents: "{}", format: :json, version: 1)
     expect { export.features }.to raise_error(NotImplementedError)
   end
 end

--- a/spec/flipper/export_spec.rb
+++ b/spec/flipper/export_spec.rb
@@ -1,0 +1,13 @@
+RSpec.describe Flipper::Export do
+  it "can initialize" do
+    export = described_class.new(input: "{}", format: :json, version: 1)
+    expect(export.input).to eq("{}")
+    expect(export.format).to eq(:json)
+    expect(export.version).to eq(1)
+  end
+
+  it "raises not implemented for features" do
+    export = described_class.new(input: "{}", format: :json, version: 1)
+    expect { export.features }.to raise_error(NotImplementedError)
+  end
+end

--- a/spec/flipper/exporter_spec.rb
+++ b/spec/flipper/exporter_spec.rb
@@ -1,0 +1,16 @@
+RSpec.describe Flipper::Exporter do
+  describe ".build" do
+    it "builds instance of exporter" do
+      exporter = described_class.build(format: :json, version: 1)
+      expect(exporter).to be_instance_of(Flipper::Exporters::Json::V1)
+    end
+
+    it "raises if format not found" do
+      expect { described_class.build(format: :nope, version: 1) }.to raise_error(KeyError)
+    end
+
+    it "raises if version not found" do
+      expect { described_class.build(format: :json, version: 0) }.to raise_error(KeyError)
+    end
+  end
+end

--- a/spec/flipper/exporters/json/export_spec.rb
+++ b/spec/flipper/exporters/json/export_spec.rb
@@ -1,0 +1,46 @@
+require 'flipper/exporters/json/v1'
+
+RSpec.describe Flipper::Exporters::Json::Export do
+  let(:input) {
+    <<~JSON
+      {
+        "version":1,
+        "features":{
+          "search":{"boolean":null,"groups":["admins","employees"],"actors":["User;1","User;100"],"percentage_of_actors":"10","percentage_of_time":"15"},
+          "plausible":{"boolean":"true","groups":[],"actors":[],"percentage_of_actors":null,"percentage_of_time":null},
+          "google_analytics":{"boolean":null,"groups":[],"actors":[],"percentage_of_actors":null,"percentage_of_time":null}
+        }
+      }
+    JSON
+  }
+
+  it "can initialize" do
+    export = described_class.new(input: input)
+    expect(export.format).to eq(:json)
+    expect(export.version).to be(1)
+  end
+
+  it "can initialize with version" do
+    export = described_class.new(input: input, version: 1)
+    expect(export.version).to be(1)
+  end
+
+  it "can build features from input" do
+    export = Flipper::Exporters::Json::Export.new(input: input)
+    expect(export.features).to eq({
+      "search" => {actors: ["User;1", "User;100"], boolean: nil, groups: ["admins", "employees"], percentage_of_actors: "10", percentage_of_time: "15"},
+      "plausible" => {actors: [], boolean: "true", groups: [], percentage_of_actors: nil, percentage_of_time: nil},
+      "google_analytics" => {actors: [], boolean: nil, groups: [], percentage_of_actors: nil, percentage_of_time: nil},
+    })
+  end
+
+  it "can build an adapter from features" do
+    export = Flipper::Exporters::Json::Export.new(input: input)
+    expect(export.adapter).to be_instance_of(Flipper::Adapters::Memory)
+    expect(export.adapter.get_all).to eq({
+      "search" => {actors: ["User;1", "User;100"], boolean: nil, groups: ["admins", "employees"], percentage_of_actors: "10", percentage_of_time: "15"},
+      "plausible" => {actors: [], boolean: "true", groups: [], percentage_of_actors: nil, percentage_of_time: nil},
+      "google_analytics" => {actors: [], boolean: nil, groups: [], percentage_of_actors: nil, percentage_of_time: nil},
+    })
+  end
+end

--- a/spec/flipper/exporters/json/export_spec.rb
+++ b/spec/flipper/exporters/json/export_spec.rb
@@ -1,7 +1,7 @@
 require 'flipper/exporters/json/v1'
 
 RSpec.describe Flipper::Exporters::Json::Export do
-  let(:input) {
+  let(:contents) {
     <<~JSON
       {
         "version":1,
@@ -15,32 +15,46 @@ RSpec.describe Flipper::Exporters::Json::Export do
   }
 
   it "can initialize" do
-    export = described_class.new(input: input)
+    export = described_class.new(contents: contents)
     expect(export.format).to eq(:json)
     expect(export.version).to be(1)
   end
 
   it "can initialize with version" do
-    export = described_class.new(input: input, version: 1)
+    export = described_class.new(contents: contents, version: 1)
     expect(export.version).to be(1)
   end
 
-  it "can build features from input" do
-    export = Flipper::Exporters::Json::Export.new(input: input)
+  it "can build features from contents" do
+    export = Flipper::Exporters::Json::Export.new(contents: contents)
     expect(export.features).to eq({
-      "search" => {actors: ["User;1", "User;100"], boolean: nil, groups: ["admins", "employees"], percentage_of_actors: "10", percentage_of_time: "15"},
-      "plausible" => {actors: [], boolean: "true", groups: [], percentage_of_actors: nil, percentage_of_time: nil},
-      "google_analytics" => {actors: [], boolean: nil, groups: [], percentage_of_actors: nil, percentage_of_time: nil},
+      "search" => {actors: Set["User;1", "User;100"], boolean: nil, groups: Set["admins", "employees"], percentage_of_actors: "10", percentage_of_time: "15"},
+      "plausible" => {actors: Set.new, boolean: "true", groups: Set.new, percentage_of_actors: nil, percentage_of_time: nil},
+      "google_analytics" => {actors: Set.new, boolean: nil, groups: Set.new, percentage_of_actors: nil, percentage_of_time: nil},
     })
   end
 
   it "can build an adapter from features" do
-    export = Flipper::Exporters::Json::Export.new(input: input)
+    export = Flipper::Exporters::Json::Export.new(contents: contents)
     expect(export.adapter).to be_instance_of(Flipper::Adapters::Memory)
     expect(export.adapter.get_all).to eq({
-      "search" => {actors: ["User;1", "User;100"], boolean: nil, groups: ["admins", "employees"], percentage_of_actors: "10", percentage_of_time: "15"},
-      "plausible" => {actors: [], boolean: "true", groups: [], percentage_of_actors: nil, percentage_of_time: nil},
-      "google_analytics" => {actors: [], boolean: nil, groups: [], percentage_of_actors: nil, percentage_of_time: nil},
+      "plausible" => {actors: Set.new, boolean: "true", groups: Set.new, percentage_of_actors: nil, percentage_of_time: nil},
+      "search" => {actors: Set["User;1", "User;100"], boolean: nil, groups: Set["admins", "employees"], percentage_of_actors: "10", percentage_of_time: "15"},
+      "google_analytics" => {actors: Set.new, boolean: nil, groups: Set.new, percentage_of_actors: nil, percentage_of_time: nil},
     })
+  end
+
+  it "raises for invalid json" do
+    export = described_class.new(contents: "bad contents")
+    expect {
+      export.features
+    }.to raise_error(Flipper::Exporters::Json::JsonError)
+  end
+
+  it "raises for missing features key" do
+    export = described_class.new(contents: "{}")
+    expect {
+      export.features
+    }.to raise_error(Flipper::Exporters::Json::InvalidError)
   end
 end

--- a/spec/flipper/exporters/json/v1_spec.rb
+++ b/spec/flipper/exporters/json/v1_spec.rb
@@ -20,26 +20,15 @@ RSpec.describe Flipper::Exporters::Json::V1 do
     flipper.enable_group :search, :admins
     flipper.enable_group :search, :employees
     flipper.enable :plausible
-    Flipper.disable :google_analytics
+    flipper.disable :google_analytics
 
     result = subject.call(adapter)
 
     data = JSON.parse(result)
     expect(data["features"]).to eq({
-      "plausible" => {
-        "actors" => [],
-        "boolean" => "true",
-        "groups" => [],
-        "percentage_of_actors" => nil,
-        "percentage_of_time" => nil
-      },
-      "search" => {
-        "actors" => ["User;1", "User;100"],
-        "boolean" => nil,
-        "groups" => ["admins", "employees"],
-        "percentage_of_actors" => "10",
-        "percentage_of_time" => "15"
-      },
+      "google_analytics" => {"actors"=>[], "boolean"=>nil, "groups"=>[], "percentage_of_actors"=>nil, "percentage_of_time"=>nil},
+      "plausible" => {"actors" => [], "boolean" => "true", "groups" => [], "percentage_of_actors" => nil, "percentage_of_time" => nil},
+      "search" => {"actors" => ["User;1", "User;100"], "boolean" => nil, "groups" => ["admins", "employees"], "percentage_of_actors" => "10", "percentage_of_time" => "15"},
     })
   end
 end

--- a/spec/flipper/exporters/json/v1_spec.rb
+++ b/spec/flipper/exporters/json/v1_spec.rb
@@ -5,8 +5,8 @@ RSpec.describe Flipper::Exporters::Json::V1 do
 
   it "has a version number" do
     adapter = Flipper::Adapters::Memory.new
-    result = subject.call(adapter)
-    data = JSON.parse(result)
+    export = subject.call(adapter)
+    data = JSON.parse(export.input)
     expect(data["version"]).to eq(1)
   end
 
@@ -22,9 +22,9 @@ RSpec.describe Flipper::Exporters::Json::V1 do
     flipper.enable :plausible
     flipper.disable :google_analytics
 
-    result = subject.call(adapter)
+    export = subject.call(adapter)
 
-    data = JSON.parse(result)
+    data = JSON.parse(export.input)
     expect(data["features"]).to eq({
       "google_analytics" => {"actors"=>[], "boolean"=>nil, "groups"=>[], "percentage_of_actors"=>nil, "percentage_of_time"=>nil},
       "plausible" => {"actors" => [], "boolean" => "true", "groups" => [], "percentage_of_actors" => nil, "percentage_of_time" => nil},

--- a/spec/flipper/exporters/json/v1_spec.rb
+++ b/spec/flipper/exporters/json/v1_spec.rb
@@ -1,0 +1,45 @@
+require 'flipper/exporters/json/v1'
+
+RSpec.describe Flipper::Exporters::Json::V1 do
+  subject { described_class.new }
+
+  it "has a version number" do
+    adapter = Flipper::Adapters::Memory.new
+    result = subject.call(adapter)
+    data = JSON.parse(result)
+    expect(data["version"]).to eq(1)
+  end
+
+  it "exports features and gates" do
+    adapter = Flipper::Adapters::Memory.new
+    flipper = Flipper.new(adapter)
+    flipper.enable_percentage_of_actors :search, 10
+    flipper.enable_percentage_of_time :search, 15
+    flipper.enable_actor :search, Flipper::Actor.new('User;1')
+    flipper.enable_actor :search, Flipper::Actor.new('User;100')
+    flipper.enable_group :search, :admins
+    flipper.enable_group :search, :employees
+    flipper.enable :plausible
+    Flipper.disable :google_analytics
+
+    result = subject.call(adapter)
+
+    data = JSON.parse(result)
+    expect(data["features"]).to eq({
+      "plausible" => {
+        "actors" => [],
+        "boolean" => "true",
+        "groups" => [],
+        "percentage_of_actors" => nil,
+        "percentage_of_time" => nil
+      },
+      "search" => {
+        "actors" => ["User;1", "User;100"],
+        "boolean" => nil,
+        "groups" => ["admins", "employees"],
+        "percentage_of_actors" => "10",
+        "percentage_of_time" => "15"
+      },
+    })
+  end
+end

--- a/spec/flipper/exporters/json/v1_spec.rb
+++ b/spec/flipper/exporters/json/v1_spec.rb
@@ -6,7 +6,7 @@ RSpec.describe Flipper::Exporters::Json::V1 do
   it "has a version number" do
     adapter = Flipper::Adapters::Memory.new
     export = subject.call(adapter)
-    data = JSON.parse(export.input)
+    data = JSON.parse(export.contents)
     expect(data["version"]).to eq(1)
   end
 
@@ -25,9 +25,9 @@ RSpec.describe Flipper::Exporters::Json::V1 do
     export = subject.call(adapter)
 
     expect(export.features).to eq({
-      "google_analytics" => {actors: [], boolean: nil, groups: [], percentage_of_actors: nil, percentage_of_time: nil},
-      "plausible" => {actors: [], boolean: "true", groups: [], percentage_of_actors: nil, percentage_of_time: nil},
-      "search" => {actors: ["User;1", "User;100"], boolean: nil, groups: ["admins", "employees"], percentage_of_actors: "10", percentage_of_time: "15"},
+      "google_analytics" => {actors: Set.new, boolean: nil, groups: Set.new, percentage_of_actors: nil, percentage_of_time: nil},
+      "plausible" => {actors: Set.new, boolean: "true", groups: Set.new, percentage_of_actors: nil, percentage_of_time: nil},
+      "search" => {actors: Set["User;1", "User;100"], boolean: nil, groups: Set["admins", "employees"], percentage_of_actors: "10", percentage_of_time: "15"},
     })
   end
 end

--- a/spec/flipper/exporters/json/v1_spec.rb
+++ b/spec/flipper/exporters/json/v1_spec.rb
@@ -24,11 +24,10 @@ RSpec.describe Flipper::Exporters::Json::V1 do
 
     export = subject.call(adapter)
 
-    data = JSON.parse(export.input)
-    expect(data["features"]).to eq({
-      "google_analytics" => {"actors"=>[], "boolean"=>nil, "groups"=>[], "percentage_of_actors"=>nil, "percentage_of_time"=>nil},
-      "plausible" => {"actors" => [], "boolean" => "true", "groups" => [], "percentage_of_actors" => nil, "percentage_of_time" => nil},
-      "search" => {"actors" => ["User;1", "User;100"], "boolean" => nil, "groups" => ["admins", "employees"], "percentage_of_actors" => "10", "percentage_of_time" => "15"},
+    expect(export.features).to eq({
+      "google_analytics" => {actors: [], boolean: nil, groups: [], percentage_of_actors: nil, percentage_of_time: nil},
+      "plausible" => {actors: [], boolean: "true", groups: [], percentage_of_actors: nil, percentage_of_time: nil},
+      "search" => {actors: ["User;1", "User;100"], boolean: nil, groups: ["admins", "employees"], percentage_of_actors: "10", percentage_of_time: "15"},
     })
   end
 end

--- a/spec/flipper/instrumentation/log_subscriber_spec.rb
+++ b/spec/flipper/instrumentation/log_subscriber_spec.rb
@@ -1,7 +1,12 @@
 require 'logger'
 require 'flipper/adapters/instrumented'
 require 'flipper/instrumentation/log_subscriber'
-require 'active_support/isolated_execution_state'
+
+begin
+  require 'active_support/isolated_execution_state'
+rescue LoadError
+  # ActiveSupport::IsolatedExecutionState is only available in Rails 5.2+
+end
 
 RSpec.describe Flipper::Instrumentation::LogSubscriber do
   let(:adapter) do

--- a/spec/flipper/instrumentation/log_subscriber_spec.rb
+++ b/spec/flipper/instrumentation/log_subscriber_spec.rb
@@ -1,6 +1,7 @@
 require 'logger'
 require 'flipper/adapters/instrumented'
 require 'flipper/instrumentation/log_subscriber'
+require 'active_support/isolated_execution_state'
 
 RSpec.describe Flipper::Instrumentation::LogSubscriber do
   let(:adapter) do
@@ -24,6 +25,10 @@ RSpec.describe Flipper::Instrumentation::LogSubscriber do
 
   after do
     described_class.logger = nil
+  end
+
+  after(:all) do
+    ActiveSupport::Notifications.unsubscribe("flipper")
   end
 
   let(:log) { @io.string }

--- a/spec/flipper/instrumentation/statsd_subscriber_spec.rb
+++ b/spec/flipper/instrumentation/statsd_subscriber_spec.rb
@@ -1,7 +1,12 @@
 require 'flipper/adapters/instrumented'
 require 'flipper/instrumentation/statsd'
-require 'active_support/isolated_execution_state'
 require 'statsd'
+
+begin
+  require 'active_support/isolated_execution_state'
+rescue LoadError
+  # ActiveSupport::IsolatedExecutionState is only available in Rails 5.2+
+end
 
 RSpec.describe Flipper::Instrumentation::StatsdSubscriber do
   let(:statsd_client) { Statsd.new }

--- a/spec/flipper/instrumentation/statsd_subscriber_spec.rb
+++ b/spec/flipper/instrumentation/statsd_subscriber_spec.rb
@@ -1,5 +1,6 @@
 require 'flipper/adapters/instrumented'
 require 'flipper/instrumentation/statsd'
+require 'active_support/isolated_execution_state'
 require 'statsd'
 
 RSpec.describe Flipper::Instrumentation::StatsdSubscriber do
@@ -23,6 +24,10 @@ RSpec.describe Flipper::Instrumentation::StatsdSubscriber do
   after do
     described_class.client = nil
     Thread.current[:statsd_socket] = nil
+  end
+
+  after(:all) do
+    ActiveSupport::Notifications.unsubscribe("flipper")
   end
 
   def assert_timer(metric)

--- a/spec/flipper/typecast_spec.rb
+++ b/spec/flipper/typecast_spec.rb
@@ -114,4 +114,83 @@ RSpec.describe Flipper::Typecast do
       described_class.to_set('asdf')
     end.to raise_error(ArgumentError, %("asdf" cannot be converted to a set))
   end
+
+  describe "#features_hash" do
+    it "returns new hash" do
+      hash = {
+        "search" => {
+          boolean: nil,
+        }
+      }
+      result = described_class.features_hash(hash)
+      expect(result).not_to be(hash)
+      expect(result["search"]).not_to be(hash["search"])
+    end
+
+    it "converts gate value arrays to sets" do
+      hash = {
+        "search" => {
+          boolean: nil,
+          groups: ['a', 'b'],
+          actors: ['User;1'],
+          percentage_of_actors: nil,
+          percentage_of_time: nil,
+        },
+      }
+      result = described_class.features_hash(hash)
+      expect(result).to eq({
+        "search" => {
+          boolean: nil,
+          groups: Set['a', 'b'],
+          actors: Set['User;1'],
+          percentage_of_actors: nil,
+          percentage_of_time: nil,
+        },
+      })
+    end
+
+    it "converts gate value boolean and integers to strings" do
+      hash = {
+        "search" => {
+          boolean: true,
+          groups: Set.new,
+          actors: Set.new,
+          percentage_of_actors: 10,
+          percentage_of_time: 15,
+        },
+      }
+      result = described_class.features_hash(hash)
+      expect(result).to eq({
+        "search" => {
+          boolean: "true",
+          groups: Set.new,
+          actors: Set.new,
+          percentage_of_actors: "10",
+          percentage_of_time: "15",
+        },
+      })
+    end
+
+    it "converts string gate keys to symbols" do
+      hash = {
+        "search" => {
+          "boolean" => nil,
+          "groups" => Set.new,
+          "actors" => Set.new,
+          "percentage_of_actors" => nil,
+          "percentage_of_time" => nil,
+        },
+      }
+      result = described_class.features_hash(hash)
+      expect(result).to eq({
+        "search" => {
+          boolean: nil,
+          groups: Set.new,
+          actors: Set.new,
+          percentage_of_actors: nil,
+          percentage_of_time: nil,
+        },
+      })
+    end
+  end
 end

--- a/spec/flipper/ui/actions/backup_spec.rb
+++ b/spec/flipper/ui/actions/backup_spec.rb
@@ -47,8 +47,13 @@ RSpec.describe Flipper::UI::Actions::Features do
       expect(last_response.status).to be(200)
     end
 
+    it 'sets content disposition' do
+      expect(last_response.headers['Content-Disposition']).to match(/Attachment;filename=flipper_memory_[0-9]*\.json/)
+    end
+
     it 'renders json' do
       data = JSON.parse(last_response.body)
+      expect(last_response.headers['Content-Type']).to eq('application/json')
       expect(data['version']).to eq(1)
       expect(data['features']).to eq({
         "search"=> {"boolean"=>nil, "groups"=>["admins", "employees"], "actors"=>["User;1", "User;100"], "percentage_of_actors"=>"10", "percentage_of_time"=>"15"},

--- a/spec/flipper/ui/actions/backup_spec.rb
+++ b/spec/flipper/ui/actions/backup_spec.rb
@@ -1,0 +1,60 @@
+RSpec.describe Flipper::UI::Actions::Features do
+  let(:token) do
+    if Rack::Protection::AuthenticityToken.respond_to?(:random_token)
+      Rack::Protection::AuthenticityToken.random_token
+    else
+      'a'
+    end
+  end
+
+  let(:session) do
+    { :csrf => token, 'csrf' => token, '_csrf_token' => token }
+  end
+
+  describe 'GET /backup' do
+    before do
+      flipper[:stats].enable
+      flipper[:search].enable
+      get '/backup'
+    end
+
+    it 'responds with success' do
+      expect(last_response.status).to be(200)
+    end
+
+    it 'renders template' do
+      expect(last_response.body).to include('Download')
+    end
+  end
+
+  describe "POST /backup" do
+    before do
+      flipper.enable_percentage_of_actors :search, 10
+      flipper.enable_percentage_of_time :search, 15
+      flipper.enable_actor :search, Flipper::Actor.new('User;1')
+      flipper.enable_actor :search, Flipper::Actor.new('User;100')
+      flipper.enable_group :search, :admins
+      flipper.enable_group :search, :employees
+      flipper.enable :plausible
+      flipper.disable :google_analytics
+
+      post '/backup',
+        {'authenticity_token' => token},
+        'rack.session' => session
+    end
+
+    it 'responds with success' do
+      expect(last_response.status).to be(200)
+    end
+
+    it 'renders json' do
+      data = JSON.parse(last_response.body)
+      expect(data['version']).to eq(1)
+      expect(data['features']).to eq({
+        "search"=> {"boolean"=>nil, "groups"=>["admins", "employees"], "actors"=>["User;1", "User;100"], "percentage_of_actors"=>"10", "percentage_of_time"=>"15"},
+        "plausible"=> {"boolean"=>"true", "groups"=>[], "actors"=>[], "percentage_of_actors"=>nil, "percentage_of_time"=>nil},
+        "google_analytics"=> {"boolean"=>nil, "groups"=>[], "actors"=>[], "percentage_of_actors"=>nil, "percentage_of_time"=>nil},
+      })
+    end
+  end
+end

--- a/spec/flipper/ui/actions/export_spec.rb
+++ b/spec/flipper/ui/actions/export_spec.rb
@@ -11,23 +11,7 @@ RSpec.describe Flipper::UI::Actions::Features do
     { :csrf => token, 'csrf' => token, '_csrf_token' => token }
   end
 
-  describe 'GET /backup' do
-    before do
-      flipper[:stats].enable
-      flipper[:search].enable
-      get '/backup'
-    end
-
-    it 'responds with success' do
-      expect(last_response.status).to be(200)
-    end
-
-    it 'renders template' do
-      expect(last_response.body).to include('Download')
-    end
-  end
-
-  describe "POST /backup" do
+  describe "POST /settings/export" do
     before do
       flipper.enable_percentage_of_actors :search, 10
       flipper.enable_percentage_of_time :search, 15
@@ -38,7 +22,7 @@ RSpec.describe Flipper::UI::Actions::Features do
       flipper.enable :plausible
       flipper.disable :google_analytics
 
-      post '/backup',
+      post '/settings/export',
         {'authenticity_token' => token},
         'rack.session' => session
     end

--- a/spec/flipper/ui/actions/import_spec.rb
+++ b/spec/flipper/ui/actions/import_spec.rb
@@ -1,0 +1,41 @@
+RSpec.describe Flipper::UI::Actions::Import do
+  let(:token) do
+    if Rack::Protection::AuthenticityToken.respond_to?(:random_token)
+      Rack::Protection::AuthenticityToken.random_token
+    else
+      'a'
+    end
+  end
+
+  let(:session) do
+    { :csrf => token, 'csrf' => token, '_csrf_token' => token }
+  end
+
+  describe "POST /settings/import" do
+    before do
+      flipper.enable :plausible
+      flipper.disable :google_analytics
+      path = FlipperRoot.join("spec", "fixtures", "flipper_pstore_1679087600.json")
+
+      post '/settings/import',
+        {
+          'authenticity_token' => token,
+          'file' => Rack::Test::UploadedFile.new(path, "application/json"),
+        },
+        'rack.session' => session
+    end
+
+    it 'imports the file export' do
+      expect(flipper[:search].actors_value).to eq(Set.new(['john', 'another', 'testing']))
+      expect(flipper[:search].groups_value).to eq(Set.new(['admins']))
+      expect(flipper[:google_analytics_tag].percentage_of_actors_value).to eq(100)
+      expect(flipper[:new_pricing].boolean_value).to eq(true)
+      expect(flipper[:nope].boolean_value).to eq(false)
+    end
+
+    it 'responds with redirect to settings' do
+      expect(last_response.status).to be(302)
+      expect(last_response.headers['Location']).to eq('/features')
+    end
+  end
+end

--- a/spec/flipper/ui/actions/settings_spec.rb
+++ b/spec/flipper/ui/actions/settings_spec.rb
@@ -1,0 +1,27 @@
+RSpec.describe Flipper::UI::Actions::Settings do
+  let(:token) do
+    if Rack::Protection::AuthenticityToken.respond_to?(:random_token)
+      Rack::Protection::AuthenticityToken.random_token
+    else
+      'a'
+    end
+  end
+
+  let(:session) do
+    { :csrf => token, 'csrf' => token, '_csrf_token' => token }
+  end
+
+  describe 'GET /settings' do
+    before do
+      get '/settings'
+    end
+
+    it 'responds with success' do
+      expect(last_response.status).to be(200)
+    end
+
+    it 'renders template' do
+      expect(last_response.body).to include('Download')
+    end
+  end
+end

--- a/spec/flipper_spec.rb
+++ b/spec/flipper_spec.rb
@@ -202,6 +202,12 @@ RSpec.describe Flipper do
       expect(described_class.enabled?(:search)).to be(true)
     end
 
+    it 'delegates export to instance' do
+      described_class.enable(:search)
+      expect(described_class.export).to eq(described_class.adapter.export)
+      expect(described_class.export(format: :json)).to eq(described_class.adapter.export(format: :json))
+    end
+
     it 'delegates adapter to instance' do
       expect(described_class.adapter).to eq(described_class.instance.adapter)
     end

--- a/spec/flipper_spec.rb
+++ b/spec/flipper_spec.rb
@@ -228,7 +228,7 @@ RSpec.describe Flipper do
     end
 
     it 'delegates sync stuff to instance for Flipper::Cloud' do
-      stub = stub_request(:get, "https://www.flippercloud.io/adapter/features").
+      stub = stub_request(:get, "https://www.flippercloud.io/adapter/features?exclude_gate_names=true").
         with({
           headers: {
             'Flipper-Cloud-Token'=>'asdf',


### PR DESCRIPTION
I'd like to make it easy to backup flipper using just flipper (instead of backing up the external storage the adapter is talking to). This is a first pass. I'll look it over again in the morning, but it adds the concept of exporting the current state of the world. 

## TODO

* [x] Make it so import can accept an export (in addition to the flipper instance or adapter it currently supports in places)
* [x] Add import of an export to the UI