### PR TITLE
Add feature instance to feature_operation instrumentation payload

### DIFF
--- a/lib/flipper/feature.rb
+++ b/lib/flipper/feature.rb
@@ -438,6 +438,7 @@ module Flipper
     # Private: Instrument a feature operation.
     def instrument(operation, initial_payload = {})
       @instrumenter.instrument(InstrumentationName, initial_payload) do |payload|
+        payload[:feature] = self
         payload[:feature_name] = name
         payload[:operation] = operation
         payload[:result] = yield(payload) if block_given?

--- a/spec/flipper/feature_spec.rb
+++ b/spec/flipper/feature_spec.rb
@@ -239,6 +239,17 @@ RSpec.describe Flipper::Feature do
       expect(event.payload[:thing]).to eq(Flipper::Types::Actor.new(actor))
     end
 
+    it 'includes the feature instance in the payload' do
+      custom_flipper = Flipper.new(adapter, instrumenter: instrumenter)
+      custom_flipper.enable(:search)
+
+      event = instrumenter.events.last
+      expect(event).not_to be_nil
+      expect(event.name).to eq('feature_operation.flipper')
+      expect(event.payload[:feature]).to eq(custom_flipper[:search])
+      expect(event.payload[:feature].adapter).to eq(custom_flipper.adapter)
+    end
+
     it 'is recorded for disable' do
       thing = Flipper::Types::Boolean.new
 


### PR DESCRIPTION
## Summary
- Adds `payload[:feature]` to the `feature_operation.flipper` instrumentation payload so subscribers can access the Feature instance (and its adapter) directly instead of looking it up by name.
- Adds a regression test that subscribes via the Memory instrumenter, calls `enable(:search)` on a Flipper DSL, and asserts both the feature and its adapter are present on the payload.

## Test plan
- [x] `bundle exec rspec spec/flipper/feature_spec.rb`