### PR TITLE
Cache `get_all` separate like features

### DIFF
--- a/lib/flipper/adapters/active_support_cache_store.rb
+++ b/lib/flipper/adapters/active_support_cache_store.rb
@@ -41,6 +41,7 @@ module Flipper
         if @write_through
           result = @adapter.enable(feature, gate, thing)
           cache_write feature_cache_key(feature.key), @adapter.get(feature)
+          expire_get_all_cache
           result
         else
           super
@@ -51,6 +52,7 @@ module Flipper
         if @write_through
           result = @adapter.disable(feature, gate, thing)
           cache_write feature_cache_key(feature.key), @adapter.get(feature)
+          expire_get_all_cache
           result
         else
           super

--- a/spec/flipper/middleware/memoizer_spec.rb
+++ b/spec/flipper/middleware/memoizer_spec.rb
@@ -470,18 +470,15 @@ RSpec.describe Flipper::Middleware::Memoizer do
 
       get '/', {}, 'flipper' => flipper
       expect(logged_cached.count(:get_all)).to be(1)
-      expect(logged_memory.count(:features)).to be(1)
-      expect(logged_memory.count(:get_multi)).to be(1)
+      expect(logged_memory.count(:get_all)).to be(1)
 
       get '/', {}, 'flipper' => flipper
       expect(logged_cached.count(:get_all)).to be(2)
-      expect(logged_memory.count(:features)).to be(1)
-      expect(logged_memory.count(:get_multi)).to be(1)
+      expect(logged_memory.count(:get_all)).to be(1)
 
       get '/', {}, 'flipper' => flipper
       expect(logged_cached.count(:get_all)).to be(3)
-      expect(logged_memory.count(:features)).to be(1)
-      expect(logged_memory.count(:get_multi)).to be(1)
+      expect(logged_memory.count(:get_all)).to be(1)
     end
   end
 end


### PR DESCRIPTION
If you have hundreds or thousands of features as some do on flipper cloud, this warming of the cache doesn't work. More simple to fully cache the whole get_all response than to get multi and warm missing. 

I'd love to use write_multi but that only truly reduces network calls for redis cache store since the others don't support pipelining or bulk writing.