### PR TITLE
Improve performance of `color_name` function in log subscriber

### DIFF
--- a/lib/flipper/instrumentation/log_subscriber.rb
+++ b/lib/flipper/instrumentation/log_subscriber.rb
@@ -73,14 +73,17 @@ module Flipper
 
       private
 
+      # Rails 7.1 changed the signature of this function.
+      # Checking if > 7.0.99 rather than >= 7.1 so that 7.1 pre-release versions are included.
+      COLOR_OPTIONS = if Rails.gem_version > Gem::Version.new('7.0.99')
+        { bold: true }.freeze
+      else
+        true
+      end
+      private_constant :COLOR_OPTIONS
+
       def color_name(name)
-        # Rails 7.1 changed the signature of this function.
-        # Checking if > 7.0.99 rather than >= 7.1 so that 7.1 pre-release versions are included.
-        if Rails.gem_version > Gem::Version.new('7.0.99')
-          color(name, CYAN, bold: true)
-        else
-          color(name, CYAN, true)
-        end
+        color(name, CYAN, COLOR_OPTIONS)
       end
     end
   end


### PR DESCRIPTION
This fixes a performance degradation introduced in https://github.com/jnunemaker/flipper/pull/726

Move runtime version comparison into file-load comparison, since the gem version does not change while the process is running.

This removes two Gem::Version.new allocations (which in turn does some regex scans and string allocations), as well as a Hash allocation (`{ bold: true }` on Rails 7.1+) per `color_name` call.