### PR TITLE
Add Time, Now, and Duration expression types

### DIFF
--- a/lib/flipper/expressions/duration.rb
+++ b/lib/flipper/expressions/duration.rb
@@ -1,0 +1,37 @@
+require "flipper/expression"
+
+module Flipper
+  module Expressions
+    class Duration < Expression
+      SECONDS_PER = {
+        "second" => 1,
+        "minute" => 60,
+        "hour" => 3600,
+        "day" => 86400,
+        "week" => 604_800,
+        "month" => 26_29_746,  # 1/12 of a gregorian year
+        "year" => 31_556_952 # length of a gregorian year (365.2425 days)
+      }.freeze
+
+      def initialize(args)
+        scalar, unit = args
+        super [scalar, unit || 'second']
+      end
+
+      def evaluate(context = {})
+        scalar = evaluate_arg(0, context)
+        unit = evaluate_arg(1, context) || 'second'
+        unit = unit.to_s.downcase.chomp("s")
+
+        unless scalar.is_a?(Numeric)
+          raise ArgumentError.new("Duration value must be a number but was #{scalar.inspect}")
+        end
+        unless SECONDS_PER[unit]
+          raise ArgumentError.new("Duration unit #{unit.inspect} must be one of: #{SECONDS_PER.keys.join(', ')}")
+        end
+
+        scalar * SECONDS_PER[unit]
+      end
+    end
+  end
+end

--- a/lib/flipper/expressions/now.rb
+++ b/lib/flipper/expressions/now.rb
@@ -1,0 +1,15 @@
+require "flipper/expression"
+
+module Flipper
+  module Expressions
+    class Now < Expression
+      def initialize(_ = nil)
+        super []
+      end
+
+      def evaluate(context = {})
+        ::Time.now
+      end
+    end
+  end
+end

--- a/lib/flipper/expressions/time.rb
+++ b/lib/flipper/expressions/time.rb
@@ -1,0 +1,15 @@
+require "flipper/expression"
+
+module Flipper
+  module Expressions
+    class Time < Expression
+      def initialize(args)
+        super [args].flatten.map(&:to_s)
+      end
+
+      def evaluate(context = {})
+        ::Time.parse(evaluate_arg(0, context))
+      end
+    end
+  end
+end

--- a/spec/flipper/expressions/duration_spec.rb
+++ b/spec/flipper/expressions/duration_spec.rb
@@ -1,0 +1,49 @@
+RSpec.describe Flipper::Expressions::Duration do
+  describe "#initialize" do
+    it 'initializes with scalar and unit' do
+      expect(described_class.new([10, 'second']).args).to eq([10, 'second'])
+    end
+
+    it 'defaults unit to seconds' do
+      expect(described_class.new([1]).args).to eq([1, 'second'])
+    end
+  end
+
+  describe "#evaluate" do
+    it "raises error with invalid value" do
+      expect { described_class.new([false, 'minute']).evaluate }.to raise_error(ArgumentError)
+    end
+
+    it "raises error with invalid unit" do
+      expect { described_class.new([4, 'score']).evaluate }.to raise_error(ArgumentError)
+    end
+
+    it "evaluates seconds" do
+      expect(described_class.new([10, 'seconds']).evaluate).to eq(10)
+    end
+
+    it "evaluates minutes" do
+      expect(described_class.new([2, 'minutes']).evaluate).to eq(120)
+    end
+
+    it "evaluates hours" do
+      expect(described_class.new([2, 'hours']).evaluate).to eq(7200)
+    end
+
+    it "evaluates days" do
+      expect(described_class.new([2, 'days']).evaluate).to eq(172_800)
+    end
+
+    it "evaluates weeks" do
+      expect(described_class.new([2, 'weeks']).evaluate).to eq(1_209_600)
+    end
+
+    it "evaluates months" do
+      expect(described_class.new([2, 'months']).evaluate).to eq(5_259_492)
+    end
+
+    it "evaluates years" do
+      expect(described_class.new([2, 'years']).evaluate).to eq(63_113_904)
+    end
+  end
+end

--- a/spec/flipper/expressions/now_spec.rb
+++ b/spec/flipper/expressions/now_spec.rb
@@ -1,0 +1,13 @@
+RSpec.describe Flipper::Expressions::Now do
+  describe "#initialize" do
+    it "ignores arguments" do
+      expect(described_class.new("foo").args).to eq([])
+    end
+  end
+
+  describe "#evaluate" do
+    it "returns current time" do
+      expect(described_class.new.evaluate.round).to eq(Time.now.round)
+    end
+  end
+end

--- a/spec/flipper/expressions/time_spec.rb
+++ b/spec/flipper/expressions/time_spec.rb
@@ -1,0 +1,27 @@
+RSpec.describe Flipper::Expressions::Time do
+  let(:time) { Time.now.round }
+
+  describe "#initialize" do
+    it "works with time" do
+      expect(described_class.new(time).args).to eq([time.to_s])
+    end
+
+    it "works with Time#to_s" do
+      expect(described_class.new(time.to_s).args).to eq([time.to_s])
+    end
+
+    it "works with array" do
+      expect(described_class.new([time]).args).to eq([time.to_s])
+    end
+  end
+
+  describe "#evaluate" do
+    it "returns time for #to_s format" do
+      expect(described_class.new(time.to_s).evaluate).to eq(time)
+    end
+
+    it "returns time for #iso8601 format" do
+      expect(described_class.new(time.iso8601).evaluate).to eq(time)
+    end
+  end
+end


### PR DESCRIPTION
Enable a feature at a specific time:

```js
{
  "GreaterThan": [
    { "Now": [] },
    { "Time": "2023-03-26 13:00:00Z" }
  ]
}
```

Give an actor a 14 day trial:

```js
{
  "LessThan": [
    { "Property": ["created_at"] },
    {
      "Plus": [
        { "Now": [] },
        { "Duration": [14, "days"] }
      ]
    }
  ]
}
```

> Note: `Plus` isn't implemented yet, but it's on my list