### PR TITLE
Remove webhook polling fallback in cloud adapter

### DIFF
--- a/lib/flipper/cloud/configuration.rb
+++ b/lib/flipper/cloud/configuration.rb
@@ -142,7 +142,8 @@ module Flipper
       private
 
       def app_adapter
-        Flipper::Adapters::DualWrite.new(poll_adapter, http_adapter)
+        read_adapter = sync_method == :webhook ? local_adapter : poll_adapter
+        Flipper::Adapters::DualWrite.new(read_adapter, http_adapter)
       end
 
       def poller
@@ -201,13 +202,8 @@ module Flipper
       end
 
       def setup_sync(options)
+        set_option :sync_interval, options, default: 10, typecast: :float, minimum: 10
         set_option :sync_secret, options
-
-        # 1 hour for webhook, 10 seconds for poll. If using webhooks we don't
-        # need to sync as often but we should still sync occasionally to avoid
-        # any chance of stale data.
-        default_interval = sync_method == :webhook ? 3600 : 10
-        set_option :sync_interval, options, default: default_interval, typecast: :float, minimum: 10
       end
 
       def setup_adapter(options)

--- a/lib/flipper/poller.rb
+++ b/lib/flipper/poller.rb
@@ -99,9 +99,7 @@ module Flipper
     private
 
     def jitter
-      # Cap jitter at 30 seconds to prevent excessive delays for large intervals
-      max_jitter = [interval * 0.1, 30].min
-      rand * max_jitter
+      rand
     end
 
     def forked?

--- a/lib/flipper/version.rb
+++ b/lib/flipper/version.rb
@@ -1,5 +1,5 @@
 module Flipper
-  VERSION = '1.4.1'.freeze
+  VERSION = '1.4.2'.freeze
 
   REQUIRED_RUBY_VERSION = '2.6'.freeze
   NEXT_REQUIRED_RUBY_VERSION = '3.0'.freeze

--- a/spec/flipper/cloud/configuration_spec.rb
+++ b/spec/flipper/cloud/configuration_spec.rb
@@ -135,9 +135,6 @@ RSpec.describe Flipper::Cloud::Configuration do
   end
 
   it "sets sync_method to :webhook if sync_secret provided" do
-    # The initial sync of http to local invokes this web request.
-    stub_request(:get, /flippercloud\.io/).to_return(status: 200, body: "{}")
-
     instance = described_class.new(required_options.merge({
       sync_secret: "secret",
     }))
@@ -147,9 +144,6 @@ RSpec.describe Flipper::Cloud::Configuration do
   end
 
   it "sets sync_method to :webhook if FLIPPER_CLOUD_SYNC_SECRET set" do
-    # The initial sync of http to local invokes this web request.
-    stub_request(:get, /flippercloud\.io/).to_return(status: 200, body: "{}")
-
     ENV["FLIPPER_CLOUD_SYNC_SECRET"] = "abc"
     instance = described_class.new(required_options)
 

--- a/spec/flipper/cloud/dsl_spec.rb
+++ b/spec/flipper/cloud/dsl_spec.rb
@@ -5,9 +5,6 @@ require 'flipper/adapters/instrumented'
 
 RSpec.describe Flipper::Cloud::DSL do
   it 'delegates everything to flipper instance' do
-    # stub the initial sync of http to local
-    stub_request(:get, /flippercloud\.io/).to_return(status: 200, body: "{}")
-
     cloud_configuration = Flipper::Cloud::Configuration.new({
       token: "asdf",
       sync_secret: "tasty",
@@ -30,13 +27,10 @@ RSpec.describe Flipper::Cloud::DSL do
     })
     dsl = described_class.new(cloud_configuration)
     dsl.sync
-    expect(stub).to have_been_requested.at_least_once
+    expect(stub).to have_been_requested
   end
 
   it 'delegates sync_secret to cloud configuration' do
-    # stub the initial sync of http to local
-    stub_request(:get, /flippercloud\.io/).to_return(status: 200, body: "{}")
-
     cloud_configuration = Flipper::Cloud::Configuration.new({
       token: "asdf",
       sync_secret: "tasty",
@@ -59,15 +53,13 @@ RSpec.describe Flipper::Cloud::DSL do
     end
 
     subject do
-      # stub the initial sync of http to local
-      stub_request(:get, /flippercloud\.io/).to_return(status: 200, body: "{}")
       described_class.new(cloud_configuration)
     end
 
     it "sends reads to local adapter" do
       subject.features
       subject.enabled?(:foo)
-      expect(local_adapter.count(:features)).to be(2)
+      expect(local_adapter.count(:features)).to be(1)
       expect(local_adapter.count(:get)).to be(1)
     end
 

--- a/spec/flipper/cloud/middleware_spec.rb
+++ b/spec/flipper/cloud/middleware_spec.rb
@@ -62,7 +62,7 @@ RSpec.describe Flipper::Cloud::Middleware do
           {"name" => "premium"},
         ],
       })
-      expect(stub).to have_been_made.at_least_once
+      expect(stub).to have_been_requested
     end
   end
 
@@ -72,17 +72,15 @@ RSpec.describe Flipper::Cloud::Middleware do
       Flipper::Cloud::MessageVerifier.new(secret: "nope").generate(request_body, timestamp)
     }
 
-    it 'does not perform webhook sync' do
-      webhook_regular_stub = stub_request_for_token('regular', from_webhook: true)
-      poll_regular_stub = stub_request_for_token('regular', from_webhook: false)
+    it 'uses instance to sync' do
+      stub = stub_request_for_token('regular')
       env = {
         "HTTP_FLIPPER_CLOUD_SIGNATURE" => signature_header_value,
       }
       post '/', request_body, env
 
       expect(last_response.status).to eq(400)
-      expect(poll_regular_stub).to have_been_requested.at_least_once
-      expect(webhook_regular_stub).not_to have_been_requested
+      expect(stub).not_to have_been_requested
     end
   end
 
@@ -105,7 +103,7 @@ RSpec.describe Flipper::Cloud::Middleware do
       expect(last_response.status).to eq(402)
       expect(last_response.headers["flipper-cloud-response-error-class"]).to eq("Flipper::Adapters::Http::Error")
       expect(last_response.headers["flipper-cloud-response-error-message"]).to include("Failed with status: 402")
-      expect(stub).to have_been_made.at_least_once
+      expect(stub).to have_been_requested
     end
   end
 
@@ -128,7 +126,7 @@ RSpec.describe Flipper::Cloud::Middleware do
       expect(last_response.status).to eq(500)
       expect(last_response.headers["flipper-cloud-response-error-class"]).to eq("Flipper::Adapters::Http::Error")
       expect(last_response.headers["flipper-cloud-response-error-message"]).to include("Failed with status: 503")
-      expect(stub).to have_been_made.at_least_once
+      expect(stub).to have_been_requested
     end
   end
 
@@ -151,7 +149,7 @@ RSpec.describe Flipper::Cloud::Middleware do
       expect(last_response.status).to eq(500)
       expect(last_response.headers["flipper-cloud-response-error-class"]).to eq("Net::OpenTimeout")
       expect(last_response.headers["flipper-cloud-response-error-message"]).to eq("execution expired")
-      expect(stub).to have_been_made.at_least_once
+      expect(stub).to have_been_requested
     end
   end
 
@@ -162,8 +160,7 @@ RSpec.describe Flipper::Cloud::Middleware do
     }
 
     it 'uses env instance to sync' do
-      regular_stub = stub_request_for_token('regular')
-      env_stub = stub_request_for_token('env')
+      stub = stub_request_for_token('env')
       env = {
         "HTTP_FLIPPER_CLOUD_SIGNATURE" => signature_header_value,
         'flipper' => env_flipper,
@@ -171,8 +168,7 @@ RSpec.describe Flipper::Cloud::Middleware do
       post '/', request_body, env
 
       expect(last_response.status).to eq(200)
-      expect(regular_stub).to have_been_made.at_least_once
-      expect(env_stub).to have_been_made.at_least_once
+      expect(stub).to have_been_requested
     end
   end
 
@@ -191,7 +187,7 @@ RSpec.describe Flipper::Cloud::Middleware do
       post '/', request_body, env
 
       expect(last_response.status).to eq(200)
-      expect(stub).to have_been_made.at_least_once
+      expect(stub).to have_been_requested
     end
   end
 
@@ -202,9 +198,7 @@ RSpec.describe Flipper::Cloud::Middleware do
     }
 
     it 'uses provided env key instead of default' do
-      regular_poll_stub = stub_request_for_token('regular')
-      env_poll_stub = stub_request_for_token('env')
-      env_webhook_stub = stub_request_for_token('env', from_webhook: true)
+      stub = stub_request_for_token('env')
       env = {
         "HTTP_FLIPPER_CLOUD_SIGNATURE" => signature_header_value,
         'flipper' => flipper,
@@ -213,9 +207,7 @@ RSpec.describe Flipper::Cloud::Middleware do
       post '/', request_body, env
 
       expect(last_response.status).to eq(200)
-      expect(regular_poll_stub).to have_been_made.at_least_once
-      expect(env_poll_stub).to have_been_made.at_least_once
-      expect(env_webhook_stub).not_to have_been_requested
+      expect(stub).to have_been_requested
     end
   end
 
@@ -230,7 +222,7 @@ RSpec.describe Flipper::Cloud::Middleware do
       post '/', request_body, env
 
       expect(last_response.status).to eq(200)
-      expect(stub).to have_been_made.at_least_once
+      expect(stub).to have_been_requested
     end
   end
 
@@ -260,13 +252,12 @@ RSpec.describe Flipper::Cloud::Middleware do
           {"name" => "premium"},
         ],
       })
-      expect(stub).to have_been_made.at_least_once
+      expect(stub).to have_been_requested
     end
   end
 
   describe 'Request method unsupported' do
     it 'skips middleware' do
-      stub_request(:get, /flippercloud\.io/).to_return(status: 200, body: "{}")
       get '/'
       expect(last_response.status).to eq(404)
       expect(last_response.content_type).to eq("application/json")
@@ -276,23 +267,14 @@ RSpec.describe Flipper::Cloud::Middleware do
 
   describe 'Inspecting the built Rack app' do
     it 'returns a String' do
-      stub_request(:get, /flippercloud\.io/).to_return(status: 200, body: "{}")
       expect(Flipper::Cloud.app(flipper).inspect).to eq("Flipper::Cloud")
     end
   end
 
   private
 
-  def stub_request_for_token(token, status: 200, from_webhook: false)
-    if from_webhook
-      # Match URL with both exclude_gate_names=true and _cb=integer
-      url_pattern = %r{https://www\.flippercloud\.io/adapter/features\?.*exclude_gate_names=true.*&_cb=\d+}
-    else
-      # Match URL with just exclude_gate_names=true
-      url_pattern = %r{https://www\.flippercloud\.io/adapter/features\?.*exclude_gate_names=true}
-    end
-
-    stub = stub_request(:get, url_pattern).
+  def stub_request_for_token(token, status: 200)
+    stub = stub_request(:get, %r{https://www\.flippercloud\.io/adapter/features\?.*exclude_gate_names=true}).
       with({
         headers: {
           'flipper-cloud-token' => token,

--- a/spec/flipper/cloud/middleware_spec.rb
+++ b/spec/flipper/cloud/middleware_spec.rb
@@ -274,7 +274,7 @@ RSpec.describe Flipper::Cloud::Middleware do
   private
 
   def stub_request_for_token(token, status: 200)
-    stub = stub_request(:get, %r{https://www\.flippercloud\.io/adapter/features\?.*exclude_gate_names=true}).
+    stub = stub_request(:get, %r{\Ahttps://www\.flippercloud\.io/adapter/features\?(?=.*\bexclude_gate_names=true\b)(?=.*\b_cb=\d+\b)}).
       with({
         headers: {
           'flipper-cloud-token' => token,

--- a/spec/flipper_spec.rb
+++ b/spec/flipper_spec.rb
@@ -259,7 +259,7 @@ RSpec.describe Flipper do
       end
       described_class.sync
       expect(described_class.sync_secret).to eq("tasty")
-      expect(stub).to have_been_made.at_least_once
+      expect(stub).to have_been_requested
     end
   end
 


### PR DESCRIPTION
## Summary
- Use the local adapter for reads when `sync_method` is `:webhook`, so webhook-configured instances stop polling entirely
- Simplify `setup_sync` to a single 10s default `sync_interval` (the dual webhook/poll default is no longer needed)
- Trim `Poller#jitter` back to plain `rand` since the capped jitter only mattered for the large webhook interval
- Update specs to reflect that webhook mode no longer triggers polling requests, and tighten assertions to `have_been_requested`

## Test plan
- [x] \`bundle exec rspec spec/flipper/cloud/configuration_spec.rb spec/flipper/cloud/dsl_spec.rb spec/flipper/cloud/middleware_spec.rb spec/flipper_spec.rb\`
- [x] \`bundle exec rake\`

🤖 Generated with [Claude Code](https://claude.com/claude-code)