### PR TITLE
Document non-atomic write hazard in Moneta adapter

### DIFF
--- a/lib/flipper/adapters/moneta.rb
+++ b/lib/flipper/adapters/moneta.rb
@@ -2,6 +2,18 @@ require 'moneta'
 
 module Flipper
   module Adapters
+    # Public: Adapter that stores features in any Moneta-backed store.
+    #
+    # WARNING: This adapter is NOT safe for concurrent writes to the same
+    # feature. Set-based gates (actors, groups, percentage of actors) are
+    # updated with a non-atomic read-modify-write: the current value is read
+    # from the store, mutated in Ruby, and written back with no lock or
+    # transaction. Two writers racing on the same feature (e.g. enabling two
+    # different actors) will each read the same set and the second write will
+    # clobber the first, silently dropping one of the changes. Unlike the
+    # Memory and PStore adapters, Moneta provides no portable atomic primitive
+    # to guard against this. If you need concurrent writes to a shared store,
+    # prefer a native adapter such as ActiveRecord or Redis.
     class Moneta
       include ::Flipper::Adapter
 


### PR DESCRIPTION
The Moneta adapter updates set-based gates (actors, groups, percentage of actors) with a non-atomic read-modify-write and no lock or transaction, so two writers racing on the same feature can silently drop one of the changes. Unlike the Memory (Mutex) and PStore (transaction) adapters, Moneta offers no portable atomic primitive to guard against this. This adds a class-level caveat documenting the hazard and steering concurrent shared-store use toward native adapters like ActiveRecord or Redis. Documentation only — no behavior change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)