### PR TITLE
Add adapter_stack method for debugging adapter chains

### DIFF
--- a/lib/flipper.rb
+++ b/lib/flipper.rb
@@ -64,7 +64,7 @@ module Flipper
                  :enable_percentage_of_actors, :disable_percentage_of_actors,
                  :enable_percentage_of_time, :disable_percentage_of_time,
                  :features, :feature, :[], :preload, :preload_all,
-                 :adapter, :add, :exist?, :remove, :import, :export,
+                 :adapter, :adapter_stack, :add, :exist?, :remove, :import, :export,
                  :memoize=, :memoizing?, :read_only?,
                  :sync, :sync_secret # For Flipper::Cloud. Will error for OSS Flipper.
 

--- a/lib/flipper/adapter.rb
+++ b/lib/flipper/adapter.rb
@@ -73,6 +73,22 @@ module Flipper
     def name
       @name ||= self.class.name.split('::').last.split(/(?=[A-Z])/).join('_').downcase.to_sym
     end
+
+    # Public: Returns a string representation of the adapter stack for debugging.
+    # Shows the full chain of wrapped adapters.
+    #
+    # Examples:
+    #   "memoizable -> active_support_cache_store -> active_record"
+    #   "memoizable -> failover(primary: redis, secondary: memory)"
+    #
+    # Returns a String.
+    def adapter_stack
+      if respond_to?(:adapter) && adapter
+        "#{name} -> #{adapter.adapter_stack}"
+      else
+        name.to_s
+      end
+    end
   end
 end
 

--- a/lib/flipper/adapters/dual_write.rb
+++ b/lib/flipper/adapters/dual_write.rb
@@ -15,6 +15,10 @@ module Flipper
         @remote = remote
       end
 
+      def adapter_stack
+        "#{name}(local: #{@local.adapter_stack}, remote: #{@remote.adapter_stack})"
+      end
+
       def features
         @local.features
       end

--- a/lib/flipper/adapters/failover.rb
+++ b/lib/flipper/adapters/failover.rb
@@ -13,12 +13,18 @@ module Flipper
       #                           primary is updated
       #             :errors - Array of exception types for which to failover
 
+      attr_reader :primary, :secondary
+
       def initialize(primary, secondary, options = {})
         @primary = primary
         @secondary = secondary
 
         @dual_write = options.fetch(:dual_write, false)
         @errors = options.fetch(:errors, [ StandardError ])
+      end
+
+      def adapter_stack
+        "#{name}(primary: #{@primary.adapter_stack}, secondary: #{@secondary.adapter_stack})"
       end
 
       def features

--- a/lib/flipper/adapters/sync.rb
+++ b/lib/flipper/adapters/sync.rb
@@ -9,7 +9,7 @@ module Flipper
       include ::Flipper::Adapter
 
       # Public: The synchronizer that will keep the local and remote in sync.
-      attr_reader :synchronizer
+      attr_reader :synchronizer, :local, :remote
 
       # Public: Build a new sync instance.
       #
@@ -31,6 +31,10 @@ module Flipper
           IntervalSynchronizer.new(synchronizer, interval: options[:interval])
         end
         synchronize
+      end
+
+      def adapter_stack
+        "#{name}(local: #{@local.adapter_stack}, remote: #{@remote.adapter_stack})"
       end
 
       def features

--- a/lib/flipper/dsl.rb
+++ b/lib/flipper/dsl.rb
@@ -10,7 +10,7 @@ module Flipper
     # Private: What is being used to instrument all the things.
     attr_reader :instrumenter
 
-    def_delegators :@adapter, :memoize=, :memoizing?, :import, :export
+    def_delegators :@adapter, :memoize=, :memoizing?, :import, :export, :adapter_stack
 
     # Public: Returns a new instance of the DSL.
     #

--- a/spec/flipper/adapter_spec.rb
+++ b/spec/flipper/adapter_spec.rb
@@ -143,4 +143,24 @@ RSpec.describe Flipper::Adapter do
       expect(export.features.dig("search", :boolean)).to eq("true")
     end
   end
+
+  describe "#adapter_stack" do
+    it "returns the adapter name for a simple adapter" do
+      adapter = Flipper::Adapters::Memory.new
+      expect(adapter.adapter_stack).to eq("memory")
+    end
+
+    it "returns the chain for wrapped adapters" do
+      memory = Flipper::Adapters::Memory.new
+      memoizable = Flipper::Adapters::Memoizable.new(memory)
+      expect(memoizable.adapter_stack).to eq("memoizable -> memory")
+    end
+
+    it "returns the chain for deeply nested adapters" do
+      memory = Flipper::Adapters::Memory.new
+      strict = Flipper::Adapters::Strict.new(memory)
+      memoizable = Flipper::Adapters::Memoizable.new(strict)
+      expect(memoizable.adapter_stack).to eq("memoizable -> strict -> memory")
+    end
+  end
 end

--- a/spec/flipper/adapters/dual_write_spec.rb
+++ b/spec/flipper/adapters/dual_write_spec.rb
@@ -66,4 +66,17 @@ RSpec.describe Flipper::Adapters::DualWrite do
     expect(remote_adapter.count(:disable)).to be(1)
     expect(local_adapter.count(:disable)).to be(1)
   end
+
+  describe '#adapter_stack' do
+    it 'returns the tree representation' do
+      expect(subject.adapter_stack).to eq("dual_write(local: operation_logger -> memory, remote: operation_logger -> memory)")
+    end
+
+    it 'shows nested adapters in the tree' do
+      memory = Flipper::Adapters::Memory.new
+      strict = Flipper::Adapters::Strict.new(Flipper::Adapters::Memory.new)
+      adapter = described_class.new(memory, strict)
+      expect(adapter.adapter_stack).to eq("dual_write(local: memory, remote: strict -> memory)")
+    end
+  end
 end

--- a/spec/flipper/adapters/failover_spec.rb
+++ b/spec/flipper/adapters/failover_spec.rb
@@ -126,4 +126,16 @@ RSpec.describe Flipper::Adapters::Failover do
       end
     end
   end
+
+  describe '#adapter_stack' do
+    it 'returns the tree representation' do
+      expect(subject.adapter_stack).to eq("failover(primary: memory, secondary: memory)")
+    end
+
+    it 'shows nested adapters in the tree' do
+      strict_primary = Flipper::Adapters::Strict.new(primary)
+      adapter = described_class.new(strict_primary, secondary)
+      expect(adapter.adapter_stack).to eq("failover(primary: strict -> memory, secondary: memory)")
+    end
+  end
 end

--- a/spec/flipper/adapters/sync_spec.rb
+++ b/spec/flipper/adapters/sync_spec.rb
@@ -197,4 +197,17 @@ RSpec.describe Flipper::Adapters::Sync do
     expect(remote_adapter).to receive(:get_all).and_raise(exception)
     expect { subject.get_all }.not_to raise_error
   end
+
+  describe '#adapter_stack' do
+    it 'returns the tree representation' do
+      expect(subject.adapter_stack).to eq("sync(local: operation_logger -> memory, remote: operation_logger -> memory)")
+    end
+
+    it 'shows nested adapters in the tree' do
+      memory = Flipper::Adapters::Memory.new
+      strict = Flipper::Adapters::Strict.new(Flipper::Adapters::Memory.new)
+      adapter = described_class.new(memory, strict, interval: 1)
+      expect(adapter.adapter_stack).to eq("sync(local: memory, remote: strict -> memory)")
+    end
+  end
 end

--- a/spec/flipper_spec.rb
+++ b/spec/flipper_spec.rb
@@ -218,6 +218,11 @@ RSpec.describe Flipper do
       expect(described_class.adapter).to eq(described_class.instance.adapter)
     end
 
+    it 'delegates adapter_stack to instance' do
+      expect(described_class.adapter_stack).to eq(described_class.instance.adapter_stack)
+      expect(described_class.adapter_stack).to eq("memoizable -> memory")
+    end
+
     it 'delegates memoize= to instance' do
       expect(described_class.adapter.memoizing?).to be(false)
       described_class.memoize = true


### PR DESCRIPTION
Adds a new adapter_stack method that returns a string representation of the adapter chain, making it easier to debug complex configurations.

Examples:
  Flipper.adapter_stack
  #=> "memoizable -> memory"
  #=> "failover(primary: redis, secondary: memory)"
  #=> "dual_write(local: memory, remote: strict -> active_record)"

🤖 Generated with [Claude Code](https://claude.com/claude-code)