### PR TITLE
Add disabled? as syntax sugar for !enabled?

### DIFF
--- a/lib/flipper.rb
+++ b/lib/flipper.rb
@@ -56,7 +56,7 @@ module Flipper
   # Public: All the methods delegated to instance. These should match the
   # interface of Flipper::DSL.
   def_delegators :instance,
-                 :enabled?, :enable, :disable,
+                 :enabled?, :disabled?, :enable, :disable,
                  :enable_expression, :disable_expression,
                  :expression, :add_expression, :remove_expression,
                  :enable_actor, :disable_actor,

--- a/lib/flipper/dsl.rb
+++ b/lib/flipper/dsl.rb
@@ -36,6 +36,16 @@ module Flipper
       feature(name).enabled?(*args)
     end
 
+    # Public: Check if a feature is disabled.
+    #
+    # name - The String or Symbol name of the feature.
+    # args - The args passed through to the disabled check.
+    #
+    # Returns true if feature is disabled, false if not.
+    def disabled?(name, *args)
+      feature(name).disabled?(*args)
+    end
+
     # Public: Enable a feature.
     #
     # name - The String or Symbol name of the feature.

--- a/lib/flipper/feature.rb
+++ b/lib/flipper/feature.rb
@@ -127,6 +127,13 @@ module Flipper
       end
     end
 
+    # Public: Check if a feature is disabled for zero or more actors.
+    #
+    # Returns true if disabled, false if not.
+    def disabled?(*actors)
+      !enabled?(*actors)
+    end
+
     # Public: Enables an expression_to_add for a feature.
     #
     # expression - an Expression or Hash that can be converted to an expression.

--- a/spec/flipper/feature_spec.rb
+++ b/spec/flipper/feature_spec.rb
@@ -98,6 +98,47 @@ RSpec.describe Flipper::Feature do
     end
   end
 
+  describe "#disabled?" do
+    context "for an actor" do
+      let(:actor) { Flipper::Actor.new("User;1") }
+
+      it 'returns false if feature is enabled' do
+        subject.enable
+        expect(subject.disabled?(actor)).to be(false)
+      end
+
+      it 'returns true if feature is disabled' do
+        subject.disable
+        expect(subject.disabled?(actor)).to be(true)
+      end
+    end
+
+    context "for multiple actors" do
+      let(:actors) {
+        [
+          Flipper::Actor.new("User;1"),
+          Flipper::Actor.new("User;2"),
+          Flipper::Actor.new("User;3"),
+        ]
+      }
+
+      it 'returns false if feature is enabled' do
+        subject.enable
+        expect(subject.disabled?(actors)).to be(false)
+      end
+
+      it 'returns false if feature is enabled for any actor' do
+        subject.enable_actor actors.first
+        expect(subject.disabled?(actors)).to be(false)
+      end
+
+      it 'returns true if feature is disabled for all actors' do
+        subject.disable
+        expect(subject.disabled?(actors)).to be(true)
+      end
+    end
+  end
+
   describe '#to_s' do
     it 'returns name as string' do
       feature = described_class.new(:search, adapter)

--- a/spec/flipper_spec.rb
+++ b/spec/flipper_spec.rb
@@ -83,6 +83,12 @@ RSpec.describe Flipper do
       expect(described_class.enabled?(:search)).to eq(described_class.instance.enabled?(:search))
     end
 
+    it 'delegates disabled? to instance' do
+      expect(described_class.disabled?(:search)).to eq(described_class.instance.disabled?(:search))
+      described_class.instance.enable(:search)
+      expect(described_class.disabled?(:search)).to eq(described_class.instance.disabled?(:search))
+    end
+
     it 'delegates enable to instance' do
       described_class.enable(:search)
       expect(described_class.instance.enabled?(:search)).to be(true)


### PR DESCRIPTION
## Motivation

When checking whether a feature is **off**, you currently have to write:

```ruby
if !Flipper.enabled?(:my_feature)
  # ...
end
```

or the slightly more idiomatic but still awkward:

```ruby
unless Flipper.enabled?(:my_feature)
  # ...
end
```

Both read backwards — you're asking "is it enabled?" when you really want to express "is it disabled?". This gets noisy in call sites that deal primarily with the disabled state, and the negation adds cognitive overhead on every read.

## Change

Adds `disabled?` as the inverse of `enabled?` on `Feature`, `DSL`, and the top-level `Flipper` module:

```ruby
# Before
if !Flipper.enabled?(:my_feature, current_user)
  redirect_to upgrade_path
end

# After
if Flipper.disabled?(:my_feature, current_user)
  redirect_to upgrade_path
end
```

`disabled?` accepts the same actor arguments as `enabled?` and simply returns `!enabled?(*actors)`, so all existing gate semantics are preserved.

## Test plan

- [x] `Feature#disabled?` specs covering single actor, multiple actors, and enabled/disabled states
- [x] `Flipper.disabled?` delegation spec
- [x] Full suite passes (`bundle exec rspec spec/flipper/feature_spec.rb spec/flipper_spec.rb` — 205 examples, 0 failures)