### PR TITLE
Allow passing multiple actors to Flipper.enabled?

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -10,7 +10,13 @@ All notable changes to this project will be documented in this file.
 
 ### Deprecations
 
-* :thing in enabled? instrumentation payload. Use :actors instead.
+* `:thing` in `enabled?` instrumentation payload. Use `:actors` instead.
+    ```diff
+    ActiveSupport::Notifications.subscribe('enabled?.feature_operation.flipper') do |name, start, finish, id, payload|
+    -   payload[:thing]
+    +   payload[:actors]
+    end
+    ```
 
 ## 0.27.1
 

--- a/Changelog.md
+++ b/Changelog.md
@@ -2,6 +2,16 @@
 
 All notable changes to this project will be documented in this file.
 
+## Unreleased
+
+### Additions/Changes
+
+* Allow multiple actors for Flipper.enabled?. Improves performance of feature flags for multiple actors and simplifies code for users of flipper.
+
+### Deprecations
+
+* :thing in enabled? instrumentation payload. Use :actors instead.
+
 ## 0.27.0
 
 * Easy Import/Export (https://github.com/jnunemaker/flipper/pull/709). This has some breaking changes but only if you are using flipper internals. If you are just using Flipper.* methods, you'll be fine.

--- a/benchmark/enabled_multiple_actors_ips.rb
+++ b/benchmark/enabled_multiple_actors_ips.rb
@@ -14,7 +14,7 @@ actor8 = Flipper::Actor.new("User;8")
 actors = [actor1, actor2, actor3, actor4, actor5, actor6, actor7, actor8]
 
 Benchmark.ips do |x|
-  x.report("with 5 actors") { Flipper.enabled?(:foo, actors) }
-  x.report("with 5 enabled? checks") { actors.each { |actor| Flipper.enabled?(:foo, actor) } }
+  x.report("with array of actors") { Flipper.enabled?(:foo, actors) }
+  x.report("with multiple enabled? checks") { actors.each { |actor| Flipper.enabled?(:foo, actor) } }
   x.compare!
 end

--- a/benchmark/enabled_multiple_actors_ips.rb
+++ b/benchmark/enabled_multiple_actors_ips.rb
@@ -1,0 +1,20 @@
+require 'bundler/setup'
+require 'flipper'
+require 'benchmark/ips'
+
+actor1 = Flipper::Actor.new("User;1")
+actor2 = Flipper::Actor.new("User;2")
+actor3 = Flipper::Actor.new("User;3")
+actor4 = Flipper::Actor.new("User;4")
+actor5 = Flipper::Actor.new("User;5")
+actor6 = Flipper::Actor.new("User;6")
+actor7 = Flipper::Actor.new("User;7")
+actor8 = Flipper::Actor.new("User;8")
+
+actors = [actor1, actor2, actor3, actor4, actor5, actor6, actor7, actor8]
+
+Benchmark.ips do |x|
+  x.report("with 5 actors") { Flipper.enabled?(:foo, actors) }
+  x.report("with 5 enabled? checks") { actors.each { |actor| Flipper.enabled?(:foo, actor) } }
+  x.compare!
+end

--- a/examples/active_record/internals.rb
+++ b/examples/active_record/internals.rb
@@ -4,8 +4,8 @@ require_relative "./ar_setup"
 require 'flipper/adapters/active_record'
 
 # Register a few groups.
-Flipper.register(:admins) { |thing| thing.admin? }
-Flipper.register(:early_access) { |thing| thing.early_access? }
+Flipper.register(:admins) { |actor| actor.admin? }
+Flipper.register(:early_access) { |actor| actor.early_access? }
 
 # Create a user class that has flipper_id instance method.
 User = Struct.new(:flipper_id)

--- a/examples/dsl.rb
+++ b/examples/dsl.rb
@@ -1,7 +1,7 @@
 require 'bundler/setup'
 require 'flipper'
 
-# create a thing with an identifier
+# create an actor with an identifier
 class Person < Struct.new(:id)
   include Flipper::Identifier
 end
@@ -58,8 +58,8 @@ responds_to_flipper_id = Struct.new(:flipper_id).new(10)
 puts Flipper.actor(responds_to_flipper_id).inspect
 
 # get an instance of an actor using an object
-thing = Struct.new(:flipper_id).new(22)
-puts Flipper.actor(thing).inspect
+actor = Struct.new(:flipper_id).new(22)
+puts Flipper.actor(actor).inspect
 
 # register a top level group
 admins = Flipper.register(:admins) { |actor|

--- a/examples/mongo/internals.rb
+++ b/examples/mongo/internals.rb
@@ -6,8 +6,8 @@ ENV["FLIPPER_MONGO_URL"] ||= "mongodb://127.0.0.1:#{ENV["MONGODB_PORT"] || 27017
 require 'flipper/adapters/mongo'
 
 # Register a few groups.
-Flipper.register(:admins) { |thing| thing.admin? }
-Flipper.register(:early_access) { |thing| thing.early_access? }
+Flipper.register(:admins) { |actor| actor.admin? }
+Flipper.register(:early_access) { |actor| actor.early_access? }
 
 # Create a user class that has flipper_id instance method.
 User = Struct.new(:flipper_id)

--- a/examples/redis/internals.rb
+++ b/examples/redis/internals.rb
@@ -6,8 +6,8 @@ require 'flipper/adapters/redis'
 client = Redis.new
 
 # Register a few groups.
-Flipper.register(:admins) { |thing| thing.admin? }
-Flipper.register(:early_access) { |thing| thing.early_access? }
+Flipper.register(:admins) { |actor| actor.admin? }
+Flipper.register(:early_access) { |actor| actor.early_access? }
 
 # Create a user class that has flipper_id instance method.
 User = Struct.new(:flipper_id)

--- a/examples/redis/namespaced.rb
+++ b/examples/redis/namespaced.rb
@@ -12,8 +12,8 @@ adapter = Flipper::Adapters::Redis.new(namespaced_client)
 flipper = Flipper.new(adapter)
 
 # Register a few groups.
-Flipper.register(:admins) { |thing| thing.admin? }
-Flipper.register(:early_access) { |thing| thing.early_access? }
+Flipper.register(:admins) { |actor| actor.admin? }
+Flipper.register(:early_access) { |actor| actor.early_access? }
 
 # Create a user class that has flipper_id instance method.
 User = Struct.new(:flipper_id)

--- a/examples/sequel/internals.rb
+++ b/examples/sequel/internals.rb
@@ -9,8 +9,8 @@ CreateFlipperTablesSequel.new(Sequel::Model.db).up
 require 'flipper/adapters/sequel'
 
 # Register a few groups.
-Flipper.register(:admins) { |thing| thing.admin? }
-Flipper.register(:early_access) { |thing| thing.early_access? }
+Flipper.register(:admins) { |actor| actor.admin? }
+Flipper.register(:early_access) { |actor| actor.early_access? }
 
 # Create a user class that has flipper_id instance method.
 User = Struct.new(:flipper_id)

--- a/lib/flipper.rb
+++ b/lib/flipper.rb
@@ -72,12 +72,12 @@ module Flipper
   #
   # name - The Symbol name of the group.
   # block - The block that should be used to determine if the group matches a
-  #         given thing.
+  #         given actor.
   #
   # Examples
   #
-  #   Flipper.register(:admins) { |thing|
-  #     thing.respond_to?(:admin?) && thing.admin?
+  #   Flipper.register(:admins) { |actor|
+  #     actor.respond_to?(:admin?) && actor.admin?
   #   }
   #
   # Returns a Flipper::Group.

--- a/lib/flipper/cloud/instrumenter.rb
+++ b/lib/flipper/cloud/instrumenter.rb
@@ -28,15 +28,35 @@ module Flipper
         }
         if (thing = payload[:thing])
           dimensions["flipper_id"] = thing.value.to_s
-        end
 
-        event = {
-          type: "enabled",
-          dimensions: dimensions,
-          measures: {},
-          ts: Time.now.utc,
-        }
-        @brow.push event
+          event = {
+            type: "enabled",
+            dimensions: dimensions,
+            measures: {},
+            ts: Time.now.utc,
+          }
+          @brow.push event
+        elsif (actors = payload[:actors])
+          now = Time.now.utc
+          actors.each do |actor|
+            dimensions["flipper_id"] = actor.value.to_s
+            event = {
+              type: "enabled",
+              dimensions: dimensions,
+              measures: {},
+              ts: now,
+            }
+            @brow.push event
+          end
+        else
+          event = {
+            type: "enabled",
+            dimensions: dimensions,
+            measures: {},
+            ts: Time.now.utc,
+          }
+          @brow.push event
+        end
       end
     end
   end

--- a/lib/flipper/cloud/instrumenter.rb
+++ b/lib/flipper/cloud/instrumenter.rb
@@ -27,27 +27,21 @@ module Flipper
           "result" => payload[:result].to_s,
         }
 
-        # enabled? event shows up as actors
-        now = Time.now.utc
-        if (actors = payload[:actors])
-          dimensions["flipper_id"] = actors.first.value.to_s
-          dimensions["flipper_ids"] = actors.map { |actor| actor.value.to_s }
-          event = {
-            type: "enabled",
-            dimensions: dimensions,
-            measures: {},
-            ts: now,
-          }
-          @brow.push event
-        else
-          event = {
-            type: "enabled",
-            dimensions: dimensions,
-            measures: {},
-            ts: now,
-          }
-          @brow.push event
+        if (thing = payload[:thing])
+          dimensions["flipper_id"] = thing.value.to_s
         end
+
+        if (actors = payload[:actors])
+          dimensions["flipper_ids"] = actors.map { |actor| actor.value.to_s }
+        end
+
+        event = {
+          type: "enabled",
+          dimensions: dimensions,
+          measures: {},
+          ts: Time.now.utc,
+        }
+        @brow.push event
       end
     end
   end

--- a/lib/flipper/cloud/instrumenter.rb
+++ b/lib/flipper/cloud/instrumenter.rb
@@ -26,34 +26,25 @@ module Flipper
           "feature" => payload[:feature_name].to_s,
           "result" => payload[:result].to_s,
         }
-        if (thing = payload[:thing])
-          dimensions["flipper_id"] = thing.value.to_s
 
+        # enabled? event shows up as actors
+        now = Time.now.utc
+        if (actors = payload[:actors])
+          dimensions["flipper_id"] = actors.first.value.to_s
+          dimensions["flipper_ids"] = actors.map { |actor| actor.value.to_s }
           event = {
             type: "enabled",
             dimensions: dimensions,
             measures: {},
-            ts: Time.now.utc,
+            ts: now,
           }
           @brow.push event
-        elsif (actors = payload[:actors])
-          now = Time.now.utc
-          actors.each do |actor|
-            dimensions["flipper_id"] = actor.value.to_s
-            event = {
-              type: "enabled",
-              dimensions: dimensions,
-              measures: {},
-              ts: now,
-            }
-            @brow.push event
-          end
         else
           event = {
             type: "enabled",
             dimensions: dimensions,
             measures: {},
-            ts: Time.now.utc,
+            ts: now,
           }
           @brow.push event
         end

--- a/lib/flipper/dsl.rb
+++ b/lib/flipper/dsl.rb
@@ -237,12 +237,12 @@ module Flipper
 
     # Public: Wraps an object as a flipper actor.
     #
-    # thing - The object that you would like to wrap.
+    # actor - The object that you would like to wrap.
     #
     # Returns an instance of Flipper::Types::Actor.
-    # Raises ArgumentError if thing does not respond to `flipper_id`.
-    def actor(thing)
-      Types::Actor.new(thing)
+    # Raises ArgumentError if actor does not respond to `flipper_id`.
+    def actor(actor)
+      Types::Actor.new(actor)
     end
 
     # Public: Shortcut for getting a percentage of time instance.

--- a/lib/flipper/errors.rb
+++ b/lib/flipper/errors.rb
@@ -2,10 +2,10 @@ module Flipper
   # Top level error that all other errors inherit from.
   class Error < StandardError; end
 
-  # Raised when gate can not be found for a thing.
+  # Raised when gate can not be found for a actor.
   class GateNotFound < Error
-    def initialize(thing)
-      super "Could not find gate for #{thing.inspect}"
+    def initialize(actor)
+      super "Could not find gate for #{actor.inspect}"
     end
   end
 

--- a/lib/flipper/errors.rb
+++ b/lib/flipper/errors.rb
@@ -2,7 +2,7 @@ module Flipper
   # Top level error that all other errors inherit from.
   class Error < StandardError; end
 
-  # Raised when gate can not be found for a actor.
+  # Raised when gate can not be found for an actor.
   class GateNotFound < Error
     def initialize(actor)
       super "Could not find gate for #{actor.inspect}"

--- a/lib/flipper/feature.rb
+++ b/lib/flipper/feature.rb
@@ -96,17 +96,18 @@ module Flipper
       instrument(:clear) { adapter.clear(self) }
     end
 
-    # Public: Check if a feature is enabled for a thing.
+    # Public: Check if a feature is enabled for zero or more actors.
     #
     # Returns true if enabled, false if not.
-    def enabled?(thing = nil)
-      thing = Types::Actor.wrap(thing) unless thing.nil?
+    def enabled?(actors = nil)
+      actors = Array(actors).map { |actor| Types::Actor.wrap(actor) } unless actors.nil?
 
-      instrument(:enabled?, thing: thing) do |payload|
+      # thing is left for backwards compatibility
+      instrument(:enabled?, thing: actors&.first, actors: actors) do |payload|
         context = FeatureCheckContext.new(
           feature_name: @name,
           values: gate_values,
-          thing: thing
+          actors: actors
         )
 
         if open_gate = gates.detect { |gate| gate.open?(context) }
@@ -359,14 +360,14 @@ module Flipper
       gates_hash[name.to_sym]
     end
 
-    # Public: Find the gate that protects a thing.
+    # Public: Find the gate that protects a actor.
     #
-    # thing - The object for which you would like to find a gate
+    # actor - The object for which you would like to find a gate
     #
     # Returns a Flipper::Gate.
-    # Raises Flipper::GateNotFound if no gate found for thing
-    def gate_for(thing)
-      gates.detect { |gate| gate.protects?(thing) } || raise(GateNotFound, thing)
+    # Raises Flipper::GateNotFound if no gate found for actor
+    def gate_for(actor)
+      gates.detect { |gate| gate.protects?(actor) } || raise(GateNotFound, actor)
     end
 
     private

--- a/lib/flipper/feature.rb
+++ b/lib/flipper/feature.rb
@@ -99,8 +99,9 @@ module Flipper
     # Public: Check if a feature is enabled for zero or more actors.
     #
     # Returns true if enabled, false if not.
-    def enabled?(actors = nil)
-      actors = Array(actors).map { |actor| Types::Actor.wrap(actor) } unless actors.nil?
+    def enabled?(*actors)
+      actors = actors.flatten.compact.map { |actor| Types::Actor.wrap(actor) }
+      actors = nil if actors.empty?
 
       # thing is left for backwards compatibility
       instrument(:enabled?, thing: actors&.first, actors: actors) do |payload|
@@ -360,7 +361,7 @@ module Flipper
       gates_hash[name.to_sym]
     end
 
-    # Public: Find the gate that protects a actor.
+    # Public: Find the gate that protects an actor.
     #
     # actor - The object for which you would like to find a gate
     #

--- a/lib/flipper/feature_check_context.rb
+++ b/lib/flipper/feature_check_context.rb
@@ -7,13 +7,17 @@ module Flipper
     # gates for the feature.
     attr_reader :values
 
-    # Public: The thing we want to know if a feature is enabled for.
-    attr_reader :thing
+    # Public: The actors we want to know if a feature is enabled for.
+    attr_reader :actors
 
-    def initialize(feature_name:, values:, thing:)
+    def initialize(feature_name:, values:, actors:)
       @feature_name = feature_name
       @values = values
-      @thing = thing
+      @actors = actors
+    end
+
+    def actors?
+      !@actors.nil? && !@actors.empty?
     end
 
     # Public: Convenience method for groups value like Feature has.

--- a/lib/flipper/gate.rb
+++ b/lib/flipper/gate.rb
@@ -30,7 +30,7 @@ module Flipper
       false
     end
 
-    # Internal: Check if a gate is protects a actor. Implemented in subclass.
+    # Internal: Check if a gate is protects an actor. Implemented in subclass.
     #
     # Returns true if gate protects actor, false if not.
     def protects?(actor)

--- a/lib/flipper/gate.rb
+++ b/lib/flipper/gate.rb
@@ -18,28 +18,29 @@ module Flipper
       raise 'Not implemented'
     end
 
-    def enabled?(_value)
+    def enabled?(value)
       raise 'Not implemented'
     end
 
-    # Internal: Check if a gate is open for a thing. Implemented in subclass.
+    # Internal: Check if a gate is open for one or more actors. Implemented
+    # in subclass.
     #
-    # Returns true if gate open for thing, false if not.
-    def open?(_thing, _value, _options = {})
+    # Returns true if gate open for any actor, false if not.
+    def open?(actors, value, options = {})
       false
     end
 
-    # Internal: Check if a gate is protects a thing. Implemented in subclass.
+    # Internal: Check if a gate is protects a actor. Implemented in subclass.
     #
-    # Returns true if gate protects thing, false if not.
-    def protects?(_thing)
+    # Returns true if gate protects actor, false if not.
+    def protects?(actor)
       false
     end
 
-    # Internal: Allows gate to wrap thing using one of the supported flipper
-    # types so adapters always get something that responds to value.
-    def wrap(thing)
-      thing
+    # Internal: Allows gate to wrap actor using one of the supported flipper
+    # types so adapters always get someactor that responds to value.
+    def wrap(actor)
+      actor
     end
 
     # Public: Pretty string version for debugging.

--- a/lib/flipper/gates/actor.rb
+++ b/lib/flipper/gates/actor.rb
@@ -23,8 +23,11 @@ module Flipper
       #
       # Returns true if gate open for thing, false if not.
       def open?(context)
-        return false if context.thing.nil?
-        context.values.actors.include?(context.thing.value)
+        return false unless context.actors?
+
+        context.actors.any? do |actor|
+          context.values.actors.include?(actor.value)
+        end
       end
 
       def wrap(thing)

--- a/lib/flipper/gates/actor.rb
+++ b/lib/flipper/gates/actor.rb
@@ -19,9 +19,9 @@ module Flipper
         !value.empty?
       end
 
-      # Internal: Checks if the gate is open for a thing.
+      # Internal: Checks if the gate is open for an actor.
       #
-      # Returns true if gate open for thing, false if not.
+      # Returns true if gate open for actor, false if not.
       def open?(context)
         return false unless context.actors?
 
@@ -30,12 +30,12 @@ module Flipper
         end
       end
 
-      def wrap(thing)
-        Types::Actor.wrap(thing)
+      def wrap(actor)
+        Types::Actor.wrap(actor)
       end
 
-      def protects?(thing)
-        Types::Actor.wrappable?(thing)
+      def protects?(actor)
+        Types::Actor.wrappable?(actor)
       end
     end
   end

--- a/lib/flipper/gates/group.rb
+++ b/lib/flipper/gates/group.rb
@@ -23,10 +23,12 @@ module Flipper
       #
       # Returns true if gate open for thing, false if not.
       def open?(context)
-        return false if context.thing.nil?
+        return false unless context.actors?
 
         context.values.groups.any? do |name|
-          Flipper.group(name).match?(context.thing, context)
+          context.actors.any? do |actor|
+            Flipper.group(name).match?(actor, context)
+          end
         end
       end
 

--- a/lib/flipper/gates/percentage_of_actors.rb
+++ b/lib/flipper/gates/percentage_of_actors.rb
@@ -31,11 +31,8 @@ module Flipper
       # Returns true if gate open for any actors, false if not.
       def open?(context)
         return false unless context.actors?
-
-        context.actors.any? do |actor|
-          id = "#{context.feature_name}#{actor.value}"
-          Zlib.crc32(id) % (100 * SCALING_FACTOR) < context.values.percentage_of_actors * SCALING_FACTOR
-        end
+        id = "#{context.feature_name}#{context.actors.map(&:value).sort.join}"
+        Zlib.crc32(id) % (100 * SCALING_FACTOR) < context.values.percentage_of_actors * SCALING_FACTOR
       end
 
       def protects?(thing)

--- a/lib/flipper/gates/percentage_of_actors.rb
+++ b/lib/flipper/gates/percentage_of_actors.rb
@@ -26,14 +26,16 @@ module Flipper
       SCALING_FACTOR = 1_000
       private_constant :SCALING_FACTOR
 
-      # Internal: Checks if the gate is open for a thing.
+      # Internal: Checks if the gate is open for one or more actors.
       #
-      # Returns true if gate open for thing, false if not.
+      # Returns true if gate open for any actors, false if not.
       def open?(context)
-        return false if context.thing.nil?
+        return false unless context.actors?
 
-        id = "#{context.feature_name}#{context.thing.value}"
-        Zlib.crc32(id) % (100 * SCALING_FACTOR) < context.values.percentage_of_actors * SCALING_FACTOR
+        context.actors.any? do |actor|
+          id = "#{context.feature_name}#{actor.value}"
+          Zlib.crc32(id) % (100 * SCALING_FACTOR) < context.values.percentage_of_actors * SCALING_FACTOR
+        end
       end
 
       def protects?(thing)

--- a/lib/flipper/identifier.rb
+++ b/lib/flipper/identifier.rb
@@ -6,8 +6,8 @@ module Flipper
   #   end
   #
   #   user = User.new(99)
-  #   Flipper.enable :thing, user
-  #   Flipper.enabled? :thing, user #=> true
+  #   Flipper.enable :some_feature, user
+  #   Flipper.enabled? :some_feature, user #=> true
   #
   module Identifier
     def flipper_id

--- a/lib/flipper/instrumentation/log_subscriber.rb
+++ b/lib/flipper/instrumentation/log_subscriber.rb
@@ -10,7 +10,7 @@ module Flipper
       # Example Output
       #
       #   flipper[:search].enabled?(user)
-      #   # Flipper feature(search) enabled? false (1.2ms)  [ thing=... ]
+      #   # Flipper feature(search) enabled? false (1.2ms)  [ actors=... ]
       #
       # Returns nothing.
       def feature_operation(event)
@@ -20,10 +20,16 @@ module Flipper
         gate_name = event.payload[:gate_name]
         operation = event.payload[:operation]
         result = event.payload[:result]
-        thing = event.payload[:thing]
 
         description = "Flipper feature(#{feature_name}) #{operation} #{result.inspect}"
-        details = "thing=#{thing.inspect}"
+
+        details = if event.payload.key?(:actors)
+          "actors=#{event.payload[:actors].inspect}"
+        elsif event.payload.key?(:thing)
+          "thing=#{event.payload[:thing].inspect}"
+        else
+          ""
+        end
 
         details += " gate_name=#{gate_name}" unless gate_name.nil?
 

--- a/lib/flipper/instrumentation/log_subscriber.rb
+++ b/lib/flipper/instrumentation/log_subscriber.rb
@@ -25,10 +25,8 @@ module Flipper
 
         details = if event.payload.key?(:actors)
           "actors=#{event.payload[:actors].inspect}"
-        elsif event.payload.key?(:thing)
-          "thing=#{event.payload[:thing].inspect}"
         else
-          ""
+          "thing=#{event.payload[:thing].inspect}"
         end
 
         details += " gate_name=#{gate_name}" unless gate_name.nil?

--- a/lib/flipper/instrumentation/subscriber.rb
+++ b/lib/flipper/instrumentation/subscriber.rb
@@ -45,7 +45,6 @@ module Flipper
         gate_name = @payload[:gate_name]
         operation = strip_trailing_question_mark(@payload[:operation])
         result = @payload[:result]
-        thing = @payload[:thing]
 
         update_timer "flipper.feature_operation.#{operation}"
 

--- a/lib/flipper/types/actor.rb
+++ b/lib/flipper/types/actor.rb
@@ -1,35 +1,35 @@
 module Flipper
   module Types
     class Actor < Type
-      def self.wrappable?(thing)
-        return false if thing.nil?
-        thing.respond_to?(:flipper_id)
+      def self.wrappable?(actor)
+        return false if actor.nil?
+        actor.respond_to?(:flipper_id)
       end
 
-      attr_reader :thing
+      attr_reader :actor
 
-      def initialize(thing)
-        raise ArgumentError, 'thing cannot be nil' if thing.nil?
+      def initialize(actor)
+        raise ArgumentError, 'actor cannot be nil' if actor.nil?
 
-        unless thing.respond_to?(:flipper_id)
-          raise ArgumentError, "#{thing.inspect} must respond to flipper_id, but does not"
+        unless actor.respond_to?(:flipper_id)
+          raise ArgumentError, "#{actor.inspect} must respond to flipper_id, but does not"
         end
 
-        @thing = thing
-        @value = thing.flipper_id.to_s
+        @actor = actor
+        @value = actor.flipper_id.to_s
       end
 
       def respond_to?(*args)
-        super || @thing.respond_to?(*args)
+        super || @actor.respond_to?(*args)
       end
 
       if RUBY_VERSION >= '3.0'
         def method_missing(name, *args, **kwargs, &block)
-          @thing.send name, *args, **kwargs, &block
+          @actor.send name, *args, **kwargs, &block
         end
       else
         def method_missing(name, *args, &block)
-          @thing.send name, *args, &block
+          @actor.send name, *args, &block
         end
       end
     end

--- a/lib/flipper/types/group.rb
+++ b/lib/flipper/types/group.rb
@@ -16,16 +16,16 @@ module Flipper
           @block = block
           @single_argument = call_with_no_context?(@block)
         else
-          @block = ->(_thing, _context) { false }
+          @block = ->(actor, context) { false }
           @single_argument = false
         end
       end
 
-      def match?(thing, context)
+      def match?(actor, context)
         if @single_argument
-          @block.call(thing)
+          @block.call(actor)
         else
-          @block.call(thing, context)
+          @block.call(actor, context)
         end
       end
 

--- a/spec/flipper/dsl_spec.rb
+++ b/spec/flipper/dsl_spec.rb
@@ -149,12 +149,12 @@ RSpec.describe Flipper::DSL do
   end
 
   describe '#actor' do
-    context 'for a thing' do
+    context 'for an actor' do
       it 'returns actor instance' do
-        thing = Flipper::Actor.new(33)
-        actor = subject.actor(thing)
-        expect(actor).to be_instance_of(Flipper::Types::Actor)
-        expect(actor.value).to eq('33')
+        actor = Flipper::Actor.new(33)
+        flipper_actor = subject.actor(actor)
+        expect(flipper_actor).to be_instance_of(Flipper::Types::Actor)
+        expect(flipper_actor.value).to eq('33')
       end
     end
 

--- a/spec/flipper/feature_check_context_spec.rb
+++ b/spec/flipper/feature_check_context_spec.rb
@@ -1,12 +1,12 @@
 RSpec.describe Flipper::FeatureCheckContext do
   let(:feature_name) { :new_profiles }
   let(:values) { Flipper::GateValues.new({}) }
-  let(:thing) { Flipper::Actor.new('5') }
+  let(:actor) { Flipper::Actor.new('5') }
   let(:options) do
     {
       feature_name: feature_name,
       values: values,
-      thing: thing,
+      actors: [actor],
     }
   end
 
@@ -14,7 +14,7 @@ RSpec.describe Flipper::FeatureCheckContext do
     instance = described_class.new(**options)
     expect(instance.feature_name).to eq(feature_name)
     expect(instance.values).to eq(values)
-    expect(instance.thing).to eq(thing)
+    expect(instance.actors).to eq([actor])
   end
 
   it 'requires feature_name' do
@@ -31,8 +31,8 @@ RSpec.describe Flipper::FeatureCheckContext do
     end.to raise_error(ArgumentError)
   end
 
-  it 'requires thing' do
-    options.delete(:thing)
+  it 'requires actors' do
+    options.delete(:actors)
     expect do
       described_class.new(**options)
     end.to raise_error(ArgumentError)

--- a/spec/flipper/feature_spec.rb
+++ b/spec/flipper/feature_spec.rb
@@ -66,6 +66,11 @@ RSpec.describe Flipper::Feature do
         expect(subject.enabled?(actors)).to be(true)
       end
 
+      it 'returns true if feature is enabled for any actor with multiple arguments' do
+        subject.enable_actor actors.last
+        expect(subject.enabled?(*actors)).to be(true)
+      end
+
       it 'returns false if feature is disabled for all actors' do
         subject.disable
         expect(subject.enabled?(actors)).to be(false)

--- a/spec/flipper/gates/boolean_spec.rb
+++ b/spec/flipper/gates/boolean_spec.rb
@@ -9,7 +9,7 @@ RSpec.describe Flipper::Gates::Boolean do
     Flipper::FeatureCheckContext.new(
       feature_name: feature_name,
       values: Flipper::GateValues.new(boolean: bool),
-      actors: [Flipper::Types::Actor.new(Flipper::Actor.new(1))]
+      actors: [Flipper::Types::Actor.new(Flipper::Actor.new('1'))]
     )
   end
 

--- a/spec/flipper/gates/boolean_spec.rb
+++ b/spec/flipper/gates/boolean_spec.rb
@@ -9,7 +9,7 @@ RSpec.describe Flipper::Gates::Boolean do
     Flipper::FeatureCheckContext.new(
       feature_name: feature_name,
       values: Flipper::GateValues.new(boolean: bool),
-      thing: Flipper::Types::Actor.new(Flipper::Actor.new(1))
+      actors: [Flipper::Types::Actor.new(Flipper::Actor.new(1))]
     )
   end
 

--- a/spec/flipper/gates/group_spec.rb
+++ b/spec/flipper/gates/group_spec.rb
@@ -9,18 +9,17 @@ RSpec.describe Flipper::Gates::Group do
     Flipper::FeatureCheckContext.new(
       feature_name: feature_name,
       values: Flipper::GateValues.new(groups: set),
-      thing: Flipper::Types::Actor.new(Flipper::Actor.new('5'))
+      actors: [Flipper::Types::Actor.new(Flipper::Actor.new('5'))]
     )
   end
 
   describe '#open?' do
     context 'with a group in adapter, but not registered' do
       before do
-        Flipper.register(:staff) { |_thing| true }
+        Flipper.register(:staff) { |actor| true }
       end
 
       it 'ignores group' do
-        thing = Flipper::Actor.new('5')
         expect(subject.open?(context(Set[:newbs, :staff]))).to be(true)
       end
     end

--- a/spec/flipper/gates/percentage_of_actors_spec.rb
+++ b/spec/flipper/gates/percentage_of_actors_spec.rb
@@ -9,7 +9,7 @@ RSpec.describe Flipper::Gates::PercentageOfActors do
     Flipper::FeatureCheckContext.new(
       feature_name: feature,
       values: Flipper::GateValues.new(percentage_of_actors: percentage_of_actors_value),
-      actors: Array(actors) || [Flipper::Types::Actor.new(Flipper::Actor.new(1))]
+      actors: Array(actors) || [Flipper::Types::Actor.new(Flipper::Actor.new('1'))]
     )
   end
 
@@ -20,7 +20,7 @@ RSpec.describe Flipper::Gates::PercentageOfActors do
       let(:number_of_actors) { 10_000 }
 
       let(:actors) do
-        (1..number_of_actors).map { |n| Flipper::Types::Actor.new(Flipper::Actor.new(n)) }
+        (1..number_of_actors).map { |n| Flipper::Types::Actor.new(Flipper::Actor.new(n.to_s)) }
       end
 
       let(:feature_one_enabled_actors) do
@@ -110,7 +110,7 @@ RSpec.describe Flipper::Gates::PercentageOfActors do
       let(:number_of_actors) { 10_000 }
 
       let(:actors) do
-        (1..number_of_actors).map { |n| Flipper::Types::Actor.new(Flipper::Actor.new(n)) }
+        (1..number_of_actors).map { |n| Flipper::Types::Actor.new(Flipper::Actor.new(n.to_s)) }
       end
 
       subject { described_class.new }

--- a/spec/flipper/gates/percentage_of_actors_spec.rb
+++ b/spec/flipper/gates/percentage_of_actors_spec.rb
@@ -5,11 +5,11 @@ RSpec.describe Flipper::Gates::PercentageOfActors do
     described_class.new
   end
 
-  def context(percentage_of_actors_value, feature = feature_name, thing = nil)
+  def context(percentage_of_actors_value, feature = feature_name, actors = nil)
     Flipper::FeatureCheckContext.new(
       feature_name: feature,
       values: Flipper::GateValues.new(percentage_of_actors: percentage_of_actors_value),
-      thing: Flipper::Types::Actor.new(thing || Flipper::Actor.new(1))
+      actors: Array(actors) || [Flipper::Types::Actor.new(Flipper::Actor.new(1))]
     )
   end
 
@@ -20,7 +20,7 @@ RSpec.describe Flipper::Gates::PercentageOfActors do
       let(:number_of_actors) { 10_000 }
 
       let(:actors) do
-        (1..number_of_actors).map { |n| Flipper::Actor.new(n) }
+        (1..number_of_actors).map { |n| Flipper::Types::Actor.new(Flipper::Actor.new(n)) }
       end
 
       let(:feature_one_enabled_actors) do
@@ -54,7 +54,7 @@ RSpec.describe Flipper::Gates::PercentageOfActors do
       let(:number_of_actors) { 10_000 }
 
       let(:actors) do
-        (1..number_of_actors).map { |n| Flipper::Actor.new(n) }
+        (1..number_of_actors).map { |n| Flipper::Types::Actor.new(Flipper::Actor.new(n)) }
       end
 
       subject { described_class.new }
@@ -64,7 +64,7 @@ RSpec.describe Flipper::Gates::PercentageOfActors do
         expected_open_count = number_of_actors * decimal
 
         open_count = actors.select do |actor|
-          context = context(percentage, :feature, actor)
+          context = context(percentage, :feature, [actor])
           subject.open?(context)
         end.size
 

--- a/spec/flipper/gates/percentage_of_actors_spec.rb
+++ b/spec/flipper/gates/percentage_of_actors_spec.rb
@@ -48,6 +48,62 @@ RSpec.describe Flipper::Gates::PercentageOfActors do
       end
     end
 
+    context "with an array of actors" do
+      let(:percentage) { 0.05 }
+      let(:percentage_as_integer) { percentage * 100 }
+      let(:number_of_actors) { 3_000 }
+
+      let(:user_actors) do
+        (1..number_of_actors).map { |n| Flipper::Types::Actor.new(Flipper::Actor.new("User;#{n}")) }
+      end
+
+      let(:team_actors) do
+        (1..number_of_actors).map { |n| Flipper::Types::Actor.new(Flipper::Actor.new("Team;#{n}")) }
+      end
+
+      let(:org_actors) do
+        (1..number_of_actors).map { |n| Flipper::Types::Actor.new(Flipper::Actor.new("Org;#{n}")) }
+      end
+
+      let(:actors) { user_actors + team_actors + org_actors }
+
+      let(:feature_one_enabled_actors) do
+        actors.each_slice(3).select do |group|
+          context = context(percentage_as_integer, :name_one, group)
+          subject.open?(context)
+        end.flatten
+      end
+
+      let(:feature_two_enabled_actors) do
+        actors.each_slice(3).select do |group|
+          context = context(percentage_as_integer, :name_two, group)
+          subject.open?(context)
+        end.flatten
+      end
+
+      it 'does not enable both features for same set of actors' do
+        expect(feature_one_enabled_actors).not_to eq(feature_two_enabled_actors)
+      end
+
+      it 'enables feature for accurate number of actors for each feature' do
+        margin_of_error = 0.02 * actors.size # 2 percent margin of error
+        expected_enabled_size = actors.size * percentage
+
+        [
+          feature_one_enabled_actors.size,
+          feature_two_enabled_actors.size,
+        ].each do |size|
+          expect(size).to be_within(margin_of_error).of(expected_enabled_size)
+        end
+      end
+
+      it "is consistent regardless of order of actors" do
+        actors = user_actors.first(10)
+        results = 100.times.map { |n| subject.open?(context(75, :some_feature, actors.shuffle)) }
+        expect(results.uniq).to eq([true])
+      end
+    end
+
     context 'for fractional percentage' do
       let(:decimal) { 0.001 }
       let(:percentage) { decimal * 100 }

--- a/spec/flipper/gates/percentage_of_time_spec.rb
+++ b/spec/flipper/gates/percentage_of_time_spec.rb
@@ -9,7 +9,7 @@ RSpec.describe Flipper::Gates::PercentageOfTime do
     Flipper::FeatureCheckContext.new(
       feature_name: feature,
       values: Flipper::GateValues.new(percentage_of_time: percentage_of_time_value),
-      actors: Array(actors) || [Flipper::Types::Actor.new(Flipper::Actor.new(1))]
+      actors: Array(actors) || [Flipper::Types::Actor.new(Flipper::Actor.new('1'))]
     )
   end
 

--- a/spec/flipper/gates/percentage_of_time_spec.rb
+++ b/spec/flipper/gates/percentage_of_time_spec.rb
@@ -5,11 +5,11 @@ RSpec.describe Flipper::Gates::PercentageOfTime do
     described_class.new
   end
 
-  def context(percentage_of_time_value, feature = feature_name, thing = nil)
+  def context(percentage_of_time_value, feature = feature_name, actors = nil)
     Flipper::FeatureCheckContext.new(
       feature_name: feature,
       values: Flipper::GateValues.new(percentage_of_time: percentage_of_time_value),
-      thing: thing || Flipper::Types::Actor.new(Flipper::Actor.new(1))
+      actors: Array(actors) || [Flipper::Types::Actor.new(Flipper::Actor.new(1))]
     )
   end
 

--- a/spec/flipper/instrumentation/log_subscriber_spec.rb
+++ b/spec/flipper/instrumentation/log_subscriber_spec.rb
@@ -18,8 +18,8 @@ RSpec.describe Flipper::Instrumentation::LogSubscriber do
   end
 
   before do
-    Flipper.register(:admins) do |thing|
-      thing.respond_to?(:admin?) && thing.admin?
+    Flipper.register(:admins) do |actor|
+      actor.respond_to?(:admin?) && actor.admin?
     end
 
     @io = StringIO.new
@@ -46,7 +46,7 @@ RSpec.describe Flipper::Instrumentation::LogSubscriber do
 
     it 'logs feature calls with result after operation' do
       feature_line = find_line('Flipper feature(search) enabled? false')
-      expect(feature_line).to include('[ thing=nil ]')
+      expect(feature_line).to include('[ actors=nil ]')
     end
 
     it 'logs adapter calls' do
@@ -56,7 +56,7 @@ RSpec.describe Flipper::Instrumentation::LogSubscriber do
     end
   end
 
-  context 'feature enabled checks with a thing' do
+  context 'feature enabled checks with an actor' do
     let(:user) { Flipper::Types::Actor.new(Flipper::Actor.new('1')) }
 
     before do
@@ -64,7 +64,7 @@ RSpec.describe Flipper::Instrumentation::LogSubscriber do
       flipper[:search].enabled?(user)
     end
 
-    it 'logs thing for feature' do
+    it 'logs actors for feature' do
       feature_line = find_line('Flipper feature(search) enabled?')
       expect(feature_line).to include(user.inspect)
     end

--- a/spec/flipper/types/actor_spec.rb
+++ b/spec/flipper/types/actor_spec.rb
@@ -2,11 +2,11 @@ require 'flipper/types/actor'
 
 RSpec.describe Flipper::Types::Actor do
   subject do
-    thing = thing_class.new('2')
-    described_class.new(thing)
+    actor = actor_class.new('2')
+    described_class.new(actor)
   end
 
-  let(:thing_class) do
+  let(:actor_class) do
     Class.new do
       attr_reader :flipper_id
 
@@ -22,14 +22,14 @@ RSpec.describe Flipper::Types::Actor do
 
   describe '.wrappable?' do
     it 'returns true if actor' do
-      thing = thing_class.new('1')
-      actor = described_class.new(thing)
-      expect(described_class.wrappable?(actor)).to eq(true)
+      actor = actor_class.new('1')
+      actor_type_instance = described_class.new(actor)
+      expect(described_class.wrappable?(actor_type_instance)).to eq(true)
     end
 
     it 'returns true if responds to flipper_id' do
-      thing = thing_class.new(10)
-      expect(described_class.wrappable?(thing)).to eq(true)
+      actor = actor_class.new(10)
+      expect(described_class.wrappable?(actor)).to eq(true)
     end
 
     it 'returns false if nil' do
@@ -38,27 +38,27 @@ RSpec.describe Flipper::Types::Actor do
   end
 
   describe '.wrap' do
-    context 'for actor' do
-      it 'returns actor' do
-        actor = described_class.wrap(subject)
-        expect(actor).to be_instance_of(described_class)
-        expect(actor).to be(subject)
+    context 'for actor type instance' do
+      it 'returns actor type instance' do
+        actor_type_instance = described_class.wrap(subject)
+        expect(actor_type_instance).to be_instance_of(described_class)
+        expect(actor_type_instance).to be(subject)
       end
     end
 
-    context 'for other thing' do
-      it 'returns actor' do
-        thing = thing_class.new('1')
-        actor = described_class.wrap(thing)
-        expect(actor).to be_instance_of(described_class)
+    context 'for other object' do
+      it 'returns actor type instance' do
+        actor = actor_class.new('1')
+        actor_type_instance = described_class.wrap(actor)
+        expect(actor_type_instance).to be_instance_of(described_class)
       end
     end
   end
 
-  it 'initializes with thing that responds to id' do
-    thing = thing_class.new('1')
-    actor = described_class.new(thing)
-    expect(actor.value).to eq('1')
+  it 'initializes with object that responds to flipper_id' do
+    actor = actor_class.new('1')
+    actor_type_instance = described_class.new(actor)
+    expect(actor_type_instance.value).to eq('1')
   end
 
   it 'raises error when initialized with nil' do
@@ -68,48 +68,48 @@ RSpec.describe Flipper::Types::Actor do
   end
 
   it 'raises error when initalized with non-wrappable object' do
-    unwrappable_thing = Struct.new(:id).new(1)
+    unwrappable_object = Struct.new(:id).new(1)
     expect do
-      described_class.new(unwrappable_thing)
+      described_class.new(unwrappable_object)
     end.to raise_error(ArgumentError,
-                       "#{unwrappable_thing.inspect} must respond to flipper_id, but does not")
+                       "#{unwrappable_object.inspect} must respond to flipper_id, but does not")
   end
 
   it 'converts id to string' do
-    thing = thing_class.new(2)
-    actor = described_class.new(thing)
+    actor = actor_class.new(2)
+    actor = described_class.new(actor)
     expect(actor.value).to eq('2')
   end
 
-  it 'proxies everything to thing' do
-    thing = thing_class.new(10)
-    actor = described_class.new(thing)
+  it 'proxies everything to actor' do
+    actor = actor_class.new(10)
+    actor = described_class.new(actor)
     expect(actor.admin?).to eq(true)
   end
 
-  it 'exposes thing' do
-    thing = thing_class.new(10)
-    actor = described_class.new(thing)
-    expect(actor.thing).to be(thing)
+  it 'exposes actor' do
+    actor = actor_class.new(10)
+    actor_type_instance = described_class.new(actor)
+    expect(actor_type_instance.actor).to be(actor)
   end
 
   describe '#respond_to?' do
     it 'returns true if responds to method' do
-      thing = thing_class.new('1')
-      actor = described_class.new(thing)
-      expect(actor.respond_to?(:value)).to eq(true)
+      actor = actor_class.new('1')
+      actor_type_instance = described_class.new(actor)
+      expect(actor_type_instance.respond_to?(:value)).to eq(true)
     end
 
-    it 'returns true if thing responds to method' do
-      thing = thing_class.new(10)
-      actor = described_class.new(thing)
-      expect(actor.respond_to?(:admin?)).to eq(true)
+    it 'returns true if actor responds to method' do
+      actor = actor_class.new(10)
+      actor_type_instance = described_class.new(actor)
+      expect(actor_type_instance.respond_to?(:admin?)).to eq(true)
     end
 
-    it 'returns false if does not respond to method and thing does not respond to method' do
-      thing = thing_class.new(10)
-      actor = described_class.new(thing)
-      expect(actor.respond_to?(:frankenstein)).to eq(false)
+    it 'returns false if does not respond to method and actor does not respond to method' do
+      actor = actor_class.new(10)
+      actor_type_instance = described_class.new(actor)
+      expect(actor_type_instance.respond_to?(:frankenstein)).to eq(false)
     end
   end
 end

--- a/spec/flipper/types/group_spec.rb
+++ b/spec/flipper/types/group_spec.rb
@@ -90,7 +90,7 @@ RSpec.describe Flipper::Types::Group do
       context = Flipper::FeatureCheckContext.new(
         feature_name: :my_feature,
         values: Flipper::GateValues.new({}),
-        thing: Flipper::Types::Actor.new(Flipper::Actor.new(1))
+        actors: [Flipper::Types::Actor.new(Flipper::Actor.new(1))]
       )
       group = Flipper.register(:group_with_context) { |actor| actor }
       yielded_actor = group.match?(admin_actor, context)
@@ -101,7 +101,7 @@ RSpec.describe Flipper::Types::Group do
       context = Flipper::FeatureCheckContext.new(
         feature_name: :my_feature,
         values: Flipper::GateValues.new({}),
-        thing: Flipper::Types::Actor.new(Flipper::Actor.new(1))
+        actors: [Flipper::Types::Actor.new(Flipper::Actor.new(1))]
       )
       group = Flipper.register(:group_with_context) { |actor, context| [actor, context] }
       yielded_actor, yielded_context = group.match?(admin_actor, context)

--- a/spec/flipper/types/group_spec.rb
+++ b/spec/flipper/types/group_spec.rb
@@ -90,7 +90,7 @@ RSpec.describe Flipper::Types::Group do
       context = Flipper::FeatureCheckContext.new(
         feature_name: :my_feature,
         values: Flipper::GateValues.new({}),
-        actors: [Flipper::Types::Actor.new(Flipper::Actor.new(1))]
+        actors: [Flipper::Types::Actor.new(Flipper::Actor.new('1'))]
       )
       group = Flipper.register(:group_with_context) { |actor| actor }
       yielded_actor = group.match?(admin_actor, context)
@@ -101,7 +101,7 @@ RSpec.describe Flipper::Types::Group do
       context = Flipper::FeatureCheckContext.new(
         feature_name: :my_feature,
         values: Flipper::GateValues.new({}),
-        actors: [Flipper::Types::Actor.new(Flipper::Actor.new(1))]
+        actors: [Flipper::Types::Actor.new(Flipper::Actor.new('1'))]
       )
       group = Flipper.register(:group_with_context) { |actor, context| [actor, context] }
       yielded_actor, yielded_context = group.match?(admin_actor, context)

--- a/spec/flipper_integration_spec.rb
+++ b/spec/flipper_integration_spec.rb
@@ -7,17 +7,17 @@ RSpec.describe Flipper do
   let(:admin_group) { flipper.group(:admins) }
   let(:dev_group)   { flipper.group(:devs) }
 
-  let(:admin_thing) do
+  let(:admin_actor) do
     double 'Non Flipper Thing', flipper_id: 1,  admin?: true, dev?: false
   end
-  let(:dev_thing) do
+  let(:dev_actor) do
     double 'Non Flipper Thing', flipper_id: 10, admin?: false, dev?: true
   end
 
-  let(:admin_truthy_thing) do
+  let(:admin_truthy_actor) do
     double 'Non Flipper Thing', flipper_id: 1,  admin?: 'true-ish', dev?: false
   end
-  let(:admin_falsey_thing) do
+  let(:admin_falsey_actor) do
     double 'Non Flipper Thing', flipper_id: 1,  admin?: nil, dev?: false
   end
 
@@ -60,20 +60,20 @@ RSpec.describe Flipper do
         expect(@result).to eq(true)
       end
 
-      it 'enables feature for non flipper thing in group' do
-        expect(feature.enabled?(admin_thing)).to eq(true)
+      it 'enables feature for non flipper actor in group' do
+        expect(feature.enabled?(admin_actor)).to eq(true)
       end
 
-      it 'does not enable feature for non flipper thing in other group' do
-        expect(feature.enabled?(dev_thing)).to eq(false)
+      it 'does not enable feature for non flipper actor in other group' do
+        expect(feature.enabled?(dev_actor)).to eq(false)
       end
 
       it 'enables feature for flipper actor in group' do
-        expect(feature.enabled?(flipper.actor(admin_thing))).to eq(true)
+        expect(feature.enabled?(flipper.actor(admin_actor))).to eq(true)
       end
 
       it 'does not enable for flipper actor not in group' do
-        expect(feature.enabled?(flipper.actor(dev_thing))).to eq(false)
+        expect(feature.enabled?(flipper.actor(dev_actor))).to eq(false)
       end
 
       it 'does not enable feature for all' do
@@ -118,8 +118,8 @@ RSpec.describe Flipper do
 
       it 'enables feature for actor within percentage' do
         enabled = (1..100).select do |i|
-          thing = Flipper::Actor.new(i)
-          feature.enabled?(thing)
+          actor = Flipper::Actor.new(i)
+          feature.enabled?(actor)
         end.size
 
         expect(enabled).to be_within(2).of(5)
@@ -141,8 +141,8 @@ RSpec.describe Flipper do
 
       it 'enables feature for actor within percentage' do
         enabled = (1..100).select do |i|
-          thing = Flipper::Actor.new(i)
-          feature.enabled?(thing)
+          actor = Flipper::Actor.new(i)
+          feature.enabled?(actor)
         end.size
 
         expect(enabled).to be_within(2).of(5)
@@ -180,10 +180,10 @@ RSpec.describe Flipper do
 
     context 'with argument that has no gate' do
       it 'raises error' do
-        thing = Object.new
+        actor = Object.new
         expect do
-          feature.enable(thing)
-        end.to raise_error(Flipper::GateNotFound, "Could not find gate for #{thing.inspect}")
+          feature.enable(actor)
+        end.to raise_error(Flipper::GateNotFound, "Could not find gate for #{actor.inspect}")
       end
     end
   end
@@ -215,13 +215,13 @@ RSpec.describe Flipper do
       end
 
       it 'disables actor in group' do
-        expect(feature.enabled?(admin_thing)).to eq(false)
+        expect(feature.enabled?(admin_actor)).to eq(false)
       end
 
       it 'disables actor in percentage of actors' do
         enabled = (1..100).select do |i|
-          thing = Flipper::Actor.new(i)
-          feature.enabled?(thing)
+          actor = Flipper::Actor.new(i)
+          feature.enabled?(actor)
         end.size
 
         expect(enabled).to be(0)
@@ -247,20 +247,20 @@ RSpec.describe Flipper do
         expect(@result).to eq(true)
       end
 
-      it 'disables the feature for non flipper thing in the group' do
-        expect(feature.enabled?(admin_thing)).to eq(false)
+      it 'disables the feature for non flipper actor in the group' do
+        expect(feature.enabled?(admin_actor)).to eq(false)
       end
 
-      it 'does not disable feature for non flipper thing in other groups' do
-        expect(feature.enabled?(dev_thing)).to eq(true)
+      it 'does not disable feature for non flipper actor in other groups' do
+        expect(feature.enabled?(dev_actor)).to eq(true)
       end
 
       it 'disables feature for flipper actor in group' do
-        expect(feature.enabled?(flipper.actor(admin_thing))).to eq(false)
+        expect(feature.enabled?(flipper.actor(admin_actor))).to eq(false)
       end
 
       it 'does not disable feature for flipper actor in other groups' do
-        expect(feature.enabled?(flipper.actor(dev_thing))).to eq(true)
+        expect(feature.enabled?(flipper.actor(dev_actor))).to eq(true)
       end
 
       it 'adds feature to set of features' do
@@ -303,8 +303,8 @@ RSpec.describe Flipper do
 
       it 'disables feature' do
         enabled = (1..100).select do |i|
-          thing = Flipper::Actor.new(i)
-          feature.enabled?(thing)
+          actor = Flipper::Actor.new(i)
+          feature.enabled?(actor)
         end.size
 
         expect(enabled).to be(0)
@@ -342,10 +342,10 @@ RSpec.describe Flipper do
 
     context 'with argument that has no gate' do
       it 'raises error' do
-        thing = Object.new
+        actor = Object.new
         expect do
-          feature.disable(thing)
-        end.to raise_error(Flipper::GateNotFound, "Could not find gate for #{thing.inspect}")
+          feature.disable(actor)
+        end.to raise_error(Flipper::GateNotFound, "Could not find gate for #{actor.inspect}")
       end
     end
   end
@@ -373,23 +373,23 @@ RSpec.describe Flipper do
       end
 
       it 'returns true' do
-        expect(feature.enabled?(flipper.actor(admin_thing))).to eq(true)
-        expect(feature.enabled?(admin_thing)).to eq(true)
+        expect(feature.enabled?(flipper.actor(admin_actor))).to eq(true)
+        expect(feature.enabled?(admin_actor)).to eq(true)
       end
 
       it 'returns true for truthy block values' do
-        expect(feature.enabled?(flipper.actor(admin_truthy_thing))).to eq(true)
+        expect(feature.enabled?(flipper.actor(admin_truthy_actor))).to eq(true)
       end
     end
 
     context 'for actor in disabled group' do
       it 'returns false' do
-        expect(feature.enabled?(flipper.actor(dev_thing))).to eq(false)
-        expect(feature.enabled?(dev_thing)).to eq(false)
+        expect(feature.enabled?(flipper.actor(dev_actor))).to eq(false)
+        expect(feature.enabled?(dev_actor)).to eq(false)
       end
 
       it 'returns false for falsey block values' do
-        expect(feature.enabled?(flipper.actor(admin_falsey_thing))).to eq(false)
+        expect(feature.enabled?(flipper.actor(admin_falsey_actor))).to eq(false)
       end
     end
 
@@ -428,7 +428,7 @@ RSpec.describe Flipper do
         expect(feature.enabled?).to eq(true)
         expect(feature.enabled?(nil)).to eq(true)
         expect(feature.enabled?(pitt)).to eq(true)
-        expect(feature.enabled?(admin_thing)).to eq(true)
+        expect(feature.enabled?(admin_actor)).to eq(true)
       end
     end
 
@@ -446,7 +446,7 @@ RSpec.describe Flipper do
         expect(feature.enabled?).to eq(true)
         expect(feature.enabled?(nil)).to eq(true)
         expect(feature.enabled?(pitt)).to eq(true)
-        expect(feature.enabled?(admin_thing)).to eq(true)
+        expect(feature.enabled?(admin_actor)).to eq(true)
       end
     end
 
@@ -463,7 +463,7 @@ RSpec.describe Flipper do
         expect(feature.enabled?).to eq(false)
         expect(feature.enabled?(nil)).to eq(false)
         expect(feature.enabled?(pitt)).to eq(false)
-        expect(feature.enabled?(admin_thing)).to eq(false)
+        expect(feature.enabled?(admin_actor)).to eq(false)
       end
 
       it 'returns true if boolean enabled' do
@@ -471,7 +471,7 @@ RSpec.describe Flipper do
         expect(feature.enabled?).to eq(true)
         expect(feature.enabled?(nil)).to eq(true)
         expect(feature.enabled?(pitt)).to eq(true)
-        expect(feature.enabled?(admin_thing)).to eq(true)
+        expect(feature.enabled?(admin_actor)).to eq(true)
       end
     end
 
@@ -488,7 +488,7 @@ RSpec.describe Flipper do
         expect(feature.enabled?).to eq(false)
         expect(feature.enabled?(nil)).to eq(false)
         expect(feature.enabled?(pitt)).to eq(false)
-        expect(feature.enabled?(admin_thing)).to eq(false)
+        expect(feature.enabled?(admin_actor)).to eq(false)
       end
 
       it 'returns true if boolean enabled' do
@@ -496,27 +496,27 @@ RSpec.describe Flipper do
         expect(feature.enabled?).to eq(true)
         expect(feature.enabled?(nil)).to eq(true)
         expect(feature.enabled?(pitt)).to eq(true)
-        expect(feature.enabled?(admin_thing)).to eq(true)
+        expect(feature.enabled?(admin_actor)).to eq(true)
       end
     end
 
-    context 'for a non flipper thing' do
+    context 'for a non flipper actor' do
       before do
         feature.enable admin_group
       end
 
       it 'returns true if in enabled group' do
-        expect(feature.enabled?(admin_thing)).to eq(true)
+        expect(feature.enabled?(admin_actor)).to eq(true)
       end
 
       it 'returns false if not in enabled group' do
-        expect(feature.enabled?(dev_thing)).to eq(false)
+        expect(feature.enabled?(dev_actor)).to eq(false)
       end
 
       it 'returns true if boolean enabled' do
         feature.enable
-        expect(feature.enabled?(admin_thing)).to eq(true)
-        expect(feature.enabled?(dev_thing)).to eq(true)
+        expect(feature.enabled?(admin_actor)).to eq(true)
+        expect(feature.enabled?(dev_actor)).to eq(true)
       end
     end
   end
@@ -530,11 +530,11 @@ RSpec.describe Flipper do
     end
 
     it 'enables feature for object in enabled group' do
-      expect(feature.enabled?(admin_thing)).to eq(true)
+      expect(feature.enabled?(admin_actor)).to eq(true)
     end
 
     it 'does not enable feature for object in not enabled group' do
-      expect(feature.enabled?(dev_thing)).to eq(false)
+      expect(feature.enabled?(dev_actor)).to eq(false)
     end
   end
 end


### PR DESCRIPTION
Before: 

```ruby
[user, team, org].any? { |actor| Flipper.enabled?(:some_feature, actor) }
```

After:

```ruby
Flipper.enabled?(:some_feature, [user, team, org])
```

The biggest benefit is not re-running all the gates and instrumentation for every actor and every gate. Instead this runs the boolean and & of time once. Then it just checks multiple actors in the actor, % of actors and group gates.

I'm going to give this another pass to see if anything needs to change back or not.