### PR TITLE
Meta gem for recommended dependencies

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -6,6 +6,13 @@ All notable changes to this project will be documented in this file.
 
 ### Additions/Changes
 
+* New `flipper-rails` gem that includes most common dependencies (`flipper`, `flipper-active_record`, `flipper-cloud`)
+   ```diff
+   + gem 'flipper-rails'
+   - gem 'flipper'
+   - gem 'flipper-active_record'
+   - gem 'flipper-cloud'
+   ```
 * Use new method of making logs bold for rails (https://github.com/jnunemaker/flipper/pull/726)
 * Bundle bootstrap, jquery and poppler with the library. (https://github.com/jnunemaker/flipper/pull/731)
 

--- a/README.md
+++ b/README.md
@@ -17,13 +17,33 @@ Control your software &mdash; don't let it control you.
 
 ## Installation
 
+### Rails
+
+Add this line to your Rails application's Gemfile:
+
+    gem 'flipper-rails'
+
+And then execute:
+
+    $ bundle
+
+And generate the migrations:
+
+    $ bin/rails generate flipper:active_record
+    $ bin/rails db:migrate
+
+<details>
+  <summary>Advanced Ruby Setup</summary>
+
+If you are not using Rails or want more control over how Flipper is setup, you can use the `flipper` gem directly and pick a different storage [adapter](https://flippercloud.io/docs/adapters).
+
 Add this line to your application's Gemfile:
 
     gem 'flipper'
 
-You'll also want to pick a storage [adapter](https://flippercloud.io/docs/adapters), for example:
+Add a storage [adapter](https://flippercloud.io/docs/adapters), for example:
 
-    gem 'flipper-active_record'
+    gem 'flipper-redis'
 
 And then execute:
 
@@ -32,6 +52,7 @@ And then execute:
 Or install it yourself with:
 
     $ gem install flipper
+</details>
 
 ## Subscribe &amp; Ship
 

--- a/flipper-active_record.gemspec
+++ b/flipper-active_record.gemspec
@@ -8,10 +8,10 @@ end
 
 Gem::Specification.new do |gem|
   gem.authors       = ['John Nunemaker']
-  gem.email         = ['nunemaker@gmail.com']
+  gem.email         = 'support@flippercloud.io'
   gem.summary       = 'ActiveRecord adapter for Flipper'
   gem.license       = 'MIT'
-  gem.homepage      = 'https://github.com/jnunemaker/flipper'
+  gem.homepage      = 'https://www.flippercloud.io'
 
   extra_files = [
     'lib/generators/flipper/templates/migration.erb',

--- a/flipper-active_support_cache_store.gemspec
+++ b/flipper-active_support_cache_store.gemspec
@@ -8,10 +8,10 @@ end
 
 Gem::Specification.new do |gem|
   gem.authors       = ['John Nunemaker']
-  gem.email         = ['nunemaker@gmail.com']
+  gem.email         = 'support@flippercloud.io'
   gem.summary       = 'ActiveSupport::Cache store adapter for Flipper'
   gem.license       = 'MIT'
-  gem.homepage      = 'https://github.com/jnunemaker/flipper'
+  gem.homepage      = 'https://www.flippercloud.io'
 
   gem.files         = `git ls-files`.split("\n").select(&flipper_active_support_cache_store_files) + ['lib/flipper/version.rb']
   gem.test_files    = `git ls-files -- {test,spec,features}/*`.split("\n").select(&flipper_active_support_cache_store_files)

--- a/flipper-api.gemspec
+++ b/flipper-api.gemspec
@@ -8,10 +8,10 @@ end
 
 Gem::Specification.new do |gem|
   gem.authors       = ['John Nunemaker']
-  gem.email         = ['nunemaker@gmail.com']
+  gem.email         = 'support@flippercloud.io'
   gem.summary       = 'API for the Flipper gem'
   gem.license       = 'MIT'
-  gem.homepage      = 'https://github.com/jnunemaker/flipper'
+  gem.homepage      = 'https://www.flippercloud.io'
   gem.files         = `git ls-files`.split("\n").select(&flipper_api_files) + ['lib/flipper/version.rb']
   gem.test_files    = `git ls-files -- {test,spec,features}/*`.split("\n").select(&flipper_api_files)
   gem.name          = 'flipper-api'

--- a/flipper-cloud.gemspec
+++ b/flipper-cloud.gemspec
@@ -8,10 +8,10 @@ end
 
 Gem::Specification.new do |gem|
   gem.authors       = ['John Nunemaker']
-  gem.email         = ['nunemaker@gmail.com']
+  gem.email         = 'support@flippercloud.io'
   gem.summary       = 'FlipperCloud.io adapter for Flipper'
   gem.license       = 'MIT'
-  gem.homepage      = 'https://github.com/jnunemaker/flipper'
+  gem.homepage      = 'https://www.flippercloud.io'
 
   extra_files = [
     'lib/flipper/version.rb',

--- a/flipper-dalli.gemspec
+++ b/flipper-dalli.gemspec
@@ -8,10 +8,10 @@ end
 
 Gem::Specification.new do |gem|
   gem.authors       = ['John Nunemaker']
-  gem.email         = ['nunemaker@gmail.com']
+  gem.email         = 'support@flippercloud.io'
   gem.summary       = 'Dalli adapter for Flipper'
   gem.license       = 'MIT'
-  gem.homepage      = 'https://github.com/jnunemaker/flipper'
+  gem.homepage      = 'https://www.flippercloud.io'
 
   gem.files         = `git ls-files`.split("\n").select(&flipper_dalli_files) + ['lib/flipper/version.rb']
   gem.test_files    = `git ls-files -- {test,spec,features}/*`.split("\n").select(&flipper_dalli_files)

--- a/flipper-moneta.gemspec
+++ b/flipper-moneta.gemspec
@@ -7,10 +7,10 @@ end
 
 Gem::Specification.new do |gem|
   gem.authors       = ['John Nunemaker']
-  gem.email         = ['nunemaker@gmail.com']
+  gem.email         = 'support@flippercloud.io'
   gem.summary       = 'Moneta adapter for Flipper'
   gem.license       = 'MIT'
-  gem.homepage      = 'https://github.com/jnunemaker/flipper'
+  gem.homepage      = 'https://www.flippercloud.io'
 
   gem.files         = `git ls-files`.split("\n").select(&flipper_moneta_files) + ['lib/flipper/version.rb']
   gem.test_files    = `git ls-files -- {test,spec,features}/*`.split("\n").select(&flipper_moneta_files)

--- a/flipper-mongo.gemspec
+++ b/flipper-mongo.gemspec
@@ -8,10 +8,10 @@ end
 
 Gem::Specification.new do |gem|
   gem.authors       = ['John Nunemaker']
-  gem.email         = ['nunemaker@gmail.com']
+  gem.email         = 'support@flippercloud.io'
   gem.summary       = 'Mongo adapter for Flipper'
   gem.license       = 'MIT'
-  gem.homepage      = 'https://github.com/jnunemaker/flipper'
+  gem.homepage      = 'https://www.flippercloud.io'
 
   gem.files         = `git ls-files`.split("\n").select(&flipper_mongo_files) + ['lib/flipper/version.rb']
   gem.test_files    = `git ls-files -- {test,spec,features}/*`.split("\n").select(&flipper_mongo_files)

--- a/flipper-rails.gemspec
+++ b/flipper-rails.gemspec
@@ -1,0 +1,21 @@
+# -*- encoding: utf-8 -*-
+require File.expand_path('../lib/flipper/version', __FILE__)
+require File.expand_path('../lib/flipper/metadata', __FILE__)
+
+Gem::Specification.new do |gem|
+  gem.authors       = ['John Nunemaker']
+  gem.email         = 'support@flippercloud.io'
+  gem.summary       = 'Feature flags for gradual rollouts, maintenance, experiments, and more…'
+  gem.homepage      = 'https://www.flippercloud.io'
+  gem.license       = 'MIT'
+  gem.files         = ['lib/flipper/version.rb']
+  gem.require_paths = ['lib']
+
+  gem.name          = 'flipper-rails'
+  gem.version       = Flipper::VERSION
+  gem.metadata      = Flipper::METADATA
+
+  gem.add_dependency 'flipper', "~> #{Flipper::VERSION}"
+  gem.add_dependency 'flipper-active_record', "~> #{Flipper::VERSION}"
+  gem.add_dependency 'flipper-cloud', "~> #{Flipper::VERSION}"
+end

--- a/flipper-redis.gemspec
+++ b/flipper-redis.gemspec
@@ -8,10 +8,10 @@ end
 
 Gem::Specification.new do |gem|
   gem.authors       = ['John Nunemaker']
-  gem.email         = ['nunemaker@gmail.com']
+  gem.email         = 'support@flippercloud.io'
   gem.summary       = 'Redis adapter for Flipper'
   gem.license       = 'MIT'
-  gem.homepage      = 'https://github.com/jnunemaker/flipper'
+  gem.homepage      = 'https://www.flippercloud.io'
 
   gem.files         = `git ls-files`.split("\n").select(&flipper_redis_files) + ['lib/flipper/version.rb']
   gem.test_files    = `git ls-files -- {test,spec,features}/*`.split("\n").select(&flipper_redis_files)

--- a/flipper-rollout.gemspec
+++ b/flipper-rollout.gemspec
@@ -8,10 +8,10 @@ end
 
 Gem::Specification.new do |gem|
   gem.authors       = ['John Nunemaker']
-  gem.email         = ['nunemaker@gmail.com']
+  gem.email         = 'support@flippercloud.io'
   gem.summary       = 'Rollout adapter for Flipper'
   gem.license       = 'MIT'
-  gem.homepage      = 'https://github.com/jnunemaker/flipper'
+  gem.homepage      = 'https://www.flippercloud.io'
 
   gem.files         = `git ls-files`.split("\n").select(&flipper_rollout_files) + ['lib/flipper/version.rb']
   gem.test_files    = `git ls-files -- {test,spec,features}/*`.split("\n").select(&flipper_rollout_files)

--- a/flipper-sequel.gemspec
+++ b/flipper-sequel.gemspec
@@ -6,10 +6,10 @@ flipper_sequel_files = ->(file) { file =~ /sequel/ }
 
 Gem::Specification.new do |gem|
   gem.authors       = ['John Nunemaker']
-  gem.email         = ['nunemaker@gmail.com']
+  gem.email         = 'support@flippercloud.io'
   gem.summary       = 'Sequel adapter for Flipper'
   gem.license       = 'MIT'
-  gem.homepage      = 'https://github.com/jnunemaker/flipper'
+  gem.homepage      = 'https://www.flippercloud.io'
 
   extra_files = [
     'lib/flipper/version.rb',

--- a/flipper-ui.gemspec
+++ b/flipper-ui.gemspec
@@ -8,10 +8,10 @@ end
 
 Gem::Specification.new do |gem|
   gem.authors       = ['John Nunemaker']
-  gem.email         = ['nunemaker@gmail.com']
+  gem.email         = 'support@flippercloud.io'
   gem.summary       = 'UI for the Flipper gem'
   gem.license       = 'MIT'
-  gem.homepage      = 'https://github.com/jnunemaker/flipper'
+  gem.homepage      = 'https://www.flippercloud.io'
 
   gem.files         = `git ls-files`.split("\n").select(&flipper_ui_files) + ['lib/flipper/version.rb']
   gem.test_files    = `git ls-files -- {test,spec,features}/*`.split("\n").select(&flipper_ui_files)

--- a/flipper.gemspec
+++ b/flipper.gemspec
@@ -22,9 +22,9 @@ ignored_test_files.flatten!.uniq!
 
 Gem::Specification.new do |gem|
   gem.authors       = ['John Nunemaker']
-  gem.email         = ['nunemaker@gmail.com']
+  gem.email         = 'support@flippercloud.io'
   gem.summary       = 'Feature flipper for ANYTHING'
-  gem.homepage      = 'https://github.com/jnunemaker/flipper'
+  gem.homepage      = 'https://www.flippercloud.io'
   gem.license       = 'MIT'
 
   gem.files         = `git ls-files`.split("\n") - ignored_files + ['lib/flipper/version.rb']

--- a/lib/flipper/cloud/engine.rb
+++ b/lib/flipper/cloud/engine.rb
@@ -10,16 +10,13 @@ module Flipper
       end
 
       initializer "flipper.cloud.default", before: :load_config_initializers do |app|
-        Flipper.configure do |config|
-          config.default do
-            if ENV["FLIPPER_CLOUD_TOKEN"]
+        if ENV["FLIPPER_CLOUD_TOKEN"]
+          Flipper.configure do |config|
+            config.default do
               Flipper::Cloud.new(
                 local_adapter: config.adapter,
                 instrumenter: app.config.flipper.instrumenter
               )
-            else
-              warn "Missing FLIPPER_CLOUD_TOKEN environment variable. Disabling Flipper::Cloud."
-              Flipper.new(config.adapter)
             end
           end
         end

--- a/lib/flipper/metadata.rb
+++ b/lib/flipper/metadata.rb
@@ -1,5 +1,9 @@
 module Flipper
   METADATA = {
-    'changelog_uri' => 'https://github.com/jnunemaker/flipper/blob/main/Changelog.md',
+    "documentation_uri" => "https://www.flippercloud.io/docs",
+    "homepage_uri"      => "https://www.flippercloud.io",
+    "source_code_uri"   => "https://github.com/jnunemaker/flipper",
+    "bug_tracker_uri"   => "https://github.com/jnunemaker/flipper/issues",
+    "changelog_uri"     => "https://github.com/jnunemaker/flipper/blob/main/Changelog.md",
   }.freeze
 end

--- a/spec/flipper/cloud/engine_spec.rb
+++ b/spec/flipper/cloud/engine_spec.rb
@@ -85,7 +85,6 @@ RSpec.describe Flipper::Cloud::Engine do
     it "gracefully skips configuring webhook app" do
       ENV["FLIPPER_CLOUD_TOKEN"] = nil
       application.initialize!
-      expect(silence { Flipper.instance }).to match(/Missing FLIPPER_CLOUD_TOKEN/)
       expect(Flipper.instance).to be_a(Flipper::DSL)
 
       post "/_flipper"


### PR DESCRIPTION
This packages up the recommended gems (`flipper`, `flipper-active_record`, and `flipper-cloud`) into one meta gem so people don't have to add multiple gems (and make decisions about each one) to their Gemfile. What better way to solve the "too many gems" problem than to introduce one more, right? 🤣

Each of these gems already configures itself with Rails, so nothing else should be needed to make it work. `flipper-cloud` is a noop if `FLIPPER_CLOUD_TOKEN` is not set.

Note: I'm hoping to acquire the deprecated [flipper-rails](https://rubygems.org/gems/flipper-rails) gem, but open to other name ideas.