### PR TITLE
Avoid any possibility of sync writing back to remote

### DIFF
--- a/lib/flipper/cloud/configuration.rb
+++ b/lib/flipper/cloud/configuration.rb
@@ -156,11 +156,8 @@ module Flipper
       private
 
       def app_adapter
-        sync_method == :webhook ? dual_write_adapter : poll_adapter
-      end
-
-      def dual_write_adapter
-        Flipper::Adapters::DualWrite.new(local_adapter, http_adapter)
+        read_adapter = sync_method == :webhook ? local_adapter : poll_adapter
+        Flipper::Adapters::DualWrite.new(read_adapter, http_adapter)
       end
 
       def poller
@@ -172,7 +169,7 @@ module Flipper
       end
 
       def poll_adapter
-        Flipper::Adapters::Poll.new(poller, dual_write_adapter)
+        Flipper::Adapters::Poll.new(poller, local_adapter)
       end
 
       def http_adapter

--- a/lib/flipper/cloud/configuration.rb
+++ b/lib/flipper/cloud/configuration.rb
@@ -126,7 +126,6 @@ module Flipper
       def sync
         Flipper::Adapters::Sync::Synchronizer.new(local_adapter, http_adapter, {
           instrumenter: instrumenter,
-          interval: sync_interval,
         }).call
       end
 

--- a/spec/flipper/cloud/configuration_spec.rb
+++ b/spec/flipper/cloud/configuration_spec.rb
@@ -86,7 +86,7 @@ RSpec.describe Flipper::Cloud::Configuration do
     stub_request(:get, /flippercloud\.io/).to_return(status: 200, body: "{}")
 
     instance = described_class.new(required_options)
-    expect(instance.adapter).to be_instance_of(Flipper::Adapters::Poll)
+    expect(instance.adapter).to be_instance_of(Flipper::Adapters::DualWrite)
   end
 
   it "can override adapter block" do

--- a/spec/flipper/cloud_spec.rb
+++ b/spec/flipper/cloud_spec.rb
@@ -25,11 +25,10 @@ RSpec.describe Flipper::Cloud do
     it 'configures the correct adapter' do
       # pardon the nesting...
       memoized_adapter = @instance.adapter
-      poll_adapter = memoized_adapter.adapter
-      dual_write_adapter = poll_adapter.adapter
-
-      expect(poll_adapter).to be_instance_of(Flipper::Adapters::Poll)
+      dual_write_adapter = memoized_adapter.adapter
       expect(dual_write_adapter).to be_instance_of(Flipper::Adapters::DualWrite)
+      poll_adapter = dual_write_adapter.local
+      expect(poll_adapter).to be_instance_of(Flipper::Adapters::Poll)
 
       http_adapter = dual_write_adapter.remote
       client = http_adapter.client
@@ -43,8 +42,12 @@ RSpec.describe Flipper::Cloud do
 
   context 'initialize with token and options' do
     it 'sets correct url' do
-      @instance = described_class.new(token: 'asdf', url: 'https://www.fakeflipper.com/sadpanda')
-      uri = @instance.adapter.adapter.adapter.remote.client.uri
+      instance = described_class.new(token: 'asdf', url: 'https://www.fakeflipper.com/sadpanda')
+      # pardon the nesting...
+      memoized = instance.adapter
+      dual_write = memoized.adapter
+      remote = dual_write.remote
+      uri = remote.client.uri
       expect(uri.scheme).to eq('https')
       expect(uri.host).to eq('www.fakeflipper.com')
       expect(uri.path).to eq('/sadpanda')


### PR DESCRIPTION
The goal is for sync to trust the remote and overwrite local with remote. 

The problem is that using dual write adapter for poll adapter in cloud means that a sync could write back to remote (cloud). If we use local adapter for poll then a sync can only affect local and never touch remote. 

Then we can use dual write with poll adapter as the read and cloud as the remote to ensure that local Flipper.enable calls (and similar) will still go to both local and write. 