### PR TITLE
Set CI job timeout to 20 minutes

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,6 +5,7 @@ jobs:
   test:
     name: Test on ruby ${{ matrix.ruby }} and rails ${{ matrix.rails }}
     runs-on: ubuntu-latest
+    timeout-minutes: 20
     services:
       redis:
         image: redis

--- a/.github/workflows/examples.yml
+++ b/.github/workflows/examples.yml
@@ -5,6 +5,7 @@ jobs:
     if: github.repository_owner == 'flippercloud'
     name: Example on ruby ${{ matrix.ruby }} and rails ${{ matrix.rails }}
     runs-on: ubuntu-latest
+    timeout-minutes: 20
     services:
       redis:
         image: redis


### PR DESCRIPTION
Reduce from the default 6-hour timeout to catch stuck jobs faster while allowing adequate time for test runs across multiple Ruby and Rails versions.

🤖 Generated with Claude Code