### PR TITLE
Add config to disable the Fully Enable button

### DIFF
--- a/lib/flipper/ui/actions/boolean_gate.rb
+++ b/lib/flipper/ui/actions/boolean_gate.rb
@@ -16,6 +16,10 @@ module Flipper
           @feature = Decorators::Feature.new(feature)
 
           if params['action'] == 'Enable'
+            if Flipper::UI.configuration.fully_enable_disabled
+              status 403
+              halt view_response(:fully_enable_disabled)
+            end
             feature.enable
           else
             feature.disable

--- a/lib/flipper/ui/configuration.rb
+++ b/lib/flipper/ui/configuration.rb
@@ -77,6 +77,15 @@ module Flipper
       # Default is false.
       attr_accessor :confirm_disable
 
+      # Public: If set to true, the Fully Enable button will be disabled in the
+      # UI, preventing users from fully enabling features. Defaults to false.
+      attr_accessor :fully_enable_disabled
+
+      # Public: The tooltip text shown on the disabled Fully Enable button when
+      # fully_enable_disabled is true. Defaults to "Fully enabling features via
+      # the UI is disabled."
+      attr_accessor :fully_enable_disabled_with
+
       VALID_BANNER_CLASS_VALUES = %w(
         danger
         dark
@@ -106,6 +115,8 @@ module Flipper
         @actors_separator = ','
         @confirm_fully_enable = false
         @confirm_disable = true
+        @fully_enable_disabled = false
+        @fully_enable_disabled_with = "Fully enabling features via the UI is disabled."
         @read_only = false
         @nav_items = [
           { title: "Features", href: "features" },

--- a/lib/flipper/ui/views/feature.erb
+++ b/lib/flipper/ui/views/feature.erb
@@ -255,16 +255,24 @@
             <div class="row">
               <% unless @feature.boolean_value %>
                 <div class="col d-grid">
-                  <button type="submit" name="action" value="Enable" class="btn btn-outline-success"
-                    <% if Flipper::UI.configuration.confirm_fully_enable %>
-                      data-confirmation-prompt="Are you sure you want to fully enable this feature for everyone? Please enter the name of the feature to confirm it: <%= feature_name %>"
-                      data-confirmation-text="<%= feature_name %>"
-                    <% end %>
-                  >
-                    <span class="d-block" data-bs-toggle="tooltip" title="Enable for everyone">
-                      Fully Enable
+                  <% if Flipper::UI.configuration.fully_enable_disabled %>
+                    <span class="d-inline-block" tabindex="0" data-bs-toggle="tooltip" title="<%= Flipper::UI.configuration.fully_enable_disabled_with %>">
+                      <button type="submit" name="action" value="Enable" class="btn btn-outline-success w-100" disabled style="pointer-events: none;">
+                        Fully Enable
+                      </button>
                     </span>
-                  </button>
+                  <% else %>
+                    <button type="submit" name="action" value="Enable" class="btn btn-outline-success"
+                      <% if Flipper::UI.configuration.confirm_fully_enable %>
+                        data-confirmation-prompt="Are you sure you want to fully enable this feature for everyone? Please enter the name of the feature to confirm it: <%= feature_name %>"
+                        data-confirmation-text="<%= feature_name %>"
+                      <% end %>
+                    >
+                      <span class="d-block" data-bs-toggle="tooltip" title="Enable for everyone">
+                        Fully Enable
+                      </span>
+                    </button>
+                  <% end %>
                 </div>
               <% end %>
 

--- a/lib/flipper/ui/views/fully_enable_disabled.erb
+++ b/lib/flipper/ui/views/fully_enable_disabled.erb
@@ -1,0 +1,3 @@
+<div class="alert alert-danger">
+  Fully enabling features from the UI is disabled. To enable, you'll need to set <code>Flipper::UI.configuration.fully_enable_disabled = false</code> wherever flipper is running from.
+</div>

--- a/spec/flipper/ui/actions/boolean_gate_spec.rb
+++ b/spec/flipper/ui/actions/boolean_gate_spec.rb
@@ -64,5 +64,56 @@ RSpec.describe Flipper::UI::Actions::BooleanGate do
         expect(last_response.headers['location']).to eq('/features/search')
       end
     end
+
+    context 'when fully_enable_disabled is true' do
+      around do |example|
+        begin
+          @original_fully_enable_disabled = Flipper::UI.configuration.fully_enable_disabled
+          Flipper::UI.configuration.fully_enable_disabled = true
+          example.run
+        ensure
+          Flipper::UI.configuration.fully_enable_disabled = @original_fully_enable_disabled
+        end
+      end
+
+      context 'with enable' do
+        before do
+          flipper.disable :search
+          post 'features/search/boolean',
+               { 'action' => 'Enable', 'authenticity_token' => token },
+               'rack.session' => session
+        end
+
+        it 'does not enable the feature' do
+          expect(flipper.enabled?(:search)).to be(false)
+        end
+
+        it 'returns 403 status' do
+          expect(last_response.status).to be(403)
+        end
+
+        it 'renders fully enable disabled template' do
+          expect(last_response.body).to include('Fully enabling features from the UI is disabled')
+        end
+      end
+
+      context 'with disable' do
+        before do
+          flipper.enable :search
+          post 'features/search/boolean',
+               { 'action' => 'Disable', 'authenticity_token' => token },
+               'rack.session' => session
+        end
+
+        it 'still allows disabling the feature' do
+          expect(flipper.enabled?(:search)).to be(false)
+        end
+
+        it 'redirects back to feature' do
+          expect(last_response.status).to be(302)
+          expect(last_response.headers['location']).to eq('/features/search')
+        end
+      end
+    end
   end
 end

--- a/spec/flipper/ui/actions/feature_spec.rb
+++ b/spec/flipper/ui/actions/feature_spec.rb
@@ -125,6 +125,37 @@ RSpec.describe Flipper::UI::Actions::Feature do
       end
     end
 
+    context "when fully_enable_disabled is true" do
+      around do |example|
+        begin
+          @original_fully_enable_disabled = Flipper::UI.configuration.fully_enable_disabled
+          @original_fully_enable_disabled_with = Flipper::UI.configuration.fully_enable_disabled_with
+          Flipper::UI.configuration.fully_enable_disabled = true
+          example.run
+        ensure
+          Flipper::UI.configuration.fully_enable_disabled = @original_fully_enable_disabled
+          Flipper::UI.configuration.fully_enable_disabled_with = @original_fully_enable_disabled_with
+        end
+      end
+
+      it 'renders the Fully Enable button as disabled' do
+        get '/features/search'
+        expect(last_response.body).to include('Fully Enable')
+        expect(last_response.body).to match(/disabled\s*>/)
+      end
+
+      it 'shows the default disabled tooltip' do
+        get '/features/search'
+        expect(last_response.body).to include('Fully enabling features via the UI is disabled.')
+      end
+
+      it 'shows custom disabled tooltip when fully_enable_disabled_with is set' do
+        Flipper::UI.configuration.fully_enable_disabled_with = "Use deploy pipeline instead."
+        get '/features/search'
+        expect(last_response.body).to include('Use deploy pipeline instead.')
+      end
+    end
+
     context 'custom actor names' do
       before do
         actor = Flipper::Actor.new('some_actor_name')

--- a/spec/flipper/ui/configuration_spec.rb
+++ b/spec/flipper/ui/configuration_spec.rb
@@ -146,6 +146,28 @@ RSpec.describe Flipper::UI::Configuration do
     end
   end
 
+  describe "#fully_enable_disabled" do
+    it "has default value" do
+      expect(configuration.fully_enable_disabled).to eq(false)
+    end
+
+    it "can be updated" do
+      configuration.fully_enable_disabled = true
+      expect(configuration.fully_enable_disabled).to eq(true)
+    end
+  end
+
+  describe "#fully_enable_disabled_with" do
+    it "has default value" do
+      expect(configuration.fully_enable_disabled_with).to eq("Fully enabling features via the UI is disabled.")
+    end
+
+    it "can be updated" do
+      configuration.fully_enable_disabled_with = "Use deploy pipeline instead."
+      expect(configuration.fully_enable_disabled_with).to eq("Use deploy pipeline instead.")
+    end
+  end
+
   describe "#show_feature_description_in_list" do
     it "has default value" do
       expect(configuration.show_feature_description_in_list).to eq(false)


### PR DESCRIPTION
Hi!

I'm proposing to add two new configuration options for `Flipper::UI` to allow disabling the `Fully Enable` button.

### Use case

When rolling out features gradually (i.e. test group first, then wider), there are cases where fully enabling for everyone isn't appropriate - for example, when certain users have opted out of receiving new features. This configuration prevents accidental full rollouts.

### Demo

Default behavior (`config.fully_enable_disabled` is `false` by default):
<img width="825" height="659" alt="Screenshot From 2026-02-18 11-16-57" src="https://github.com/user-attachments/assets/0310c8ad-fa0a-45ef-aede-8acabcd4ecdf" />

Disabled button & default tooltip:
```
Flipper::UI.configure do |config|
  config.fully_enable_disabled = true
end
```
<img width="825" height="659" alt="Screenshot From 2026-02-18 11-15-57" src="https://github.com/user-attachments/assets/a3fbfa0d-a600-4ee9-8bda-b9c501b4b086" />

Disabled button & custom tooltip:
```
Flipper::UI.configure do |config|
  config.fully_enable_disabled = true
  config.fully_enable_disabled_with = '<Custom disabled message>.'
end
```
<img width="825" height="659" alt="Screenshot From 2026-02-18 11-18-58" src="https://github.com/user-attachments/assets/236b5731-ad94-423c-b378-21a5832b4690" />
