### PR TITLE
UI: fix path to bundled assets when mapped to a prefix

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -2,6 +2,10 @@
 
 All notable changes to this project will be documented in this file.
 
+## 0.28.2
+
+* UI: fix path to bundled assets when mounted in another Rack app (https://github.com/jnunemaker/flipper/pull/742)
+
 ## 0.28.1
 
 ### Additions/Changes

--- a/examples/ui/prefixed.ru
+++ b/examples/ui/prefixed.ru
@@ -1,0 +1,21 @@
+#
+# Usage:
+#   bundle exec rackup examples/ui/prefixed.ru -p 9999
+#
+#   http://localhost:9999/
+#
+require 'bundler/setup'
+require 'rack/reloader'
+require "flipper/ui"
+require "flipper/adapters/pstore"
+
+use Rack::Reloader
+
+run Rack::URLMap.new(
+  "/" => lambda { |env|
+    [302, {"Location" => "/flipper"}, [] ]
+  },
+  "/flipper" => Flipper::UI.app { |builder|
+    builder.use Rack::Session::Cookie, secret: "_super_secret"
+  }
+)

--- a/lib/flipper/ui/views/layout.erb
+++ b/lib/flipper/ui/views/layout.erb
@@ -6,7 +6,7 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge">
     <meta name="viewport" content="width=device-width, initial-scale=1">
 
-    <link rel="stylesheet" href="<%= bootstrap_css[:src] %>" integrity="<%= bootstrap_css[:hash] %>" crossorigin="anonymous">
+    <link rel="stylesheet" href="<%= script_name + bootstrap_css[:src] %>" integrity="<%= bootstrap_css[:hash] %>" crossorigin="anonymous">
     <link rel="stylesheet" href="<%= script_name %>/css/application.css">
   </head>
   <body class="py-4">
@@ -57,9 +57,9 @@
       <% end %>
     </div>
 
-    <script src="<%= jquery_js[:src] %>" integrity="<%= jquery_js[:hash] %>" crossorigin="anonymous"></script>
-    <script src="<%= popper_js[:src] %>" integrity="<%= popper_js[:hash] %>" crossorigin="anonymous"></script>
-    <script src="<%= bootstrap_js[:src] %>" integrity="<%= bootstrap_js[:hash] %>" crossorigin="anonymous"></script>
+    <script src="<%= script_name + jquery_js[:src] %>" integrity="<%= jquery_js[:hash] %>" crossorigin="anonymous"></script>
+    <script src="<%= script_name + popper_js[:src] %>" integrity="<%= popper_js[:hash] %>" crossorigin="anonymous"></script>
+    <script src="<%= script_name + bootstrap_js[:src] %>" integrity="<%= bootstrap_js[:hash] %>" crossorigin="anonymous"></script>
     <script src="<%= script_name %>/js/application.js"></script>
   </body>
 </html>

--- a/lib/flipper/version.rb
+++ b/lib/flipper/version.rb
@@ -1,3 +1,3 @@
 module Flipper
-  VERSION = '0.28.1'.freeze
+  VERSION = '0.28.2'.freeze
 end


### PR DESCRIPTION
Fixes #741, which was introduced in #731. I also added `examples/ui/prefixed.ru`, which is a rack app we can use to test this in the future.