### PR TITLE
Escape dashboard gate tooltip values

### DIFF
--- a/lib/flipper/ui/decorators/feature.rb
+++ b/lib/flipper/ui/decorators/feature.rb
@@ -41,11 +41,13 @@ module Flipper
           statuses = []
 
           if feature.actors_value.count > 0
-            statuses << %Q(<span data-toggle="tooltip" data-placement="bottom" title="#{Util.to_sentence(feature.actors_value.to_a)}">) + Util.pluralize(feature.actors_value.count, 'actor', 'actors') + "</span>"
+            title = Rack::Utils.escape_html(Util.to_sentence(feature.actors_value.to_a))
+            statuses << %Q(<span data-toggle="tooltip" data-placement="bottom" title="#{title}">) + Util.pluralize(feature.actors_value.count, 'actor', 'actors') + "</span>"
           end
 
           if feature.groups_value.count > 0
-            statuses << %Q(<span data-toggle="tooltip" data-placement="bottom" title="#{Util.to_sentence(feature.groups_value.to_a)}">) + Util.pluralize(feature.groups_value.count, 'group', 'groups') + "</span>"
+            title = Rack::Utils.escape_html(Util.to_sentence(feature.groups_value.to_a))
+            statuses << %Q(<span data-toggle="tooltip" data-placement="bottom" title="#{title}">) + Util.pluralize(feature.groups_value.count, 'group', 'groups') + "</span>"
           end
 
           if feature.percentage_of_actors_value > 0

--- a/spec/flipper/ui/actions/features_spec.rb
+++ b/spec/flipper/ui/actions/features_spec.rb
@@ -40,6 +40,15 @@ RSpec.describe Flipper::UI::Actions::Features do
       expect(last_response.body).to include("can_do_stuff%3F")
     end
 
+    it "escapes actor values in gate tooltip titles" do
+      flipper[:search].enable_actor Flipper::Actor.new('x" onmouseover="alert(document.domain)')
+
+      get '/features'
+
+      expect(last_response.body).to include('title="x&quot; onmouseover=&quot;alert(document.domain)"')
+      expect(last_response.body).not_to include('title="x" onmouseover="alert(document.domain)"')
+    end
+
     context "when there are no features to list" do
       before do
         @original_fun_enabled = Flipper::UI.configuration.fun

--- a/spec/flipper/ui/decorators/feature_spec.rb
+++ b/spec/flipper/ui/decorators/feature_spec.rb
@@ -20,6 +20,16 @@ RSpec.describe Flipper::UI::Decorators::Feature do
     end
   end
 
+  describe '#gates_in_words' do
+    it 'escapes actor values in the tooltip title' do
+      feature.enable_actor Flipper::Actor.new('x" onmouseover="alert(document.domain)')
+
+      expect(subject.gates_in_words).to include('title="x&quot; onmouseover=&quot;alert(document.domain)"')
+      expect(subject.gates_in_words).to include('>1 actor</span>')
+      expect(subject.gates_in_words).not_to include('title="x" onmouseover="alert(document.domain)"')
+    end
+  end
+
   describe '#<=>' do
     let(:on) do
       flipper.enable(:on_a)


### PR DESCRIPTION
Dashboard gate summaries no longer allow actor or group IDs to break out of tooltip title attributes. Actor and group values are HTML-escaped before `gates_in_words` returns trusted markup, preserving tooltip counts while closing the attribute-injection path. Added coverage at the decorator and `/features` page levels for a quote-based actor payload.

Validation: `bundle exec rspec spec/flipper/ui`.

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
![Codex](https://img.shields.io/badge/Codex-000000)
