### PR TITLE
Warn about ActiveRecord value column migration

### DIFF
--- a/lib/flipper/adapters/active_record.rb
+++ b/lib/flipper/adapters/active_record.rb
@@ -299,7 +299,9 @@ module Flipper
 
       def warned_about_value_not_text?
         return @warned_about_value_not_text if defined?(@warned_about_value_not_text)
+
         @warned_about_value_not_text = true
+        false
       end
     end
   end

--- a/spec/flipper/adapters/active_record_spec.rb
+++ b/spec/flipper/adapters/active_record_spec.rb
@@ -92,6 +92,19 @@ RSpec.describe Flipper::Adapters::ActiveRecord do
           end
         end
 
+        it "warns once if the gates value column is not text" do
+          allow(Flipper::Adapters::ActiveRecord::Gate).
+            to receive(:column_for_attribute).
+            with(:value).
+            and_return(double(type: :string))
+
+          output = capture_output do
+            2.times { subject.features }
+          end
+
+          expect(output.scan("Your database needs to be migrated").size).to eq(1)
+        end
+
         context "ActiveRecord connection_pool" do
           before do
             clear_active_connections!


### PR DESCRIPTION
The ActiveRecord adapter now emits the migration warning when `flipper_gates.value` is still a string column, instead of suppressing it on the first connection check.
The guard still marks the warning as handled before checking the column type, so nested connection checks cannot recurse and later reads do not warn repeatedly.
Regression coverage simulates the legacy string column and verifies repeated reads produce exactly one warning.

Validation: `bundle exec rspec spec/flipper/adapters/active_record_spec.rb` (159 examples, 0 failures, 2 pending).

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
![Codex](https://img.shields.io/badge/GPT_5-000000)
