### PR TITLE
Redact sensitive headers from HTTP debug output

### DIFF
--- a/lib/flipper/adapters/http/client.rb
+++ b/lib/flipper/adapters/http/client.rb
@@ -1,6 +1,7 @@
 require 'uri'
 require 'openssl'
 require 'flipper/version'
+require 'flipper/adapters/http/redacted_debug_output'
 
 module Flipper
   module Adapters
@@ -91,7 +92,7 @@ module Flipper
           http.open_timeout = @open_timeout if @open_timeout
           http.max_retries = @max_retries if @max_retries
           http.write_timeout = @write_timeout if @write_timeout
-          http.set_debug_output(@debug_output) if @debug_output
+          http.set_debug_output(RedactedDebugOutput.wrap(@debug_output)) if @debug_output
 
           if uri.scheme == HTTPS_SCHEME
             http.use_ssl = true

--- a/lib/flipper/adapters/http/redacted_debug_output.rb
+++ b/lib/flipper/adapters/http/redacted_debug_output.rb
@@ -17,13 +17,15 @@ module Flipper
 
         # Matches "<sensitive-header>: <value>" up to (but not including) the
         # next line terminator. Net::HTTP writes request headers via
-        # String#dump, so line breaks appear as the escaped "\r\n" sequence; the
-        # value char class excludes backslash and quote so it stops there. Raw
-        # CRLFs and a closing quote are handled too, just in case.
+        # String#dump, so the value may itself contain escape sequences (\t,
+        # \", \\, ...) and line breaks appear as the escaped "\r\n" sequence. The
+        # value alternation consumes escaped chars (other than \r/\n) and plain
+        # chars, stopping at the escaped or raw line terminator or the closing
+        # quote. Consuming escapes ensures a value that contains one is still
+        # fully redacted rather than leaking past the first backslash.
         PATTERN = Regexp.new(
           '((?:' + Regexp.union(SENSITIVE_HEADERS).source + '):[ \t]*)' +
-          '[^\r\n"\\\\]*' +
-          '(?=\\\\r|\r|\n|"|\z)',
+          '(?:\\\\[^rn]|[^\r\n"\\\\])*',
           Regexp::IGNORECASE
         )
 

--- a/lib/flipper/adapters/http/redacted_debug_output.rb
+++ b/lib/flipper/adapters/http/redacted_debug_output.rb
@@ -1,0 +1,68 @@
+module Flipper
+  module Adapters
+    class Http
+      # Wraps the IO-like object passed to Net::HTTP#set_debug_output and
+      # redacts the values of sensitive request headers (auth tokens, etc.)
+      # before they are written. Without this, enabling debug output dumps the
+      # raw request — including the flipper-cloud-token bearer credential — in
+      # cleartext to STDOUT/logs.
+      class RedactedDebugOutput
+        # Header names whose values must never reach debug output.
+        SENSITIVE_HEADERS = %w[
+          flipper-cloud-token
+          authorization
+        ].freeze
+
+        REDACTED = "[REDACTED]".freeze
+
+        # Matches "<sensitive-header>: <value>" up to (but not including) the
+        # next line terminator. Net::HTTP writes request headers via
+        # String#dump, so line breaks appear as the escaped "\r\n" sequence; the
+        # value char class excludes backslash and quote so it stops there. Raw
+        # CRLFs and a closing quote are handled too, just in case.
+        PATTERN = Regexp.new(
+          '((?:' + Regexp.union(SENSITIVE_HEADERS).source + '):[ \t]*)' +
+          '[^\r\n"\\\\]*' +
+          '(?=\\\\r|\r|\n|"|\z)',
+          Regexp::IGNORECASE
+        )
+
+        # Wraps output unless it is nil or already wrapped.
+        def self.wrap(output)
+          return output if output.nil? || output.is_a?(self)
+          new(output)
+        end
+
+        def self.redact(message)
+          return message unless message.is_a?(String)
+          message.gsub(PATTERN) { "#{$1}#{REDACTED}" }
+        end
+
+        def initialize(output)
+          @output = output
+        end
+
+        def <<(message)
+          @output << self.class.redact(message)
+          self
+        end
+
+        private
+
+        # Behave like the wrapped output for anything Net::HTTP doesn't route
+        # through <<.
+        def method_missing(name, *args, &block)
+          if @output.respond_to?(name)
+            @output.public_send(name, *args, &block)
+          else
+            super
+          end
+        end
+
+        def respond_to_missing?(name, include_private = false)
+          @output.respond_to?(name, include_private) || super
+        end
+      end
+    end
+  end
+end

--- a/spec/flipper/adapters/http/redacted_debug_output_spec.rb
+++ b/spec/flipper/adapters/http/redacted_debug_output_spec.rb
@@ -57,6 +57,16 @@ RSpec.describe Flipper::Adapters::Http::RedactedDebugOutput do
       expect(redacted).to include("Accept: */*")
     end
 
+    it "fully redacts values containing dump-escaped characters" do
+      # A token with a tab and a quote survives String#dump as escape
+      # sequences (\t, \") embedded in the value.
+      request = "Flipper-Cloud-Token: se\tcr\"et\r\nAccept: */*\r\n".dump
+      redacted = described_class.redact(request)
+      expect(redacted).to include("Flipper-Cloud-Token: [REDACTED]")
+      expect(redacted).not_to include("cr")
+      expect(redacted).to include("Accept: */*")
+    end
+
     it "returns non-string messages unchanged" do
       expect(described_class.redact(nil)).to be_nil
       expect(described_class.redact(42)).to eq(42)

--- a/spec/flipper/adapters/http/redacted_debug_output_spec.rb
+++ b/spec/flipper/adapters/http/redacted_debug_output_spec.rb
@@ -1,0 +1,87 @@
+require "flipper/adapters/http/redacted_debug_output"
+
+RSpec.describe Flipper::Adapters::Http::RedactedDebugOutput do
+  # Net::HTTP writes request headers to debug output via String#dump, so the
+  # separators show up as the escaped "\r\n" sequence.
+  let(:dumped_request) do
+    ("POST /features HTTP/1.1\r\n" \
+     "Content-Type: application/json\r\n" \
+     "Accept-Encoding: gzip\r\n" \
+     "Flipper-Cloud-Token: super-secret-token\r\n" \
+     "Authorization: Basic dXNlcjpwYXNz\r\n\r\n").dump
+  end
+
+  describe ".wrap" do
+    it "returns nil for nil" do
+      expect(described_class.wrap(nil)).to be_nil
+    end
+
+    it "wraps a plain output object" do
+      output = +""
+      expect(described_class.wrap(output)).to be_a(described_class)
+    end
+
+    it "does not double-wrap" do
+      wrapped = described_class.wrap(+"")
+      expect(described_class.wrap(wrapped)).to be(wrapped)
+    end
+  end
+
+  describe ".redact" do
+    subject { described_class.redact(dumped_request) }
+
+    it "redacts the flipper-cloud-token value" do
+      expect(subject).to include("Flipper-Cloud-Token: [REDACTED]")
+      expect(subject).not_to include("super-secret-token")
+    end
+
+    it "redacts the authorization value" do
+      expect(subject).to include("Authorization: [REDACTED]")
+      expect(subject).not_to include("dXNlcjpwYXNz")
+    end
+
+    it "leaves non-sensitive headers untouched" do
+      expect(subject).to include("Content-Type: application/json")
+      expect(subject).to include("Accept-Encoding: gzip")
+    end
+
+    it "is case-insensitive about header names" do
+      redacted = described_class.redact("flipper-cloud-token: secret\r\n".dump)
+      expect(redacted).not_to include("secret")
+      expect(redacted).to include("[REDACTED]")
+    end
+
+    it "handles raw CRLF separators too" do
+      redacted = described_class.redact("Flipper-Cloud-Token: secret\r\nAccept: */*\r\n")
+      expect(redacted).not_to include("secret")
+      expect(redacted).to include("Accept: */*")
+    end
+
+    it "returns non-string messages unchanged" do
+      expect(described_class.redact(nil)).to be_nil
+      expect(described_class.redact(42)).to eq(42)
+    end
+  end
+
+  describe "#<<" do
+    it "writes redacted output to the wrapped object" do
+      output = +""
+      wrapped = described_class.new(output)
+      wrapped << dumped_request
+      expect(output).not_to include("super-secret-token")
+      expect(output).not_to include("dXNlcjpwYXNz")
+      expect(output).to include("[REDACTED]")
+    end
+
+    it "returns self so writes can be chained" do
+      wrapped = described_class.new(+"")
+      expect(wrapped << "anything").to be(wrapped)
+    end
+  end
+
+  it "delegates unknown methods to the wrapped output" do
+    output = double("output", flush: :flushed)
+    wrapped = described_class.new(output)
+    expect(wrapped.flush).to eq(:flushed)
+  end
+end

--- a/spec/flipper/adapters/http_spec.rb
+++ b/spec/flipper/adapters/http_spec.rb
@@ -584,8 +584,27 @@ RSpec.describe Flipper::Adapters::Http do
       user_agent = Net::HTTP.new("app.com")
       allow(Net::HTTP).to receive(:new).and_return(user_agent)
 
-      expect(user_agent).to receive(:set_debug_output).with(debug_output)
+      expect(user_agent).to receive(:set_debug_output).with(
+        an_instance_of(Flipper::Adapters::Http::RedactedDebugOutput)
+      )
       subject.get(feature)
+    end
+
+    it 'redacts sensitive headers from debug output' do
+      user_agent = Net::HTTP.new("app.com")
+      allow(Net::HTTP).to receive(:new).and_return(user_agent)
+
+      allow(debug_output).to receive(:<<)
+      redacted = nil
+      allow(user_agent).to receive(:set_debug_output) { |output| redacted = output }
+      subject.get(feature)
+
+      redacted << 'Flipper-Cloud-Token: super-secret'.dump
+      redacted << 'Authorization: Basic dXNlcjpwYXNz'.dump
+
+      expect(debug_output).to have_received(:<<).with(a_string_including('[REDACTED]')).twice
+      expect(debug_output).not_to have_received(:<<).with(a_string_including('super-secret'))
+      expect(debug_output).not_to have_received(:<<).with(a_string_including('dXNlcjpwYXNz'))
     end
   end
 


### PR DESCRIPTION
## Problem

Enabling `FLIPPER_CLOUD_DEBUG_OUTPUT_STDOUT` (or passing `debug_output:`) handed the raw stream straight to `Net::HTTP#set_debug_output`, which dumps the full request — including the `flipper-cloud-token` bearer credential and HTTP Basic `Authorization` header — in cleartext to STDOUT/logs, leaking the token to centralized logging.

## Fix

Wrap the debug stream in a new `Flipper::Adapters::Http::RedactedDebugOutput`, which replaces the values of sensitive headers (`flipper-cloud-token`, `authorization`) with `[REDACTED]` before they reach the underlying stream, leaving header names and all other output intact. Wrapping happens at the HTTP client (`client.rb:95`) so every consumer benefits, not just cloud, and `.wrap` is a no-op on `nil` and won't double-wrap. Covered by a new unit spec plus an updated http adapter spec; all 119 http adapter examples pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)