### PR TITLE
create an include expression

### DIFF
--- a/lib/flipper/expression/builder.rb
+++ b/lib/flipper/expression/builder.rb
@@ -57,10 +57,6 @@ module Flipper
         build({ Include: [self, object] })
       end
 
-      def in(object)
-        build({ In: [self, object] })
-      end
-
       def percentage_of_actors(object)
         build({ PercentageOfActors: [self, build(object)] })
       end

--- a/lib/flipper/expression/builder.rb
+++ b/lib/flipper/expression/builder.rb
@@ -53,6 +53,14 @@ module Flipper
       alias lte less_than_or_equal_to
       alias less_than_or_equal less_than_or_equal_to
 
+      def include(object)
+        build({ Include: [self, object] })
+      end
+
+      def in(object)
+        build({ In: [self, object] })
+      end
+
       def percentage_of_actors(object)
         build({ PercentageOfActors: [self, build(object)] })
       end

--- a/lib/flipper/expressions/include.rb
+++ b/lib/flipper/expressions/include.rb
@@ -1,0 +1,9 @@
+module Flipper
+  module Expressions
+    class Include
+      def self.call(left, right)
+        left.respond_to?(:include?) && left.include?(right)
+      end
+    end
+  end
+end

--- a/spec/flipper/expression_spec.rb
+++ b/spec/flipper/expression_spec.rb
@@ -79,6 +79,19 @@ RSpec.describe Flipper::Expression do
       ])
     end
 
+    it "can build Include" do
+      expression = described_class.build({
+        "Inlcude" => [["hello"], "hello"]
+      })
+
+      expect(expression).to be_instance_of(Flipper::Expression)
+      expect(expression.function).to be(Flipper::Expressions::Include)
+      expect(expression.args).to eq([
+        Flipper.constant(["hello"]),
+        Flipper.constant("hello"),
+      ])
+    end
+
     it "can build NotEqual" do
       expression = described_class.build({
         "NotEqual" => [

--- a/spec/flipper/expressions/include_spec.rb
+++ b/spec/flipper/expressions/include_spec.rb
@@ -1,0 +1,23 @@
+RSpec.describe Flipper::Expressions::Include do
+  describe "#call" do
+    it "returns true when left includes right" do
+      expect(described_class.call([2], 2)).to be(true)
+    end
+
+    it "returns false when left does not include right" do
+      expect(described_class.call([2], "2")).to be(false)
+    end
+
+    it "returns false when left does not respond to #include?" do
+      expect(described_class.call(nil, nil)).to be(false)
+    end
+
+    it "raises ArgumentError with no arguments" do
+      expect { described_class.call }.to raise_error(ArgumentError)
+    end
+
+    it "raises ArgumentError with one argument" do
+      expect { described_class.call(10) }.to raise_error(ArgumentError)
+    end
+  end
+end


### PR DESCRIPTION
Hey Team!

At Zipline, we had extended functionality of expressions to have `include`, `intersect` and `in`. I'm not sure how useful it would be to have the others for Flipper main but `include` seems to be a pretty good candidate. Let me know if this (and the others) would be useful to be merged here.