### PR TITLE
Allow links in descriptions

### DIFF
--- a/lib/flipper/ui/action.rb
+++ b/lib/flipper/ui/action.rb
@@ -7,6 +7,14 @@ require 'sanitize'
 
 module Flipper
   module UI
+    # Sanitize config for descriptions in list view. Removes anchor tags to
+    # avoid nested links (the feature row is wrapped in an <a> tag).
+    # See: https://github.com/flippercloud/flipper/issues/939
+    SANITIZE_LIST = Sanitize::Config.merge(
+      Sanitize::Config::BASIC,
+      elements: Sanitize::Config::BASIC[:elements] - ['a']
+    )
+
     class Action
       module FeatureNameFromRoute
         def feature_name

--- a/lib/flipper/ui/views/features.erb
+++ b/lib/flipper/ui/views/features.erb
@@ -45,7 +45,7 @@
             <div class="text-truncate" style="font-weight: 500"><%= feature.key %></div>
             <% if Flipper::UI.configuration.show_feature_description_in_list? && Flipper::UI::Util.present?(feature.description) %>
               <div class="text-muted fw-light" style="line-height: 1.4; white-space: initial; padding: 8px 0">
-                <%== Sanitize.fragment(feature.description, Sanitize::Config::BASIC) %>
+                <%== Sanitize.fragment(feature.description, Flipper::UI::SANITIZE_LIST) %>
               </div>
             <% end %>
             <div class="text-muted text-truncate">

--- a/spec/flipper/ui/actions/features_spec.rb
+++ b/spec/flipper/ui/actions/features_spec.rb
@@ -88,6 +88,25 @@ RSpec.describe Flipper::UI::Actions::Features do
         expect(last_response.body).not_to include('<a class="btn btn-primary btn-sm" href="/features/new">Add Feature</a>')
       end
     end
+
+    context 'when descriptions have links' do
+      before do
+        Flipper::UI.configuration.show_feature_description_in_list = true
+        Flipper::UI.configuration.descriptions_source = lambda { |_keys|
+          { 'test_feature' => 'Check <a href="https://example.com">this link</a> for more info' }
+        }
+
+        flipper[:test_feature].enable
+      end
+
+      it 'strips anchor tags from descriptions to avoid nested links' do
+        get '/features'
+
+        expect(last_response.status).to eq(200)
+        expect(last_response.body).to include('Check this link for more info')
+        expect(last_response.body).not_to include('<a href="https://example.com">this link</a>')
+      end
+    end
   end
 
   describe 'POST /features' do


### PR DESCRIPTION
Updated sanitization in feature descriptions in list view to also remove anchor tags, preventing nested links.

fixes #939