### PR TITLE
fix sync behavior when remote expression value is set to nil

### DIFF
--- a/lib/flipper/adapters/sync/feature_synchronizer.rb
+++ b/lib/flipper/adapters/sync/feature_synchronizer.rb
@@ -53,7 +53,7 @@ module Flipper
         private
 
         def sync_expression
-          return if local_expression == remote_expression
+          return if remote_expression.nil? || local_expression == remote_expression
 
           @feature.enable_expression remote_expression
         end

--- a/spec/flipper/adapters/sync/feature_synchronizer_spec.rb
+++ b/spec/flipper/adapters/sync/feature_synchronizer_spec.rb
@@ -105,6 +105,17 @@ RSpec.describe Flipper::Adapters::Sync::FeatureSynchronizer do
       expect_no_enable_or_disable
     end
 
+    it "updates expression when remote is updated to nil" do
+      remote = Flipper::GateValues.new(expression: nil)
+      feature.enable_expression(plan_expression)
+      adapter.reset
+
+      described_class.new(feature, feature.gate_values, remote).call
+
+      expect(feature.expression_value).to eq(nil)
+      expect_only_disable
+    end
+
     it "adds remotely added actors" do
       remote = Flipper::GateValues.new(actors: Set["1", "2"])
       feature.enable_actor(Flipper::Actor.new("1"))


### PR DESCRIPTION
### Problem
When a cached/local feature has a non nil expression value and we attempt to sync with the remote, which has a nil expression value, the sync fails with the following error:

```
ArgumentError: nil cannot be converted into an expression (ArgumentError)
from /Users/jdonovan/src/flipper/lib/flipper/expression.rb:27:in 'Flipper::Expression.build'
```

This is because we are attempting to build an expression for the remote value (which is nil), to update our local value.

### Solution
Instead of building an expression, we should just let the local expression be updated to nil.