### PR TITLE
Remove convenience methods on `Flipper` and `Flipper::DSL`

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -2,7 +2,9 @@
 
 All notable changes to this project will be documented in this file.
 
-## Unreleased changes
+## Unreleased
+
+### Additions/Changes
 
 * ui, api: Allow Rack 3 (https://github.com/jnunemaker/flipper/pull/670)
 * cloud: The `flipper-cloud` gem has been merged into the `flipper` and no longer needs to be added separately. Configure cloud by setting the `FLIPPER_CLOUD_TOKEN` environment variable. (https://github.com/jnunemaker/flipper/pull/743)
@@ -11,6 +13,17 @@ All notable changes to this project will be documented in this file.
       gem 'flipper'
     - gem 'flipper-cloud'
     ```
+
+### Breaking Changes
+
+* Removed `bool`, `actors`, `time`, `actor`, `percentage_of_actors`, and `percentage_of_time` methods on `Flipper` and `Flipper::DSL`. They are rarely if ever used and conflict with some upcoming features. If you are using them, you can migrate via a search and replace like so:
+  * Change `Flipper.bool` => `Flipper::Types::Boolean.new`
+  * Change `Flipper.boolean` => `Flipper::Types::Boolean.new`
+  * Change `Flipper.actor` => `Flipper::Types::Actor.new`
+  * Change `Flipper.percentage_of_actors` => `Flipper::Types::PercentageOfActors.new`
+  * Change `Flipper.actors` => `Flipper::Types::PercentageOfActors.new`
+  * Change `Flipper.percentage_of_time` => `Flipper::Types::PercentageOfTime.new`
+  * Change `Flipper.time` => `Flipper::Types::PercentageOfTime.new`
 
 ## 0.28.3
 

--- a/examples/dsl.rb
+++ b/examples/dsl.rb
@@ -47,20 +47,6 @@ puts "stats.enabled?: #{stats.enabled?}"
 puts "stats.enabled? person: #{stats.enabled? person}"
 puts
 
-# get an instance of the percentage of time type set to 5
-puts Flipper.time(5).inspect
-
-# get an instance of the percentage of actors type set to 15
-puts Flipper.actors(15).inspect
-
-# get an instance of an actor using an object that responds to flipper_id
-responds_to_flipper_id = Struct.new(:flipper_id).new(10)
-puts Flipper.actor(responds_to_flipper_id).inspect
-
-# get an instance of an actor using an object
-actor = Struct.new(:flipper_id).new(22)
-puts Flipper.actor(actor).inspect
-
 # register a top level group
 admins = Flipper.register(:admins) { |actor|
   actor.respond_to?(:admin?) && actor.admin?

--- a/lib/flipper.rb
+++ b/lib/flipper.rb
@@ -56,13 +56,11 @@ module Flipper
   # Public: All the methods delegated to instance. These should match the
   # interface of Flipper::DSL.
   def_delegators :instance,
-                 :enabled?, :enable, :disable, :bool, :boolean,
-                 :enable_actor, :disable_actor, :actor,
+                 :enabled?, :enable, :disable,
+                 :enable_actor, :disable_actor,
                  :enable_group, :disable_group,
                  :enable_percentage_of_actors, :disable_percentage_of_actors,
-                 :actors, :percentage_of_actors,
                  :enable_percentage_of_time, :disable_percentage_of_time,
-                 :time, :percentage_of_time,
                  :features, :feature, :[], :preload, :preload_all,
                  :adapter, :add, :exist?, :remove, :import, :export,
                  :memoize=, :memoizing?,

--- a/lib/flipper/dsl.rb
+++ b/lib/flipper/dsl.rb
@@ -210,22 +210,6 @@ module Flipper
     # Returns an instance of Flipper::Feature.
     alias_method :[], :feature
 
-    # Public: Shortcut for getting a boolean type instance.
-    #
-    # value - The true or false value for the boolean.
-    #
-    # Returns a Flipper::Types::Boolean instance.
-    def boolean(value = true)
-      Types::Boolean.new(value)
-    end
-
-    # Public: Even shorter shortcut for getting a boolean type instance.
-    #
-    # value - The true or false value for the boolean.
-    #
-    # Returns a Flipper::Types::Boolean instance.
-    alias_method :bool, :boolean
-
     # Public: Access a flipper group by name.
     #
     # name - The String or Symbol name of the feature.
@@ -234,36 +218,6 @@ module Flipper
     def group(name)
       Flipper.group(name)
     end
-
-    # Public: Wraps an object as a flipper actor.
-    #
-    # actor - The object that you would like to wrap.
-    #
-    # Returns an instance of Flipper::Types::Actor.
-    # Raises ArgumentError if actor does not respond to `flipper_id`.
-    def actor(actor)
-      Types::Actor.new(actor)
-    end
-
-    # Public: Shortcut for getting a percentage of time instance.
-    #
-    # number - The percentage of time that should be enabled.
-    #
-    # Returns Flipper::Types::PercentageOfTime.
-    def time(number)
-      Types::PercentageOfTime.new(number)
-    end
-    alias_method :percentage_of_time, :time
-
-    # Public: Shortcut for getting a percentage of actors instance.
-    #
-    # number - The percentage of actors that should be enabled.
-    #
-    # Returns Flipper::Types::PercentageOfActors.
-    def actors(number)
-      Types::PercentageOfActors.new(number)
-    end
-    alias_method :percentage_of_actors, :actors
 
     # Public: Returns a Set of the known features for this adapter.
     #

--- a/lib/flipper/spec/shared_adapter_specs.rb
+++ b/lib/flipper/spec/shared_adapter_specs.rb
@@ -46,12 +46,12 @@ RSpec.shared_examples_for 'a flipper adapter' do
   end
 
   it 'can enable, disable and get value for boolean gate' do
-    expect(subject.enable(feature, boolean_gate, flipper.boolean)).to eq(true)
+    expect(subject.enable(feature, boolean_gate, Flipper::Types::Boolean.new)).to eq(true)
 
     result = subject.get(feature)
     expect(result[:boolean]).to eq('true')
 
-    expect(subject.disable(feature, boolean_gate, flipper.boolean(false))).to eq(true)
+    expect(subject.disable(feature, boolean_gate, Flipper::Types::Boolean.new(false))).to eq(true)
 
     result = subject.get(feature)
     expect(result[:boolean]).to eq(nil)
@@ -59,13 +59,13 @@ RSpec.shared_examples_for 'a flipper adapter' do
 
   it 'fully disables all enabled things when boolean gate disabled' do
     actor22 = Flipper::Actor.new('22')
-    expect(subject.enable(feature, boolean_gate, flipper.boolean)).to eq(true)
+    expect(subject.enable(feature, boolean_gate, Flipper::Types::Boolean.new)).to eq(true)
     expect(subject.enable(feature, group_gate, flipper.group(:admins))).to eq(true)
-    expect(subject.enable(feature, actor_gate, flipper.actor(actor22))).to eq(true)
-    expect(subject.enable(feature, actors_gate, flipper.actors(25))).to eq(true)
-    expect(subject.enable(feature, time_gate, flipper.time(45))).to eq(true)
+    expect(subject.enable(feature, actor_gate, Flipper::Types::Actor.new(actor22))).to eq(true)
+    expect(subject.enable(feature, actors_gate, Flipper::Types::PercentageOfActors.new(25))).to eq(true)
+    expect(subject.enable(feature, time_gate, Flipper::Types::PercentageOfTime.new(45))).to eq(true)
 
-    expect(subject.disable(feature, boolean_gate, flipper.boolean(false))).to eq(true)
+    expect(subject.disable(feature, boolean_gate, Flipper::Types::Boolean.new(false))).to eq(true)
 
     expect(subject.get(feature)).to eq(subject.default_config)
   end
@@ -90,34 +90,34 @@ RSpec.shared_examples_for 'a flipper adapter' do
     actor22 = Flipper::Actor.new('22')
     actor_asdf = Flipper::Actor.new('asdf')
 
-    expect(subject.enable(feature, actor_gate, flipper.actor(actor22))).to eq(true)
-    expect(subject.enable(feature, actor_gate, flipper.actor(actor_asdf))).to eq(true)
+    expect(subject.enable(feature, actor_gate, Flipper::Types::Actor.new(actor22))).to eq(true)
+    expect(subject.enable(feature, actor_gate, Flipper::Types::Actor.new(actor_asdf))).to eq(true)
 
     result = subject.get(feature)
     expect(result[:actors]).to eq(Set['22', 'asdf'])
 
-    expect(subject.disable(feature, actor_gate, flipper.actor(actor22))).to eq(true)
+    expect(subject.disable(feature, actor_gate, Flipper::Types::Actor.new(actor22))).to eq(true)
     result = subject.get(feature)
     expect(result[:actors]).to eq(Set['asdf'])
 
-    expect(subject.disable(feature, actor_gate, flipper.actor(actor_asdf))).to eq(true)
+    expect(subject.disable(feature, actor_gate, Flipper::Types::Actor.new(actor_asdf))).to eq(true)
     result = subject.get(feature)
     expect(result[:actors]).to eq(Set.new)
   end
 
   it 'can enable, disable and get value for percentage of actors gate' do
-    expect(subject.enable(feature, actors_gate, flipper.actors(15))).to eq(true)
+    expect(subject.enable(feature, actors_gate, Flipper::Types::PercentageOfActors.new(15))).to eq(true)
     result = subject.get(feature)
     expect(result[:percentage_of_actors]).to eq('15')
 
-    expect(subject.disable(feature, actors_gate, flipper.actors(0))).to eq(true)
+    expect(subject.disable(feature, actors_gate, Flipper::Types::PercentageOfActors.new(0))).to eq(true)
     result = subject.get(feature)
     expect(result[:percentage_of_actors]).to eq('0')
   end
 
   it 'can enable percentage of actors gate many times and consistently return values' do
     (1..100).each do |percentage|
-      expect(subject.enable(feature, actors_gate, flipper.actors(percentage))).to eq(true)
+      expect(subject.enable(feature, actors_gate, Flipper::Types::PercentageOfActors.new(percentage))).to eq(true)
       result = subject.get(feature)
       expect(result[:percentage_of_actors]).to eq(percentage.to_s)
     end
@@ -125,25 +125,25 @@ RSpec.shared_examples_for 'a flipper adapter' do
 
   it 'can disable percentage of actors gate many times and consistently return values' do
     (1..100).each do |percentage|
-      expect(subject.disable(feature, actors_gate, flipper.actors(percentage))).to eq(true)
+      expect(subject.disable(feature, actors_gate, Flipper::Types::PercentageOfActors.new(percentage))).to eq(true)
       result = subject.get(feature)
       expect(result[:percentage_of_actors]).to eq(percentage.to_s)
     end
   end
 
   it 'can enable, disable and get value for percentage of time gate' do
-    expect(subject.enable(feature, time_gate, flipper.time(10))).to eq(true)
+    expect(subject.enable(feature, time_gate, Flipper::Types::PercentageOfTime.new(10))).to eq(true)
     result = subject.get(feature)
     expect(result[:percentage_of_time]).to eq('10')
 
-    expect(subject.disable(feature, time_gate, flipper.time(0))).to eq(true)
+    expect(subject.disable(feature, time_gate, Flipper::Types::PercentageOfTime.new(0))).to eq(true)
     result = subject.get(feature)
     expect(result[:percentage_of_time]).to eq('0')
   end
 
   it 'can enable percentage of time gate many times and consistently return values' do
     (1..100).each do |percentage|
-      expect(subject.enable(feature, time_gate, flipper.time(percentage))).to eq(true)
+      expect(subject.enable(feature, time_gate, Flipper::Types::PercentageOfTime.new(percentage))).to eq(true)
       result = subject.get(feature)
       expect(result[:percentage_of_time]).to eq(percentage.to_s)
     end
@@ -151,20 +151,20 @@ RSpec.shared_examples_for 'a flipper adapter' do
 
   it 'can disable percentage of time gate many times and consistently return values' do
     (1..100).each do |percentage|
-      expect(subject.disable(feature, time_gate, flipper.time(percentage))).to eq(true)
+      expect(subject.disable(feature, time_gate, Flipper::Types::PercentageOfTime.new(percentage))).to eq(true)
       result = subject.get(feature)
       expect(result[:percentage_of_time]).to eq(percentage.to_s)
     end
   end
 
   it 'converts boolean value to a string' do
-    expect(subject.enable(feature, boolean_gate, flipper.boolean)).to eq(true)
+    expect(subject.enable(feature, boolean_gate, Flipper::Types::Boolean.new)).to eq(true)
     result = subject.get(feature)
     expect(result[:boolean]).to eq('true')
   end
 
   it 'converts the actor value to a string' do
-    expect(subject.enable(feature, actor_gate, flipper.actor(Flipper::Actor.new(22)))).to eq(true)
+    expect(subject.enable(feature, actor_gate, Flipper::Types::Actor.new(Flipper::Actor.new(22)))).to eq(true)
     result = subject.get(feature)
     expect(result[:actors]).to eq(Set['22'])
   end
@@ -176,13 +176,13 @@ RSpec.shared_examples_for 'a flipper adapter' do
   end
 
   it 'converts percentage of time integer value to a string' do
-    expect(subject.enable(feature, time_gate, flipper.time(10))).to eq(true)
+    expect(subject.enable(feature, time_gate, Flipper::Types::PercentageOfTime.new(10))).to eq(true)
     result = subject.get(feature)
     expect(result[:percentage_of_time]).to eq('10')
   end
 
   it 'converts percentage of actors integer value to a string' do
-    expect(subject.enable(feature, actors_gate, flipper.actors(10))).to eq(true)
+    expect(subject.enable(feature, actors_gate, Flipper::Types::PercentageOfActors.new(10))).to eq(true)
     result = subject.get(feature)
     expect(result[:percentage_of_actors]).to eq('10')
   end
@@ -205,11 +205,11 @@ RSpec.shared_examples_for 'a flipper adapter' do
 
   it 'clears all the gate values for the feature on remove' do
     actor22 = Flipper::Actor.new('22')
-    expect(subject.enable(feature, boolean_gate, flipper.boolean)).to eq(true)
+    expect(subject.enable(feature, boolean_gate, Flipper::Types::Boolean.new)).to eq(true)
     expect(subject.enable(feature, group_gate, flipper.group(:admins))).to eq(true)
-    expect(subject.enable(feature, actor_gate, flipper.actor(actor22))).to eq(true)
-    expect(subject.enable(feature, actors_gate, flipper.actors(25))).to eq(true)
-    expect(subject.enable(feature, time_gate, flipper.time(45))).to eq(true)
+    expect(subject.enable(feature, actor_gate, Flipper::Types::Actor.new(actor22))).to eq(true)
+    expect(subject.enable(feature, actors_gate, Flipper::Types::PercentageOfActors.new(25))).to eq(true)
+    expect(subject.enable(feature, time_gate, Flipper::Types::PercentageOfTime.new(45))).to eq(true)
 
     expect(subject.remove(feature)).to eq(true)
 
@@ -221,11 +221,11 @@ RSpec.shared_examples_for 'a flipper adapter' do
     subject.add(feature)
     expect(subject.features).to include(feature.key)
 
-    expect(subject.enable(feature, boolean_gate, flipper.boolean)).to eq(true)
+    expect(subject.enable(feature, boolean_gate, Flipper::Types::Boolean.new)).to eq(true)
     expect(subject.enable(feature, group_gate, flipper.group(:admins))).to eq(true)
-    expect(subject.enable(feature, actor_gate, flipper.actor(actor22))).to eq(true)
-    expect(subject.enable(feature, actors_gate, flipper.actors(25))).to eq(true)
-    expect(subject.enable(feature, time_gate, flipper.time(45))).to eq(true)
+    expect(subject.enable(feature, actor_gate, Flipper::Types::Actor.new(actor22))).to eq(true)
+    expect(subject.enable(feature, actors_gate, Flipper::Types::PercentageOfActors.new(25))).to eq(true)
+    expect(subject.enable(feature, time_gate, Flipper::Types::PercentageOfTime.new(45))).to eq(true)
 
     expect(subject.clear(feature)).to eq(true)
     expect(subject.features).to include(feature.key)
@@ -238,7 +238,7 @@ RSpec.shared_examples_for 'a flipper adapter' do
 
   it 'can get multiple features' do
     expect(subject.add(flipper[:stats])).to eq(true)
-    expect(subject.enable(flipper[:stats], boolean_gate, flipper.boolean)).to eq(true)
+    expect(subject.enable(flipper[:stats], boolean_gate, Flipper::Types::Boolean.new)).to eq(true)
     expect(subject.add(flipper[:search])).to eq(true)
 
     result = subject.get_multi([flipper[:stats], flipper[:search], flipper[:other]])
@@ -254,7 +254,7 @@ RSpec.shared_examples_for 'a flipper adapter' do
 
   it 'can get all features' do
     expect(subject.add(flipper[:stats])).to eq(true)
-    expect(subject.enable(flipper[:stats], boolean_gate, flipper.boolean)).to eq(true)
+    expect(subject.enable(flipper[:stats], boolean_gate, Flipper::Types::Boolean.new)).to eq(true)
     expect(subject.add(flipper[:search])).to eq(true)
 
     result = subject.get_all
@@ -277,8 +277,8 @@ RSpec.shared_examples_for 'a flipper adapter' do
 
   it 'can double enable an actor without error' do
     actor = Flipper::Actor.new('Flipper::Actor;22')
-    expect(subject.enable(feature, actor_gate, flipper.actor(actor))).to eq(true)
-    expect(subject.enable(feature, actor_gate, flipper.actor(actor))).to eq(true)
+    expect(subject.enable(feature, actor_gate, Flipper::Types::Actor.new(actor))).to eq(true)
+    expect(subject.enable(feature, actor_gate, Flipper::Types::Actor.new(actor))).to eq(true)
     expect(subject.get(feature).fetch(:actors)).to eq(Set['Flipper::Actor;22'])
   end
 
@@ -289,13 +289,13 @@ RSpec.shared_examples_for 'a flipper adapter' do
   end
 
   it 'can double enable percentage without error' do
-    expect(subject.enable(feature, actors_gate, flipper.actors(25))).to eq(true)
-    expect(subject.enable(feature, actors_gate, flipper.actors(25))).to eq(true)
+    expect(subject.enable(feature, actors_gate, Flipper::Types::PercentageOfActors.new(25))).to eq(true)
+    expect(subject.enable(feature, actors_gate, Flipper::Types::PercentageOfActors.new(25))).to eq(true)
   end
 
   it 'can double enable without error' do
-    expect(subject.enable(feature, boolean_gate, flipper.boolean)).to eq(true)
-    expect(subject.enable(feature, boolean_gate, flipper.boolean)).to eq(true)
+    expect(subject.enable(feature, boolean_gate, Flipper::Types::Boolean.new)).to eq(true)
+    expect(subject.enable(feature, boolean_gate, Flipper::Types::Boolean.new)).to eq(true)
   end
 
   it 'can get_all features when there are none' do
@@ -305,11 +305,11 @@ RSpec.shared_examples_for 'a flipper adapter' do
 
   it 'clears other gate values on enable' do
     actor = Flipper::Actor.new('Flipper::Actor;22')
-    subject.enable(feature, actors_gate, flipper.actors(25))
-    subject.enable(feature, time_gate, flipper.time(25))
+    subject.enable(feature, actors_gate, Flipper::Types::PercentageOfActors.new(25))
+    subject.enable(feature, time_gate, Flipper::Types::PercentageOfTime.new(25))
     subject.enable(feature, group_gate, flipper.group(:admins))
-    subject.enable(feature, actor_gate, flipper.actor(actor))
-    subject.enable(feature, boolean_gate, flipper.boolean(true))
+    subject.enable(feature, actor_gate, Flipper::Types::Actor.new(actor))
+    subject.enable(feature, boolean_gate, Flipper::Types::Boolean.new(true))
     expect(subject.get(feature)).to eq(subject.default_config.merge(boolean: "true"))
   end
 

--- a/lib/flipper/test/shared_adapter_test.rb
+++ b/lib/flipper/test/shared_adapter_test.rb
@@ -48,20 +48,20 @@ module Flipper
       end
 
       def test_can_enable_disable_and_get_value_for_boolean_gate
-        assert_equal true, @adapter.enable(@feature, @boolean_gate, @flipper.boolean)
+        assert_equal true, @adapter.enable(@feature, @boolean_gate, Flipper::Types::Boolean.new)
         assert_equal 'true', @adapter.get(@feature)[:boolean]
-        assert_equal true, @adapter.disable(@feature, @boolean_gate, @flipper.boolean(false))
+        assert_equal true, @adapter.disable(@feature, @boolean_gate, Flipper::Types::Boolean.new(false))
         assert_nil @adapter.get(@feature)[:boolean]
       end
 
       def test_fully_disables_all_enabled_things_when_boolean_gate_disabled
         actor22 = Flipper::Actor.new('22')
-        assert_equal true, @adapter.enable(@feature, @boolean_gate, @flipper.boolean)
+        assert_equal true, @adapter.enable(@feature, @boolean_gate, Flipper::Types::Boolean.new)
         assert_equal true, @adapter.enable(@feature, @group_gate, @flipper.group(:admins))
-        assert_equal true, @adapter.enable(@feature, @actor_gate, @flipper.actor(actor22))
-        assert_equal true, @adapter.enable(@feature, @actors_gate, @flipper.actors(25))
-        assert_equal true, @adapter.enable(@feature, @time_gate, @flipper.time(45))
-        assert_equal true, @adapter.disable(@feature, @boolean_gate, @flipper.boolean(false))
+        assert_equal true, @adapter.enable(@feature, @actor_gate, Flipper::Types::Actor.new(actor22))
+        assert_equal true, @adapter.enable(@feature, @actors_gate, Flipper::Types::PercentageOfActors.new(25))
+        assert_equal true, @adapter.enable(@feature, @time_gate, Flipper::Types::PercentageOfTime.new(45))
+        assert_equal true, @adapter.disable(@feature, @boolean_gate, Flipper::Types::Boolean.new(false))
         assert_equal @adapter.default_config, @adapter.get(@feature)
       end
 
@@ -85,34 +85,34 @@ module Flipper
         actor22 = Flipper::Actor.new('22')
         actor_asdf = Flipper::Actor.new('asdf')
 
-        assert_equal true, @adapter.enable(@feature, @actor_gate, @flipper.actor(actor22))
-        assert_equal true, @adapter.enable(@feature, @actor_gate, @flipper.actor(actor_asdf))
+        assert_equal true, @adapter.enable(@feature, @actor_gate, Flipper::Types::Actor.new(actor22))
+        assert_equal true, @adapter.enable(@feature, @actor_gate, Flipper::Types::Actor.new(actor_asdf))
 
         result = @adapter.get(@feature)
         assert_equal Set['22', 'asdf'], result[:actors]
 
-        assert true, @adapter.disable(@feature, @actor_gate, @flipper.actor(actor22))
+        assert true, @adapter.disable(@feature, @actor_gate, Flipper::Types::Actor.new(actor22))
         result = @adapter.get(@feature)
         assert_equal Set['asdf'], result[:actors]
 
-        assert_equal true, @adapter.disable(@feature, @actor_gate, @flipper.actor(actor_asdf))
+        assert_equal true, @adapter.disable(@feature, @actor_gate, Flipper::Types::Actor.new(actor_asdf))
         result = @adapter.get(@feature)
         assert_equal Set.new, result[:actors]
       end
 
       def test_can_enable_disable_get_value_for_percentage_of_actors_gate
-        assert_equal true, @adapter.enable(@feature, @actors_gate, @flipper.actors(15))
+        assert_equal true, @adapter.enable(@feature, @actors_gate, Flipper::Types::PercentageOfActors.new(15))
         result = @adapter.get(@feature)
         assert_equal '15', result[:percentage_of_actors]
 
-        assert_equal true, @adapter.disable(@feature, @actors_gate, @flipper.actors(0))
+        assert_equal true, @adapter.disable(@feature, @actors_gate, Flipper::Types::PercentageOfActors.new(0))
         result = @adapter.get(@feature)
         assert_equal '0', result[:percentage_of_actors]
       end
 
       def test_can_enable_percentage_of_actors_gate_many_times_and_consistently_return_values
         (1..100).each do |percentage|
-          assert_equal true, @adapter.enable(@feature, @actors_gate, @flipper.actors(percentage))
+          assert_equal true, @adapter.enable(@feature, @actors_gate, Flipper::Types::PercentageOfActors.new(percentage))
           result = @adapter.get(@feature)
           assert_equal percentage.to_s, result[:percentage_of_actors]
         end
@@ -120,25 +120,25 @@ module Flipper
 
       def test_can_disable_percentage_of_actors_gate_many_times_and_consistently_return_values
         (1..100).each do |percentage|
-          assert_equal true, @adapter.disable(@feature, @actors_gate, @flipper.actors(percentage))
+          assert_equal true, @adapter.disable(@feature, @actors_gate, Flipper::Types::PercentageOfActors.new(percentage))
           result = @adapter.get(@feature)
           assert_equal percentage.to_s, result[:percentage_of_actors]
         end
       end
 
       def test_can_enable_disable_and_get_value_for_percentage_of_time_gate
-        assert_equal true, @adapter.enable(@feature, @time_gate, @flipper.time(10))
+        assert_equal true, @adapter.enable(@feature, @time_gate, Flipper::Types::PercentageOfTime.new(10))
         result = @adapter.get(@feature)
         assert_equal '10', result[:percentage_of_time]
 
-        assert_equal true, @adapter.disable(@feature, @time_gate, @flipper.time(0))
+        assert_equal true, @adapter.disable(@feature, @time_gate, Flipper::Types::PercentageOfTime.new(0))
         result = @adapter.get(@feature)
         assert_equal '0', result[:percentage_of_time]
       end
 
       def test_can_enable_percentage_of_time_gate_many_times_and_consistently_return_values
         (1..100).each do |percentage|
-          assert_equal true, @adapter.enable(@feature, @time_gate, @flipper.time(percentage))
+          assert_equal true, @adapter.enable(@feature, @time_gate, Flipper::Types::PercentageOfTime.new(percentage))
           result = @adapter.get(@feature)
           assert_equal percentage.to_s, result[:percentage_of_time]
         end
@@ -146,21 +146,21 @@ module Flipper
 
       def test_can_disable_percentage_of_time_gate_many_times_and_consistently_return_values
         (1..100).each do |percentage|
-          assert_equal true, @adapter.disable(@feature, @time_gate, @flipper.time(percentage))
+          assert_equal true, @adapter.disable(@feature, @time_gate, Flipper::Types::PercentageOfTime.new(percentage))
           result = @adapter.get(@feature)
           assert_equal percentage.to_s, result[:percentage_of_time]
         end
       end
 
       def test_converts_boolean_value_to_a_string
-        assert_equal true, @adapter.enable(@feature, @boolean_gate, @flipper.boolean)
+        assert_equal true, @adapter.enable(@feature, @boolean_gate, Flipper::Types::Boolean.new)
         result = @adapter.get(@feature)
         assert_equal 'true', result[:boolean]
       end
 
       def test_converts_the_actor_value_to_a_string
         assert_equal true,
-                     @adapter.enable(@feature, @actor_gate, @flipper.actor(Flipper::Actor.new(22)))
+                     @adapter.enable(@feature, @actor_gate, Flipper::Types::Actor.new(Flipper::Actor.new(22)))
         result = @adapter.get(@feature)
         assert_equal Set['22'], result[:actors]
       end
@@ -172,13 +172,13 @@ module Flipper
       end
 
       def test_converts_percentage_of_time_integer_value_to_a_string
-        assert_equal true, @adapter.enable(@feature, @time_gate, @flipper.time(10))
+        assert_equal true, @adapter.enable(@feature, @time_gate, Flipper::Types::PercentageOfTime.new(10))
         result = @adapter.get(@feature)
         assert_equal '10', result[:percentage_of_time]
       end
 
       def test_converts_percentage_of_actors_integer_value_to_a_string
-        assert_equal true, @adapter.enable(@feature, @actors_gate, @flipper.actors(10))
+        assert_equal true, @adapter.enable(@feature, @actors_gate, Flipper::Types::PercentageOfActors.new(10))
         result = @adapter.get(@feature)
         assert_equal '10', result[:percentage_of_actors]
       end
@@ -201,11 +201,11 @@ module Flipper
 
       def test_clears_all_the_gate_values_for_the_feature_on_remove
         actor22 = Flipper::Actor.new('22')
-        assert_equal true, @adapter.enable(@feature, @boolean_gate, @flipper.boolean)
+        assert_equal true, @adapter.enable(@feature, @boolean_gate, Flipper::Types::Boolean.new)
         assert_equal true, @adapter.enable(@feature, @group_gate, @flipper.group(:admins))
-        assert_equal true, @adapter.enable(@feature, @actor_gate, @flipper.actor(actor22))
-        assert_equal true, @adapter.enable(@feature, @actors_gate, @flipper.actors(25))
-        assert_equal true, @adapter.enable(@feature, @time_gate, @flipper.time(45))
+        assert_equal true, @adapter.enable(@feature, @actor_gate, Flipper::Types::Actor.new(actor22))
+        assert_equal true, @adapter.enable(@feature, @actors_gate, Flipper::Types::PercentageOfActors.new(25))
+        assert_equal true, @adapter.enable(@feature, @time_gate, Flipper::Types::PercentageOfTime.new(45))
 
         assert_equal true, @adapter.remove(@feature)
 
@@ -217,11 +217,11 @@ module Flipper
         @adapter.add(@feature)
         assert_includes @adapter.features, @feature.key
 
-        assert_equal true, @adapter.enable(@feature, @boolean_gate, @flipper.boolean)
+        assert_equal true, @adapter.enable(@feature, @boolean_gate, Flipper::Types::Boolean.new)
         assert_equal true, @adapter.enable(@feature, @group_gate, @flipper.group(:admins))
-        assert_equal true, @adapter.enable(@feature, @actor_gate, @flipper.actor(actor22))
-        assert_equal true, @adapter.enable(@feature, @actors_gate, @flipper.actors(25))
-        assert_equal true, @adapter.enable(@feature, @time_gate, @flipper.time(45))
+        assert_equal true, @adapter.enable(@feature, @actor_gate, Flipper::Types::Actor.new(actor22))
+        assert_equal true, @adapter.enable(@feature, @actors_gate, Flipper::Types::PercentageOfActors.new(25))
+        assert_equal true, @adapter.enable(@feature, @time_gate, Flipper::Types::PercentageOfTime.new(45))
 
         assert_equal true, @adapter.clear(@feature)
         assert_includes @adapter.features, @feature.key
@@ -234,7 +234,7 @@ module Flipper
 
       def test_can_get_multiple_features
         assert @adapter.add(@flipper[:stats])
-        assert @adapter.enable(@flipper[:stats], @boolean_gate, @flipper.boolean)
+        assert @adapter.enable(@flipper[:stats], @boolean_gate, Flipper::Types::Boolean.new)
         assert @adapter.add(@flipper[:search])
 
         result = @adapter.get_multi([@flipper[:stats], @flipper[:search], @flipper[:other]])
@@ -250,7 +250,7 @@ module Flipper
 
       def test_can_get_all_features
         assert @adapter.add(@flipper[:stats])
-        assert @adapter.enable(@flipper[:stats], @boolean_gate, @flipper.boolean)
+        assert @adapter.enable(@flipper[:stats], @boolean_gate, Flipper::Types::Boolean.new)
         assert @adapter.add(@flipper[:search])
 
         result = @adapter.get_all
@@ -273,8 +273,8 @@ module Flipper
 
       def test_can_double_enable_an_actor_without_error
         actor = Flipper::Actor.new('Flipper::Actor;22')
-        assert_equal true, @adapter.enable(@feature, @actor_gate, @flipper.actor(actor))
-        assert_equal true, @adapter.enable(@feature, @actor_gate, @flipper.actor(actor))
+        assert_equal true, @adapter.enable(@feature, @actor_gate, Flipper::Types::Actor.new(actor))
+        assert_equal true, @adapter.enable(@feature, @actor_gate, Flipper::Types::Actor.new(actor))
         assert_equal Set['Flipper::Actor;22'], @adapter.get(@feature).fetch(:actors)
       end
 
@@ -285,13 +285,13 @@ module Flipper
       end
 
       def test_can_double_enable_percentage_without_error
-        assert_equal true, @adapter.enable(@feature, @actors_gate, @flipper.actors(25))
-        assert_equal true, @adapter.enable(@feature, @actors_gate, @flipper.actors(25))
+        assert_equal true, @adapter.enable(@feature, @actors_gate, Flipper::Types::PercentageOfActors.new(25))
+        assert_equal true, @adapter.enable(@feature, @actors_gate, Flipper::Types::PercentageOfActors.new(25))
       end
 
       def test_can_double_enable_without_error
-        assert_equal true, @adapter.enable(@feature, @boolean_gate, @flipper.boolean)
-        assert_equal true, @adapter.enable(@feature, @boolean_gate, @flipper.boolean)
+        assert_equal true, @adapter.enable(@feature, @boolean_gate, Flipper::Types::Boolean.new)
+        assert_equal true, @adapter.enable(@feature, @boolean_gate, Flipper::Types::Boolean.new)
       end
 
       def test_can_get_all_features_when_there_are_none
@@ -302,11 +302,11 @@ module Flipper
 
       def test_clears_other_gate_values_on_enable
         actor = Flipper::Actor.new('Flipper::Actor;22')
-        assert_equal true, @adapter.enable(@feature, @actors_gate, @flipper.actors(25))
-        assert_equal true, @adapter.enable(@feature, @time_gate, @flipper.time(25))
+        assert_equal true, @adapter.enable(@feature, @actors_gate, Flipper::Types::PercentageOfActors.new(25))
+        assert_equal true, @adapter.enable(@feature, @time_gate, Flipper::Types::PercentageOfTime.new(25))
         assert_equal true, @adapter.enable(@feature, @group_gate, @flipper.group(:admins))
-        assert_equal true, @adapter.enable(@feature, @actor_gate, @flipper.actor(actor))
-        assert_equal true, @adapter.enable(@feature, @boolean_gate, @flipper.boolean(true))
+        assert_equal true, @adapter.enable(@feature, @actor_gate, Flipper::Types::Actor.new(actor))
+        assert_equal true, @adapter.enable(@feature, @boolean_gate, Flipper::Types::Boolean.new(true))
         assert_equal @adapter.default_config.merge(boolean: "true"), @adapter.get(@feature)
       end
 

--- a/spec/flipper/adapters/active_support_cache_store_spec.rb
+++ b/spec/flipper/adapters/active_support_cache_store_spec.rb
@@ -48,7 +48,7 @@ RSpec.describe Flipper::Adapters::ActiveSupportCacheStore do
     let(:feature) { flipper[:stats] }
 
     before do
-      adapter.enable(feature, feature.gate(:boolean), flipper.boolean)
+      adapter.enable(feature, feature.gate(:boolean), Flipper::Types::Boolean.new(true))
     end
 
     it 'enables feature and deletes the cache' do
@@ -72,7 +72,7 @@ RSpec.describe Flipper::Adapters::ActiveSupportCacheStore do
     let(:feature) { flipper[:stats] }
 
     before do
-      adapter.disable(feature, feature.gate(:boolean), flipper.boolean)
+      adapter.disable(feature, feature.gate(:boolean), Flipper::Types::Boolean.new)
     end
 
     it 'disables feature and deletes the cache' do

--- a/spec/flipper/adapters/dual_write_spec.rb
+++ b/spec/flipper/adapters/dual_write_spec.rb
@@ -55,14 +55,14 @@ RSpec.describe Flipper::Adapters::DualWrite do
 
   it 'updates remote and local for #enable' do
     feature = sync[:search]
-    subject.enable feature, feature.gate(:boolean), local.boolean
+    subject.enable feature, feature.gate(:boolean), Flipper::Types::Boolean.new(true)
     expect(remote_adapter.count(:enable)).to be(1)
     expect(local_adapter.count(:enable)).to be(1)
   end
 
   it 'updates remote and local for #disable' do
     feature = sync[:search]
-    subject.disable feature, feature.gate(:boolean), local.boolean(false)
+    subject.disable feature, feature.gate(:boolean), Flipper::Types::Boolean.new(false)
     expect(remote_adapter.count(:disable)).to be(1)
     expect(local_adapter.count(:disable)).to be(1)
   end

--- a/spec/flipper/adapters/instrumented_spec.rb
+++ b/spec/flipper/adapters/instrumented_spec.rb
@@ -8,7 +8,7 @@ RSpec.describe Flipper::Adapters::Instrumented do
 
   let(:feature) { flipper[:stats] }
   let(:gate) { feature.gate(:percentage_of_actors) }
-  let(:thing) { flipper.actors(22) }
+  let(:thing) { Flipper::Types::PercentageOfActors.new(22) }
 
   subject do
     described_class.new(adapter, instrumenter: instrumenter)

--- a/spec/flipper/adapters/memoizable_spec.rb
+++ b/spec/flipper/adapters/memoizable_spec.rb
@@ -189,7 +189,7 @@ RSpec.describe Flipper::Adapters::Memoizable do
         feature = flipper[:stats]
         gate = feature.gate(:boolean)
         cache[described_class.key_for(feature.key)] = { some: 'thing' }
-        subject.enable(feature, gate, flipper.bool)
+        subject.enable(feature, gate, Flipper::Types::Boolean.new)
         expect(cache[described_class.key_for(feature.key)]).to be_nil
       end
     end
@@ -202,8 +202,8 @@ RSpec.describe Flipper::Adapters::Memoizable do
       it 'returns result' do
         feature = flipper[:stats]
         gate = feature.gate(:boolean)
-        result = subject.enable(feature, gate, flipper.bool)
-        adapter_result = adapter.enable(feature, gate, flipper.bool)
+        result = subject.enable(feature, gate, Flipper::Types::Boolean.new)
+        adapter_result = adapter.enable(feature, gate, Flipper::Types::Boolean.new)
         expect(result).to eq(adapter_result)
       end
     end
@@ -219,7 +219,7 @@ RSpec.describe Flipper::Adapters::Memoizable do
         feature = flipper[:stats]
         gate = feature.gate(:boolean)
         cache[described_class.key_for(feature.key)] = { some: 'thing' }
-        subject.disable(feature, gate, flipper.bool)
+        subject.disable(feature, gate, Flipper::Types::Boolean.new)
         expect(cache[described_class.key_for(feature.key)]).to be_nil
       end
     end
@@ -232,8 +232,8 @@ RSpec.describe Flipper::Adapters::Memoizable do
       it 'returns result' do
         feature = flipper[:stats]
         gate = feature.gate(:boolean)
-        result = subject.disable(feature, gate, flipper.bool)
-        adapter_result = adapter.disable(feature, gate, flipper.bool)
+        result = subject.disable(feature, gate, Flipper::Types::Boolean.new)
+        adapter_result = adapter.disable(feature, gate, Flipper::Types::Boolean.new)
         expect(result).to eq(adapter_result)
       end
     end

--- a/spec/flipper/adapters/operation_logger_spec.rb
+++ b/spec/flipper/adapters/operation_logger_spec.rb
@@ -37,7 +37,7 @@ RSpec.describe Flipper::Adapters::OperationLogger do
     before do
       @feature = flipper[:stats]
       @gate = @feature.gate(:boolean)
-      @thing = flipper.bool
+      @thing = Flipper::Types::Boolean.new
       @result = subject.enable(@feature, @gate, @thing)
     end
 
@@ -54,7 +54,7 @@ RSpec.describe Flipper::Adapters::OperationLogger do
     before do
       @feature = flipper[:stats]
       @gate = @feature.gate(:boolean)
-      @thing = flipper.bool
+      @thing = Flipper::Types::Boolean.new
       @result = subject.disable(@feature, @gate, @thing)
     end
 

--- a/spec/flipper/adapters/read_only_spec.rb
+++ b/spec/flipper/adapters/read_only_spec.rb
@@ -42,11 +42,11 @@ RSpec.describe Flipper::Adapters::ReadOnly do
 
   it 'can get feature' do
     actor22 = Flipper::Actor.new('22')
-    adapter.enable(feature, boolean_gate, flipper.boolean)
+    adapter.enable(feature, boolean_gate, Flipper::Types::Boolean.new)
     adapter.enable(feature, group_gate, flipper.group(:admins))
-    adapter.enable(feature, actor_gate, flipper.actor(actor22))
-    adapter.enable(feature, actors_gate, flipper.actors(25))
-    adapter.enable(feature, time_gate, flipper.time(45))
+    adapter.enable(feature, actor_gate, Flipper::Types::Actor.new(actor22))
+    adapter.enable(feature, actors_gate, Flipper::Types::PercentageOfActors.new(25))
+    adapter.enable(feature, time_gate, Flipper::Types::PercentageOfTime.new(45))
 
     expect(subject.get(feature)).to eq(boolean: 'true',
                                        groups: Set['admins'],
@@ -74,12 +74,12 @@ RSpec.describe Flipper::Adapters::ReadOnly do
   end
 
   it 'raises error on enable' do
-    expect { subject.enable(feature, boolean_gate, flipper.boolean) }
+    expect { subject.enable(feature, boolean_gate, Flipper::Types::Boolean.new) }
       .to raise_error(Flipper::Adapters::ReadOnly::WriteAttempted)
   end
 
   it 'raises error on disable' do
-    expect { subject.disable(feature, boolean_gate, flipper.boolean) }
+    expect { subject.disable(feature, boolean_gate, Flipper::Types::Boolean.new) }
       .to raise_error(Flipper::Adapters::ReadOnly::WriteAttempted)
   end
 end

--- a/spec/flipper/api/v1/actions/clear_feature_spec.rb
+++ b/spec/flipper/api/v1/actions/clear_feature_spec.rb
@@ -7,11 +7,11 @@ RSpec.describe Flipper::Api::V1::Actions::ClearFeature do
       actor22 = Flipper::Actor.new('22')
 
       feature = flipper[:my_feature]
-      feature.enable flipper.boolean
+      feature.enable Flipper::Types::Boolean.new
       feature.enable flipper.group(:admins)
-      feature.enable flipper.actor(actor22)
-      feature.enable flipper.actors(25)
-      feature.enable flipper.time(45)
+      feature.enable Flipper::Types::Actor.new(actor22)
+      feature.enable Flipper::Types::PercentageOfActors.new(25)
+      feature.enable Flipper::Types::PercentageOfTime.new(45)
 
       delete '/features/my_feature/clear'
     end
@@ -28,11 +28,11 @@ RSpec.describe Flipper::Api::V1::Actions::ClearFeature do
       actor22 = Flipper::Actor.new('22')
 
       feature = flipper["my/feature"]
-      feature.enable flipper.boolean
+      feature.enable Flipper::Types::Boolean.new
       feature.enable flipper.group(:admins)
-      feature.enable flipper.actor(actor22)
-      feature.enable flipper.actors(25)
-      feature.enable flipper.time(45)
+      feature.enable Flipper::Types::Actor.new(actor22)
+      feature.enable Flipper::Types::PercentageOfActors.new(25)
+      feature.enable Flipper::Types::PercentageOfTime.new(45)
 
       delete '/features/my/feature/clear'
     end

--- a/spec/flipper/dsl_spec.rb
+++ b/spec/flipper/dsl_spec.rb
@@ -123,18 +123,6 @@ RSpec.describe Flipper::DSL do
     end
   end
 
-  describe '#boolean' do
-    it_should_behave_like 'a DSL boolean method' do
-      let(:method_name) { :boolean }
-    end
-  end
-
-  describe '#bool' do
-    it_should_behave_like 'a DSL boolean method' do
-      let(:method_name) { :bool }
-    end
-  end
-
   describe '#group' do
     context 'for registered group' do
       before do
@@ -145,69 +133,6 @@ RSpec.describe Flipper::DSL do
         expect(Flipper).to receive(:group).with(:admins).and_return(@group)
         expect(subject.group(:admins)).to be(@group)
       end
-    end
-  end
-
-  describe '#actor' do
-    context 'for an actor' do
-      it 'returns actor instance' do
-        actor = Flipper::Actor.new(33)
-        flipper_actor = subject.actor(actor)
-        expect(flipper_actor).to be_instance_of(Flipper::Types::Actor)
-        expect(flipper_actor.value).to eq('33')
-      end
-    end
-
-    context 'for nil' do
-      it 'raises argument error' do
-        expect do
-          subject.actor(nil)
-        end.to raise_error(ArgumentError)
-      end
-    end
-
-    context 'for something that is not actor wrappable' do
-      it 'raises argument error' do
-        expect do
-          subject.actor(Object.new)
-        end.to raise_error(ArgumentError)
-      end
-    end
-  end
-
-  describe '#time' do
-    before do
-      @result = subject.time(5)
-    end
-
-    it 'returns percentage of time' do
-      expect(@result).to be_instance_of(Flipper::Types::PercentageOfTime)
-    end
-
-    it 'sets value' do
-      expect(@result.value).to eq(5)
-    end
-
-    it 'is aliased to percentage_of_time' do
-      expect(@result).to eq(subject.percentage_of_time(@result.value))
-    end
-  end
-
-  describe '#actors' do
-    before do
-      @result = subject.actors(17)
-    end
-
-    it 'returns percentage of actors' do
-      expect(@result).to be_instance_of(Flipper::Types::PercentageOfActors)
-    end
-
-    it 'sets value' do
-      expect(@result.value).to eq(17)
-    end
-
-    it 'is aliased to percentage_of_actors' do
-      expect(@result).to eq(subject.percentage_of_actors(@result.value))
     end
   end
 

--- a/spec/flipper_integration_spec.rb
+++ b/spec/flipper_integration_spec.rb
@@ -24,8 +24,8 @@ RSpec.describe Flipper do
   let(:pitt)        { Flipper::Actor.new(1) }
   let(:clooney)     { Flipper::Actor.new(10) }
 
-  let(:five_percent_of_actors) { flipper.actors(5) }
-  let(:five_percent_of_time) { flipper.time(5) }
+  let(:five_percent_of_actors) { Flipper::Types::PercentageOfActors.new(5) }
+  let(:five_percent_of_time) { Flipper::Types::PercentageOfTime.new(5) }
 
   before do
     described_class.register(:admins, &:admin?)
@@ -69,11 +69,11 @@ RSpec.describe Flipper do
       end
 
       it 'enables feature for flipper actor in group' do
-        expect(feature.enabled?(flipper.actor(admin_actor))).to eq(true)
+        expect(feature.enabled?(Flipper::Types::Actor.new(admin_actor))).to eq(true)
       end
 
       it 'does not enable for flipper actor not in group' do
-        expect(feature.enabled?(flipper.actor(dev_actor))).to eq(false)
+        expect(feature.enabled?(Flipper::Types::Actor.new(dev_actor))).to eq(false)
       end
 
       it 'does not enable feature for all' do
@@ -256,11 +256,11 @@ RSpec.describe Flipper do
       end
 
       it 'disables feature for flipper actor in group' do
-        expect(feature.enabled?(flipper.actor(admin_actor))).to eq(false)
+        expect(feature.enabled?(Flipper::Types::Actor.new(admin_actor))).to eq(false)
       end
 
       it 'does not disable feature for flipper actor in other groups' do
-        expect(feature.enabled?(flipper.actor(dev_actor))).to eq(true)
+        expect(feature.enabled?(Flipper::Types::Actor.new(dev_actor))).to eq(true)
       end
 
       it 'adds feature to set of features' do
@@ -294,7 +294,7 @@ RSpec.describe Flipper do
 
     context 'with a percentage of actors' do
       before do
-        @result = feature.disable(flipper.actors(0))
+        @result = feature.disable(Flipper::Types::PercentageOfActors.new(0))
       end
 
       it 'returns true' do
@@ -318,7 +318,7 @@ RSpec.describe Flipper do
     context 'with a percentage of time' do
       before do
         @gate = feature.gate(:percentage_of_time)
-        @result = feature.disable(flipper.time(0))
+        @result = feature.disable(Flipper::Types::PercentageOfTime.new(0))
       end
 
       it 'returns true' do
@@ -373,12 +373,12 @@ RSpec.describe Flipper do
       end
 
       it 'returns true' do
-        expect(feature.enabled?(flipper.actor(admin_actor))).to eq(true)
+        expect(feature.enabled?(Flipper::Types::Actor.new(admin_actor))).to eq(true)
         expect(feature.enabled?(admin_actor)).to eq(true)
       end
 
       it 'returns true for truthy block values' do
-        expect(feature.enabled?(flipper.actor(admin_truthy_actor))).to eq(true)
+        expect(feature.enabled?(Flipper::Types::Actor.new(admin_truthy_actor))).to eq(true)
       end
 
       it 'returns true if any actor is in enabled group' do
@@ -388,12 +388,12 @@ RSpec.describe Flipper do
 
     context 'for actor in disabled group' do
       it 'returns false' do
-        expect(feature.enabled?(flipper.actor(dev_actor))).to eq(false)
+        expect(feature.enabled?(Flipper::Types::Actor.new(dev_actor))).to eq(false)
         expect(feature.enabled?(dev_actor)).to eq(false)
       end
 
       it 'returns false for falsey block values' do
-        expect(feature.enabled?(flipper.actor(admin_falsey_actor))).to eq(false)
+        expect(feature.enabled?(Flipper::Types::Actor.new(admin_falsey_actor))).to eq(false)
       end
     end
 

--- a/spec/flipper_spec.rb
+++ b/spec/flipper_spec.rb
@@ -88,14 +88,6 @@ RSpec.describe Flipper do
       expect(described_class.instance.enabled?(:search)).to be(false)
     end
 
-    it 'delegates bool to instance' do
-      expect(described_class.bool).to eq(described_class.instance.bool)
-    end
-
-    it 'delegates boolean to instance' do
-      expect(described_class.boolean).to eq(described_class.instance.boolean)
-    end
-
     it 'delegates enable_actor to instance' do
       described_class.enable_actor(:search, actor)
       expect(described_class.instance.enabled?(:search, actor)).to be(true)
@@ -104,10 +96,6 @@ RSpec.describe Flipper do
     it 'delegates disable_actor to instance' do
       described_class.disable_actor(:search, actor)
       expect(described_class.instance.enabled?(:search, actor)).to be(false)
-    end
-
-    it 'delegates actor to instance' do
-      expect(described_class.actor(actor)).to eq(described_class.instance.actor(actor))
     end
 
     it 'delegates enable_group to instance' do
@@ -130,15 +118,6 @@ RSpec.describe Flipper do
       expect(described_class.instance[:search].percentage_of_actors_value).to be(0)
     end
 
-    it 'delegates actors to instance' do
-      expect(described_class.actors(5)).to eq(described_class.instance.actors(5))
-    end
-
-    it 'delegates percentage_of_actors to instance' do
-      expected = described_class.instance.percentage_of_actors(5)
-      expect(described_class.percentage_of_actors(5)).to eq(expected)
-    end
-
     it 'delegates enable_percentage_of_time to instance' do
       described_class.enable_percentage_of_time(:search, 5)
       expect(described_class.instance[:search].percentage_of_time_value).to be(5)
@@ -147,15 +126,6 @@ RSpec.describe Flipper do
     it 'delegates disable_percentage_of_time to instance' do
       described_class.disable_percentage_of_time(:search)
       expect(described_class.instance[:search].percentage_of_time_value).to be(0)
-    end
-
-    it 'delegates time to instance' do
-      expect(described_class.time(56)).to eq(described_class.instance.time(56))
-    end
-
-    it 'delegates percentage_of_time to instance' do
-      expected = described_class.instance.percentage_of_time(56)
-      expect(described_class.percentage_of_time(56)).to eq(expected)
     end
 
     it 'delegates features to instance' do

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -91,15 +91,3 @@ RSpec.shared_examples_for 'a DSL feature' do
     end.to raise_error(ArgumentError, /must be a String or Symbol/)
   end
 end
-
-RSpec.shared_examples_for 'a DSL boolean method' do
-  it 'returns boolean with value set' do
-    result = subject.send(method_name, true)
-    expect(result).to be_instance_of(Flipper::Types::Boolean)
-    expect(result.value).to be(true)
-
-    result = subject.send(method_name, false)
-    expect(result).to be_instance_of(Flipper::Types::Boolean)
-    expect(result.value).to be(false)
-  end
-end


### PR DESCRIPTION
Backported from #692 to the v1.0 branch