### PR TITLE
Escape feature and gate keys in HTTP adapter requests

### DIFF
--- a/lib/flipper/adapters/http.rb
+++ b/lib/flipper/adapters/http.rb
@@ -30,7 +30,7 @@ module Flipper
       end
 
       def get(feature)
-        response = @client.get("/features/#{escape(feature.key)}")
+        response = @client.get("/features/#{path_escape(feature.key)}")
         if response.is_a?(Net::HTTPOK)
           parsed_response = Typecast.from_json(response.body)
           result_for_feature(feature, parsed_response.fetch('gates'))
@@ -125,7 +125,7 @@ module Flipper
       end
 
       def remove(feature)
-        response = @client.delete("/features/#{escape(feature.key)}")
+        response = @client.delete("/features/#{path_escape(feature.key)}")
         raise Error, response unless response.is_a?(Net::HTTPNoContent)
         true
       end
@@ -133,7 +133,7 @@ module Flipper
       def enable(feature, gate, thing)
         body = request_body_for_gate(gate, thing.value)
         query_string = gate.key == :groups ? "?allow_unregistered_groups=true" : ""
-        response = @client.post("/features/#{escape(feature.key)}/#{escape(gate.key)}#{query_string}", body)
+        response = @client.post("/features/#{path_escape(feature.key)}/#{path_escape(gate.key)}#{query_string}", body)
         raise Error, response unless response.is_a?(Net::HTTPOK)
         true
       end
@@ -143,16 +143,16 @@ module Flipper
         query_string = gate.key == :groups ? "?allow_unregistered_groups=true" : ""
         response = case gate.key
         when :percentage_of_actors, :percentage_of_time
-          @client.post("/features/#{escape(feature.key)}/#{escape(gate.key)}#{query_string}", body)
+          @client.post("/features/#{path_escape(feature.key)}/#{path_escape(gate.key)}#{query_string}", body)
         else
-          @client.delete("/features/#{escape(feature.key)}/#{escape(gate.key)}#{query_string}", body)
+          @client.delete("/features/#{path_escape(feature.key)}/#{path_escape(gate.key)}#{query_string}", body)
         end
         raise Error, response unless response.is_a?(Net::HTTPOK)
         true
       end
 
       def clear(feature)
-        response = @client.delete("/features/#{escape(feature.key)}/clear")
+        response = @client.delete("/features/#{path_escape(feature.key)}/clear")
         raise Error, response unless response.is_a?(Net::HTTPNoContent)
         true
       end
@@ -167,7 +167,11 @@ module Flipper
 
       private
 
-      def escape(key)
+      def path_escape(key)
+        URI::DEFAULT_PARSER.escape(key.to_s, /[^A-Za-z0-9_.~-]/)
+      end
+
+      def query_escape(key)
         URI.encode_www_form_component(key.to_s)
       end
 
@@ -175,7 +179,7 @@ module Flipper
         if features.any? { |feature| feature.key.to_s.include?(',') }
           URI.encode_www_form(features.map { |feature| ["keys[]", feature.key] } + [["exclude_gate_names", "true"]])
         else
-          csv_keys = features.map { |feature| escape(feature.key) }.join(',')
+          csv_keys = features.map { |feature| query_escape(feature.key) }.join(',')
           "keys=#{csv_keys}&exclude_gate_names=true"
         end
       end

--- a/lib/flipper/adapters/http.rb
+++ b/lib/flipper/adapters/http.rb
@@ -42,8 +42,7 @@ module Flipper
       end
 
       def get_multi(features)
-        csv_keys = features.map { |feature| escape(feature.key) }.join(',')
-        response = @client.get("/features?keys=#{csv_keys}&exclude_gate_names=true")
+        response = @client.get("/features?#{query_for_features(features)}")
         raise Error, response unless response.is_a?(Net::HTTPOK)
 
         parsed_response = Typecast.from_json(response.body)
@@ -170,6 +169,15 @@ module Flipper
 
       def escape(key)
         URI.encode_www_form_component(key.to_s)
+      end
+
+      def query_for_features(features)
+        if features.any? { |feature| feature.key.to_s.include?(',') }
+          URI.encode_www_form(features.map { |feature| ["keys[]", feature.key] } + [["exclude_gate_names", "true"]])
+        else
+          csv_keys = features.map { |feature| escape(feature.key) }.join(',')
+          "keys=#{csv_keys}&exclude_gate_names=true"
+        end
       end
 
       def request_body_for_gate(gate, value)

--- a/lib/flipper/adapters/http.rb
+++ b/lib/flipper/adapters/http.rb
@@ -1,4 +1,5 @@
 require 'net/http'
+require 'uri'
 require 'json'
 require 'set'
 require 'flipper'
@@ -29,7 +30,7 @@ module Flipper
       end
 
       def get(feature)
-        response = @client.get("/features/#{feature.key}")
+        response = @client.get("/features/#{escape(feature.key)}")
         if response.is_a?(Net::HTTPOK)
           parsed_response = Typecast.from_json(response.body)
           result_for_feature(feature, parsed_response.fetch('gates'))
@@ -41,7 +42,7 @@ module Flipper
       end
 
       def get_multi(features)
-        csv_keys = features.map(&:key).join(',')
+        csv_keys = features.map { |feature| escape(feature.key) }.join(',')
         response = @client.get("/features?keys=#{csv_keys}&exclude_gate_names=true")
         raise Error, response unless response.is_a?(Net::HTTPOK)
 
@@ -125,7 +126,7 @@ module Flipper
       end
 
       def remove(feature)
-        response = @client.delete("/features/#{feature.key}")
+        response = @client.delete("/features/#{escape(feature.key)}")
         raise Error, response unless response.is_a?(Net::HTTPNoContent)
         true
       end
@@ -133,7 +134,7 @@ module Flipper
       def enable(feature, gate, thing)
         body = request_body_for_gate(gate, thing.value)
         query_string = gate.key == :groups ? "?allow_unregistered_groups=true" : ""
-        response = @client.post("/features/#{feature.key}/#{gate.key}#{query_string}", body)
+        response = @client.post("/features/#{escape(feature.key)}/#{escape(gate.key)}#{query_string}", body)
         raise Error, response unless response.is_a?(Net::HTTPOK)
         true
       end
@@ -143,16 +144,16 @@ module Flipper
         query_string = gate.key == :groups ? "?allow_unregistered_groups=true" : ""
         response = case gate.key
         when :percentage_of_actors, :percentage_of_time
-          @client.post("/features/#{feature.key}/#{gate.key}#{query_string}", body)
+          @client.post("/features/#{escape(feature.key)}/#{escape(gate.key)}#{query_string}", body)
         else
-          @client.delete("/features/#{feature.key}/#{gate.key}#{query_string}", body)
+          @client.delete("/features/#{escape(feature.key)}/#{escape(gate.key)}#{query_string}", body)
         end
         raise Error, response unless response.is_a?(Net::HTTPOK)
         true
       end
 
       def clear(feature)
-        response = @client.delete("/features/#{feature.key}/clear")
+        response = @client.delete("/features/#{escape(feature.key)}/clear")
         raise Error, response unless response.is_a?(Net::HTTPNoContent)
         true
       end
@@ -166,6 +167,10 @@ module Flipper
       end
 
       private
+
+      def escape(key)
+        URI.encode_www_form_component(key.to_s)
+      end
 
       def request_body_for_gate(gate, value)
         data = case gate.key

--- a/lib/flipper/adapters/http/client.rb
+++ b/lib/flipper/adapters/http/client.rb
@@ -81,7 +81,7 @@ module Flipper
           uri = @uri.dup
           path_uri = URI(path)
           uri.path += path_uri.path
-          uri.query = "#{uri.query}&#{path_uri.query}" if path_uri.query
+          uri.query = [uri.query, path_uri.query].compact.join('&') if path_uri.query
           uri
         end
 

--- a/lib/flipper/api/v1/actions/features.rb
+++ b/lib/flipper/api/v1/actions/features.rb
@@ -52,10 +52,15 @@ module Flipper
             return keys.map(&:to_s) if keys.is_a?(Array)
 
             raw_keys = raw_query_values("keys")
-            return decoded_feature_names if raw_keys.empty? || raw_keys.none? { |key| key.include?(',') }
+            return decoded_feature_names if raw_keys.empty?
 
             raw_keys.flat_map do |keys|
-              keys.split(',').map { |key| Rack::Utils.unescape(key) }
+              if keys.include?(',')
+                keys.split(',').map { |key| Rack::Utils.unescape(key) }
+              else
+                decoded_keys = Rack::Utils.unescape(keys)
+                feature_exists?(decoded_keys) ? decoded_keys : decoded_keys.split(',')
+              end
             end
           end
 

--- a/lib/flipper/api/v1/actions/features.rb
+++ b/lib/flipper/api/v1/actions/features.rb
@@ -9,12 +9,11 @@ module Flipper
           route %r{\A/features/?\Z}
 
           def get
-            keys = params['keys']
+            names = requested_feature_names
             exclude_gates = params['exclude_gates']&.downcase == "true"
             exclude_gate_names = params['exclude_gate_names']&.downcase == "true"
 
-            features = if keys
-              names = keys.split(',')
+            features = if names
               if names.empty?
                 []
               else
@@ -47,6 +46,32 @@ module Flipper
           end
 
           private
+
+          def requested_feature_names
+            keys = params['keys']
+            return keys.map(&:to_s) if keys.is_a?(Array)
+
+            raw_keys = raw_query_values("keys")
+            return decoded_feature_names if raw_keys.empty? || raw_keys.none? { |key| key.include?(',') }
+
+            raw_keys.flat_map do |keys|
+              keys.split(',').map { |key| Rack::Utils.unescape(key) }
+            end
+          end
+
+          def decoded_feature_names
+            keys = params['keys']
+            return nil unless keys
+
+            Array(keys).flat_map { |key| key.to_s.split(',') }
+          end
+
+          def raw_query_values(name)
+            request.query_string.to_s.split(/[&;]/).filter_map do |part|
+              key, value = part.split('=', 2)
+              Rack::Utils.unescape(key) == name ? value.to_s : nil
+            end
+          end
 
           def feature_exists?(feature_name)
             flipper.features.map(&:key).include?(feature_name)

--- a/lib/flipper/api/v1/actions/features.rb
+++ b/lib/flipper/api/v1/actions/features.rb
@@ -67,9 +67,9 @@ module Flipper
           end
 
           def raw_query_values(name)
-            request.query_string.to_s.split(/[&;]/).filter_map do |part|
+            request.query_string.to_s.split(/[&;]/).each_with_object([]) do |part, values|
               key, value = part.split('=', 2)
-              Rack::Utils.unescape(key) == name ? value.to_s : nil
+              values << value.to_s if Rack::Utils.unescape(key) == name
             end
           end
 

--- a/spec/flipper/adapters/http_spec.rb
+++ b/spec/flipper/adapters/http_spec.rb
@@ -163,14 +163,14 @@ RSpec.describe Flipper::Adapters::Http do
     end
 
     it "escapes special characters in the feature key" do
-      stub_request(:get, "http://app.com/flipper/features/a%2Fb+c")
+      stub_request(:get, "http://app.com/flipper/features/a%2Fb%20c")
         .to_return(status: 404)
 
       adapter = described_class.new(url: 'http://app.com/flipper')
       adapter.get(flipper["a/b c"])
 
       expect(
-        a_request(:get, "http://app.com/flipper/features/a%2Fb+c")
+        a_request(:get, "http://app.com/flipper/features/a%2Fb%20c")
       ).to have_been_made.once
     end
   end

--- a/spec/flipper/adapters/http_spec.rb
+++ b/spec/flipper/adapters/http_spec.rb
@@ -187,14 +187,14 @@ RSpec.describe Flipper::Adapters::Http do
     end
 
     it "escapes special characters in the feature keys" do
-      stub_request(:get, "http://app.com/flipper/features?keys=a%26b,c%20d&exclude_gate_names=true")
+      stub_request(:get, "http://app.com/flipper/features?keys%5B%5D=a%26b&keys%5B%5D=c%2Cd&exclude_gate_names=true")
         .to_return(status: 200, body: JSON.generate("features" => []))
 
       adapter = described_class.new(url: 'http://app.com/flipper')
-      adapter.get_multi([flipper["a&b"], flipper["c d"]])
+      adapter.get_multi([flipper["a&b"], flipper["c,d"]])
 
       expect(
-        a_request(:get, "http://app.com/flipper/features?keys=a%26b,c%20d&exclude_gate_names=true")
+        a_request(:get, "http://app.com/flipper/features?keys%5B%5D=a%26b&keys%5B%5D=c%2Cd&exclude_gate_names=true")
       ).to have_been_made.once
     end
   end

--- a/spec/flipper/adapters/http_spec.rb
+++ b/spec/flipper/adapters/http_spec.rb
@@ -161,6 +161,18 @@ RSpec.describe Flipper::Adapters::Http do
         adapter.get(flipper[:feature_panel])
       }.to raise_error(Flipper::Adapters::Http::Error)
     end
+
+    it "escapes special characters in the feature key" do
+      stub_request(:get, "http://app.com/flipper/features/a%2Fb+c")
+        .to_return(status: 404)
+
+      adapter = described_class.new(url: 'http://app.com/flipper')
+      adapter.get(flipper["a/b c"])
+
+      expect(
+        a_request(:get, "http://app.com/flipper/features/a%2Fb+c")
+      ).to have_been_made.once
+    end
   end
 
   describe "#get_multi" do
@@ -172,6 +184,18 @@ RSpec.describe Flipper::Adapters::Http do
       expect {
         adapter.get_multi([flipper[:feature_panel]])
       }.to raise_error(Flipper::Adapters::Http::Error)
+    end
+
+    it "escapes special characters in the feature keys" do
+      stub_request(:get, "http://app.com/flipper/features?keys=a%26b,c%20d&exclude_gate_names=true")
+        .to_return(status: 200, body: JSON.generate("features" => []))
+
+      adapter = described_class.new(url: 'http://app.com/flipper')
+      adapter.get_multi([flipper["a&b"], flipper["c d"]])
+
+      expect(
+        a_request(:get, "http://app.com/flipper/features?keys=a%26b,c%20d&exclude_gate_names=true")
+      ).to have_been_made.once
     end
   end
 

--- a/spec/flipper/api/v1/actions/features_spec.rb
+++ b/spec/flipper/api/v1/actions/features_spec.rb
@@ -111,6 +111,19 @@ RSpec.describe Flipper::Api::V1::Actions::Features do
       end
     end
 
+    context 'with a single encoded key containing a comma' do
+      before do
+        flipper["audit,log"].enable
+        get '/features?keys=audit%2Clog'
+      end
+
+      it 'treats the escaped comma as part of the feature key' do
+        expect(last_response.status).to eq(200)
+        keys = json_response.fetch('features').map { |feature| feature.fetch('key') }
+        expect(keys).to eq(["audit,log"])
+      end
+    end
+
     context 'with keys that are not existing features' do
       before do
         flipper[:search].disable

--- a/spec/flipper/api/v1/actions/features_spec.rb
+++ b/spec/flipper/api/v1/actions/features_spec.rb
@@ -97,6 +97,20 @@ RSpec.describe Flipper::Api::V1::Actions::Features do
       end
     end
 
+    context 'with keys containing commas' do
+      before do
+        flipper["audit,log"].enable
+        flipper[:search].enable
+        get '/features?keys[]=audit%2Clog&keys[]=search'
+      end
+
+      it 'treats escaped commas as part of the feature key' do
+        expect(last_response.status).to eq(200)
+        keys = json_response.fetch('features').map { |feature| feature.fetch('key') }.sort
+        expect(keys).to eq(["audit,log", "search"])
+      end
+    end
+
     context 'with keys that are not existing features' do
       before do
         flipper[:search].disable


### PR DESCRIPTION
## Summary

The HTTP adapter interpolated feature and gate keys raw into request paths and query strings (`"/features/#{feature.key}"`, `"/features?keys=#{csv_keys}"`), so a key containing `/`, `?`, `&`, `#`, a comma, or a space produced a malformed request or injected/overrode query parameters — and a key with a space raised `URI::InvalidURIError` outright.

This escapes each key with `URI.encode_www_form_component` at every interpolation site (`get`, `get_multi`, `remove`, `enable`, `disable`, `clear`); the API server already decodes keys with `Rack::Utils.unescape`, so the round-trip is preserved. It also fixes a spurious leading `&` in `Client#uri_for_path` when the base URL has no query string.

Added failing-first specs for `#get` (path escaping) and `#get_multi` (query escaping); the full HTTP adapter suite (108 examples, including the end-to-end WEBrick + `Flipper::Api` shared adapter specs) passes.