### PR TITLE
Conditionally disable "Migrate to Flipper Cloud" section

### DIFF
--- a/lib/flipper/ui/views/settings.erb
+++ b/lib/flipper/ui/views/settings.erb
@@ -2,28 +2,30 @@
   <div class="alert alert-danger"><%= params["error"] %></div>
 <% end %>
 
-<div class="card mb-4">
-  <div class="card-header">
-    <h4 class="m-0">Migrate to Flipper Cloud</h4>
+<% if Flipper::UI.configuration.cloud_recommendation %>
+  <div class="card mb-4">
+    <div class="card-header">
+      <h4 class="m-0">Migrate to Flipper Cloud</h4>
+    </div>
+    <div class="card-body">
+      <p>Flipper Cloud gives you audit history, rollback, finer-grained permissions, and multi-environment sync. We even have a free tier!</p>
+
+      <ul class="mb-3">
+        <li>Audit log of every feature change</li>
+        <li>Instant rollback to any previous state</li>
+        <li>Team permissions and approval workflows</li>
+        <li>Sync flags across environments</li>
+      </ul>
+
+      <p>You have <strong><%= flipper.features.count %></strong> <%= flipper.features.count == 1 ? 'feature' : 'features' %> ready to migrate.</p>
+
+      <form action="<%= script_name %>/settings/cloud" method="post">
+        <%== csrf_input_tag %>
+        <input type="submit" value="Migrate to Flipper Cloud" class="btn btn-primary">
+      </form>
+    </div>
   </div>
-  <div class="card-body">
-    <p>Flipper Cloud gives you audit history, rollback, finer-grained permissions, and multi-environment sync. We even have a free tier!</p>
-
-    <ul class="mb-3">
-      <li>Audit log of every feature change</li>
-      <li>Instant rollback to any previous state</li>
-      <li>Team permissions and approval workflows</li>
-      <li>Sync flags across environments</li>
-    </ul>
-
-    <p>You have <strong><%= flipper.features.count %></strong> <%= flipper.features.count == 1 ? 'feature' : 'features' %> ready to migrate.</p>
-
-    <form action="<%= script_name %>/settings/cloud" method="post">
-      <%== csrf_input_tag %>
-      <input type="submit" value="Migrate to Flipper Cloud" class="btn btn-primary">
-    </form>
-  </div>
-</div>
+<% end %>
 
 <div class="card mb-4 ">
   <div class="card-header">

--- a/spec/flipper/ui/actions/settings_spec.rb
+++ b/spec/flipper/ui/actions/settings_spec.rb
@@ -32,4 +32,24 @@ RSpec.describe Flipper::UI::Actions::Settings do
       expect(last_response.body).to include('features ready to migrate')
     end
   end
+
+  describe 'GET /settings with cloud_recommendation disabled' do
+    before do
+      @original_cloud_recommendation = Flipper::UI.configuration.cloud_recommendation
+      Flipper::UI.configuration.cloud_recommendation = false
+      get '/settings'
+    end
+
+    after do
+      Flipper::UI.configuration.cloud_recommendation = @original_cloud_recommendation
+    end
+
+    it 'responds with success' do
+      expect(last_response.status).to be(200)
+    end
+
+    it 'does not include migrate to Flipper Cloud card' do
+      expect(last_response.body).not_to include('Migrate to Flipper Cloud')
+    end
+  end
 end


### PR DESCRIPTION
Groups the "Migrate to Flipper Cloud" section (on the Settings page) under the `cloud_recommendation` config option, so that the section is only shown when that option is truthy.

My thinking is that the migration section is another kind of recommendation/reminder, so it makes sense for the same setting to apply in both cases.