### PR TITLE
Address `color` deprecation warning

### DIFF
--- a/lib/flipper/instrumentation/log_subscriber.rb
+++ b/lib/flipper/instrumentation/log_subscriber.rb
@@ -32,7 +32,7 @@ module Flipper
         details += " gate_name=#{gate_name}" unless gate_name.nil?
 
         name = '%s (%.1fms)' % [description, event.duration]
-        debug "  #{color(name, CYAN, true)}  [ #{details} ]"
+        debug "  #{color(name, CYAN, bold: true)}  [ #{details} ]"
       end
 
       # Logs an adapter operation. If operation is for a feature, then that
@@ -64,7 +64,7 @@ module Flipper
         details = "result=#{result.inspect}"
 
         name = '%s (%.1fms)' % [description, event.duration]
-        debug "  #{color(name, CYAN, true)}  [ #{details} ]"
+        debug "  #{color(name, CYAN, bold: true)}  [ #{details} ]"
       end
 
       def logger


### PR DESCRIPTION
While using Flipper with `rails>7.0`, the following deprecation warning is output:

```
DEPRECATION WARNING: Bolding log text with a positional boolean is deprecated and will be removed in Rails 7.2. Use an option hash instead (eg. `color(:red, "my text", bold: true)`).
```

To address this issue, this commit makes the suggested changes to the `LogSubscriber` class.