### PR TITLE
Fix concurrent feature memoization

### DIFF
--- a/lib/flipper/dsl.rb
+++ b/lib/flipper/dsl.rb
@@ -1,4 +1,5 @@
 require 'forwardable'
+require 'concurrent/map'
 
 module Flipper
   class DSL
@@ -23,7 +24,10 @@ module Flipper
       memoize = options.fetch(:memoize, true)
       adapter = Adapters::Memoizable.new(adapter) if memoize
       @adapter = adapter
-      @memoized_features = {}
+      # Concurrent::Map so a single DSL instance shared across threads (e.g. a
+      # Flipper.new(adapter) or Flipper::Cloud.new held in a constant) can
+      # memoize features without a non-atomic Hash mutation racing.
+      @memoized_features = Concurrent::Map.new
     end
 
     # Public: Check if a feature is enabled.
@@ -218,7 +222,9 @@ module Flipper
         raise ArgumentError, "#{name} must be a String or Symbol"
       end
 
-      @memoized_features[name.to_sym] ||= Feature.new(name, @adapter, instrumenter: instrumenter)
+      @memoized_features.compute_if_absent(name.to_sym) do
+        Feature.new(name, @adapter, instrumenter: instrumenter)
+      end
     end
 
     # Public: Preload the features with the given names.

--- a/spec/flipper/dsl_spec.rb
+++ b/spec/flipper/dsl_spec.rb
@@ -43,6 +43,26 @@ RSpec.describe Flipper::DSL do
       let(:feature) { dsl.send(method_name, :stats) }
       let(:dsl) { described_class.new(adapter, instrumenter: instrumenter) }
     end
+
+    it 'returns the same memoized instance across concurrent threads' do
+      dsl = described_class.new(adapter)
+      names = 100.times.map { |n| :"feature_#{n}" }
+
+      results = Array.new(10) do
+        Thread.new do
+          Thread.pass
+          names.map { |name| dsl.feature(name) }
+        end
+      end.map(&:value)
+
+      # Every thread should observe the exact same Feature instance per name,
+      # and building the memo concurrently must not raise or drop keys.
+      results.each do |features|
+        features.each_with_index do |feature, index|
+          expect(feature).to equal(results.first[index])
+        end
+      end
+    end
   end
 
   describe '#preload' do


### PR DESCRIPTION
DSL feature lookup now memoizes through a thread-safe map, so shared Flipper instances return one Feature object per feature even when multiple threads populate the cache at once. This replaces non-atomic Hash mutation with `Concurrent::Map#compute_if_absent` while preserving existing key normalization and feature construction behavior. Covered by a new concurrent DSL spec.

Tested with `bundle exec rspec spec/flipper/dsl_spec.rb` and `git diff --check`.

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
![GPT_5](https://img.shields.io/badge/GPT_5-000000)
