### PR TITLE
Test: Add coverage for question marks in feature names

### DIFF
--- a/spec/flipper/ui/actions/feature_spec.rb
+++ b/spec/flipper/ui/actions/feature_spec.rb
@@ -211,4 +211,18 @@ RSpec.describe Flipper::UI::Actions::Feature do
       expect(last_response.body).to include('../../../../blah')
     end
   end
+
+  describe 'GET /features/:feature with question mark in feature name' do
+    before do
+      get '/features/can_do_stuff%3F'
+    end
+
+    it 'responds with success' do
+      expect(last_response.status).to be(200)
+    end
+
+    it 'renders template with question mark in feature name' do
+      expect(last_response.body).to include('can_do_stuff?')
+    end
+  end
 end

--- a/spec/flipper/ui/actions/features_spec.rb
+++ b/spec/flipper/ui/actions/features_spec.rb
@@ -32,10 +32,12 @@ RSpec.describe Flipper::UI::Actions::Features do
       flipper.add("../../../../blah")
       flipper.add("this that")
       flipper.add("foo/bar")
+      flipper.add("can_do_stuff?")
       get '/features'
       expect(last_response.body).to include("..%2F..%2F..%2F..%2Fblah")
       expect(last_response.body).to include("this+that")
       expect(last_response.body).to include("foo%2Fbar")
+      expect(last_response.body).to include("can_do_stuff%3F")
     end
 
     context "when there are no features to list" do
@@ -167,6 +169,19 @@ RSpec.describe Flipper::UI::Actions::Features do
         it 'redirects to feature' do
           expect(last_response.status).to be(302)
           expect(last_response.headers['location']).to eq('/features/..%2F..%2F..%2Ffoo')
+        end
+      end
+
+      context 'feature name contains question mark' do
+        let(:feature_name) { 'can_do_stuff?' }
+
+        it 'adds feature with question mark' do
+          expect(flipper.features.map(&:key)).to include('can_do_stuff?')
+        end
+
+        it 'redirects to feature with encoded question mark' do
+          expect(last_response.status).to be(302)
+          expect(last_response.headers['location']).to eq('/features/can_do_stuff%3F')
         end
       end
 


### PR DESCRIPTION
## Summary
Add test coverage for feature names containing question marks to verify they are properly URI-encoded in URLs and redirects. This addresses issue #967 and ensures question marks are not stripped from feature names when using the UI.

## Test Plan
- `bundle exec rspec spec/flipper/ui/actions/feature_spec.rb` - Verify feature page loads with encoded question mark
- `bundle exec rspec spec/flipper/ui/actions/features_spec.rb` - Verify features list and creation with question marks
- All 162 UI tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)