### PR TITLE
Use model.arel_table in ActiveRecord get_all for Rails main compatibility

### DIFF
--- a/lib/flipper/adapters/active_record.rb
+++ b/lib/flipper/adapters/active_record.rb
@@ -106,8 +106,8 @@ module Flipper
       def get_all(**kwargs)
         with_connection(@feature_class) do |connection|
           # query the gates from the db in a single query
-          features = ::Arel::Table.new(@feature_class.table_name.to_sym)
-          gates = ::Arel::Table.new(@gate_class.table_name.to_sym)
+          features = @feature_class.arel_table
+          gates = @gate_class.arel_table
           rows_query = features.join(gates, ::Arel::Nodes::OuterJoin)
             .on(features[:key].eq(gates[:feature_key]))
             .project(features[:key].as('feature_key'), gates[:key], gates[:value])


### PR DESCRIPTION
## Problem

`Flipper::Adapters::ActiveRecord#get_all` builds its join query with positional `Arel::Table.new` calls:

```ruby
features = ::Arel::Table.new(@feature_class.table_name.to_sym)
gates    = ::Arel::Table.new(@gate_class.table_name.to_sym)
```

Rails main reworked `Arel::Table` to be **keyword-only** ([rails/rails#57021](https://github.com/rails/rails/pull/57021) — `def initialize(name: nil, as: nil, klass: nil, ...)`). The positional call now raises:

```
ArgumentError: wrong number of arguments (given 1, expected 0)
```

Because `Flipper::Middleware::Memoizer` calls `preload_all` → `get_all` on **every request**, this breaks *every* request (including health-check endpoints) on any app tracking Rails main / edge. We hit this in production when our Rails-main pin moved past that commit.

## Fix

Use `ActiveRecord::Base.arel_table` instead. It returns the same table, is maintained by Rails, and has existed since Rails 4 — so it sidesteps the constructor signature entirely and works across the full supported matrix (5.2–8.0) **and** Rails main.

```ruby
features = @feature_class.arel_table
gates    = @gate_class.arel_table
```

## Testing

- `bundle exec rspec spec/flipper/adapters/active_record_spec.rb` (sqlite): **52 examples, 0 failures** (the 2 pending are pre-existing sqlite role limitations).
- Verified downstream against Rails main: reproduced the `ArgumentError`, confirmed the change makes `Flipper.preload_all` succeed.

CI's matrix doesn't currently include Rails main, so this regression isn't caught upstream — happy to add a `rails: main` matrix entry in a follow-up if useful.