### PR TITLE
statsd cleanup

### DIFF
--- a/lib/flipper/instrumentation/statsd_subscriber.rb
+++ b/lib/flipper/instrumentation/statsd_subscriber.rb
@@ -12,13 +12,11 @@ module Flipper
       end
 
       def update_timer(metric)
-        if self.class.client
-          self.class.client.timing metric, (@duration * 1_000).round
-        end
+        self.class.client&.timing metric, (@duration * 1_000).round
       end
 
       def update_counter(metric)
-        self.class.client.increment metric if self.class.client
+        self.class.client&.increment metric
       end
     end
   end

--- a/spec/flipper/instrumentation/statsd_subscriber_spec.rb
+++ b/spec/flipper/instrumentation/statsd_subscriber_spec.rb
@@ -78,4 +78,19 @@ RSpec.describe Flipper::Instrumentation::StatsdSubscriber do
     flipper[:stats].disable(user)
     assert_timer 'flipper.adapter.memory.disable'
   end
+
+  context 'when client is nil' do
+    before do
+      described_class.client = nil
+    end
+
+    it 'does not raise error' do
+      expect { flipper[:stats].enable(user) }.not_to raise_error
+    end
+
+    it 'does not update metrics' do
+      flipper[:stats].enable(user)
+      expect(socket.buffer).to be_empty
+    end
+  end
 end


### PR DESCRIPTION
I was poking around and discovered the statsd subscriber.  In addition to being excited to test it out in prod, I noticed a couple small improvements we might make to simplify - using the `&.` operator to guard against nil objects, and adding test coverage...  what'd you think?