### PR TITLE
Document intentional CRC32 modulo bias in percentage-of-actors

### DIFF
--- a/lib/flipper/expressions/percentage_of_actors.rb
+++ b/lib/flipper/expressions/percentage_of_actors.rb
@@ -5,6 +5,13 @@ module Flipper
 
       def self.call(text, percentage, context: {})
         prefix = context[:feature_name] || ""
+        # NOTE: `crc32 % 100_000` has a tiny modulo bias (2**32 is not a
+        # multiple of 100_000, so buckets 0..67_295 are ~0.0023% over-
+        # represented). Intentionally left as-is: any "fix" changes the
+        # hash-to-bucket mapping and would re-bucket essentially every
+        # actor on upgrade, silently flipping who is enabled. Stable,
+        # deterministic bucketing matters more than perfect uniformity.
+        # Keep in sync with Flipper::Gates::PercentageOfActors. Do not change.
         Zlib.crc32("#{prefix}#{text}") % (100 * SCALING_FACTOR) < percentage * SCALING_FACTOR
       end
     end

--- a/lib/flipper/gates/percentage_of_actors.rb
+++ b/lib/flipper/gates/percentage_of_actors.rb
@@ -32,6 +32,13 @@ module Flipper
       def open?(context)
         return false unless context.actors?
         id = "#{context.feature_name}#{context.actors.map(&:value).sort.join}"
+        # NOTE: `crc32 % 100_000` has a tiny modulo bias (2**32 is not a
+        # multiple of 100_000, so buckets 0..67_295 are ~0.0023% over-
+        # represented). This is intentionally left as-is: the bias is
+        # negligible, and any "fix" changes the hash-to-bucket mapping,
+        # which would re-bucket essentially every actor on upgrade and
+        # silently flip who is enabled. Stable, deterministic bucketing
+        # matters far more here than perfect uniformity. Do not change.
         Zlib.crc32(id) % (100 * SCALING_FACTOR) < context.values.percentage_of_actors * SCALING_FACTOR
       end
 


### PR DESCRIPTION
The `crc32 % 100_000` bucketing used for percentage-of-actors has a negligible (~0.0023%) modulo bias, since `2**32` is not a multiple of `100_000` and buckets `0..67_295` are slightly over-represented. This PR adds explanatory comments in both the gate (`lib/flipper/gates/percentage_of_actors.rb`) and the expression (`lib/flipper/expressions/percentage_of_actors.rb`) documenting that the bias is intentionally left as-is. Any "fix" would change the hash-to-bucket mapping and silently re-bucket essentially every actor on upgrade, flipping who is enabled. Stable, deterministic bucketing matters far more here than perfect uniformity, so this is documentation-only with no behavior change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)