### PR TITLE
Fix: Pass instrumenter to Feature instances in Synchronizer

### DIFF
--- a/lib/flipper/adapters/sync/synchronizer.rb
+++ b/lib/flipper/adapters/sync/synchronizer.rb
@@ -38,7 +38,7 @@ module Flipper
 
           # Sync all the gate values.
           remote_get_all.each do |feature_key, remote_gates_hash|
-            feature = Feature.new(feature_key, @local)
+            feature = Feature.new(feature_key, @local, instrumenter: @instrumenter)
             # Check if feature_key is in hash before accessing to prevent unintended hash modification
             local_gates_hash = local_get_all.key?(feature_key) ? local_get_all[feature_key] : @local.default_config
             local_gate_values = GateValues.new(local_gates_hash)
@@ -48,11 +48,11 @@ module Flipper
 
           # Add features that are missing in local and present in remote.
           features_to_add = remote_get_all.keys - local_get_all.keys
-          features_to_add.each { |key| Feature.new(key, @local).add }
+          features_to_add.each { |key| Feature.new(key, @local, instrumenter: @instrumenter).add }
 
           # Remove features that are present in local and missing in remote.
           features_to_remove = local_get_all.keys - remote_get_all.keys
-          features_to_remove.each { |key| Feature.new(key, @local).remove }
+          features_to_remove.each { |key| Feature.new(key, @local, instrumenter: @instrumenter).remove }
 
           nil
         rescue => exception


### PR DESCRIPTION
## Summary

When using Flipper Cloud with webhooks, the `Synchronizer` creates `Feature` instances without passing the configured `instrumenter`. This causes `feature_operation.flipper` events to never be emitted during sync operations, even when an instrumenter like `ActiveSupport::Notifications` is configured.

## Problem

The `Synchronizer` accepts an `instrumenter` option and uses it for its own events (`synchronizer_call.flipper`, `synchronizer_exception.flipper`), but doesn't pass it when creating `Feature` instances:

```ruby
# Current code - instrumenter not passed
feature = Feature.new(feature_key, @local)
```

Since `Feature#initialize` defaults to `Instrumenters::Noop` when no instrumenter is provided, no `feature_operation.flipper` events are emitted when the sync calls `feature.enable`, `feature.disable`, etc.

## Solution

Pass `@instrumenter` when creating Feature instances in the Synchronizer's `sync` method.

## Impact

This allows users to subscribe to `feature_operation.flipper` events during webhook-triggered syncs, enabling use cases like:
- Cache invalidation when flags change
- Audit logging of flag changes  
- Slack/PagerDuty notifications

## Test Plan

- Added specs verifying `feature_operation.flipper` events are emitted when:
  - Syncing feature state changes
  - Adding new features
  - Removing features