### PR TITLE
Update http.rb

### DIFF
--- a/lib/flipper/adapters/http.rb
+++ b/lib/flipper/adapters/http.rb
@@ -68,7 +68,7 @@ module Flipper
         end
 
         result = {}
-        gates_by_key.keys.each do |key|
+        gates_by_key.each_key do |key|
           feature = Feature.new(key, self)
           result[feature.key] = result_for_feature(feature, gates_by_key[feature.key])
         end


### PR DESCRIPTION
Replace keys.each with each_key for performance benefits. keys.each allocates an array for keys, while each_key iterates through the keys without the allocation.