### PR TITLE
Don’t require ActiveRecord models until after ActiveRecord is loaded

### DIFF
--- a/lib/flipper/adapters/active_record.rb
+++ b/lib/flipper/adapters/active_record.rb
@@ -2,9 +2,12 @@ require 'set'
 require 'securerandom'
 require 'flipper'
 require 'active_record'
-require_relative 'active_record/model'
-require_relative 'active_record/feature'
-require_relative 'active_record/gate'
+
+ActiveSupport.on_load(:active_record) do
+  require_relative 'active_record/model'
+  require_relative 'active_record/feature'
+  require_relative 'active_record/gate'
+end
 
 module Flipper
   module Adapters


### PR DESCRIPTION
The change in #944 rolled back the changes introduced in 622099a and re-introduced the load order problem