### PR TITLE
Avoid mutating adapter data during JSON export

### DIFF
--- a/lib/flipper/exporters/json/v1.rb
+++ b/lib/flipper/exporters/json/v1.rb
@@ -8,15 +8,11 @@ module Flipper
         VERSION = 1
 
         def call(adapter)
-          features = adapter.get_all
-
-          # Convert sets to arrays for json
-          features.each do |feature_key, gates|
-            gates.each do |key, value|
-              case value
-              when Set
-                features[feature_key][key] = value.to_a
-              end
+          # Build a new structure rather than mutating the hash returned by
+          # the adapter, which may be a reference to the adapter's live data.
+          features = adapter.get_all.transform_values do |gates|
+            gates.transform_values do |value|
+              value.is_a?(Set) ? value.to_a : value
             end
           end
 

--- a/spec/flipper/exporters/json/v1_spec.rb
+++ b/spec/flipper/exporters/json/v1_spec.rb
@@ -30,4 +30,19 @@ RSpec.describe Flipper::Exporters::Json::V1 do
       "search" => {actors: Set["User;1", "User;100"], boolean: nil, expression: nil, groups: Set["admins", "employees"], percentage_of_actors: "10", percentage_of_time: "15"},
     })
   end
+
+  it "does not mutate adapter data while exporting" do
+    adapter = Flipper::Adapters::Memory.new
+    flipper = Flipper.new(adapter)
+    flipper.enable_actor :search, Flipper::Actor.new('User;1')
+    flipper.enable_group :search, :admins
+
+    before = adapter.get_all
+
+    subject.call(adapter)
+
+    expect(adapter.get_all).to eq(before)
+    expect(adapter.get_all.dig("search", :actors)).to be_a(Set)
+    expect(adapter.get_all.dig("search", :groups)).to be_a(Set)
+  end
 end


### PR DESCRIPTION
## Summary
JSON export no longer risks changing adapter-owned feature data while preparing Set-backed gates for serialization. The exporter now builds a fresh feature structure for JSON output, preserving the existing export shape without feeding array-converted gates back into live adapter state.

## Validation
`bundle exec rspec spec/flipper/exporters/json/v1_spec.rb spec/flipper/exporters/json/export_spec.rb` (8 examples, 0 failures).

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
![GPT--5](https://img.shields.io/badge/GPT--5-000000)
