### PR TITLE
Return false for type-mismatched comparison operands

### DIFF
--- a/lib/flipper/expressions/comparable.rb
+++ b/lib/flipper/expressions/comparable.rb
@@ -7,6 +7,10 @@ module Flipper
 
       def self.call(left, right)
         left.respond_to?(operator) && right.respond_to?(operator) && left.public_send(operator, right)
+      rescue ArgumentError
+        # Operands respond to the operator but aren't type-compatible
+        # (e.g. "25" > 21), which raises ArgumentError. Treat as false.
+        false
       end
     end
   end

--- a/spec/flipper/expressions/greater_than_or_equal_to_spec.rb
+++ b/spec/flipper/expressions/greater_than_or_equal_to_spec.rb
@@ -17,6 +17,11 @@ RSpec.describe Flipper::Expressions::GreaterThanOrEqualTo do
       expect(described_class.call(1, nil)).to be(false)
     end
 
+    it "returns false when operands are not type-compatible" do
+      expect(described_class.call("25", 21)).to be(false)
+      expect(described_class.call(21, "25")).to be(false)
+    end
+
     it "raises ArgumentError with no arguments" do
       expect { described_class.call }.to raise_error(ArgumentError)
     end

--- a/spec/flipper/expressions/greater_than_spec.rb
+++ b/spec/flipper/expressions/greater_than_spec.rb
@@ -17,6 +17,11 @@ RSpec.describe Flipper::Expressions::GreaterThan do
       expect(described_class.call(1, nil)).to be(false)
     end
 
+    it "returns false when operands are not type-compatible" do
+      expect(described_class.call("25", 21)).to be(false)
+      expect(described_class.call(21, "25")).to be(false)
+    end
+
     it "raises ArgumentError with no arguments" do
       expect { described_class.call }.to raise_error(ArgumentError)
     end

--- a/spec/flipper/expressions/less_than_or_equal_to_spec.rb
+++ b/spec/flipper/expressions/less_than_or_equal_to_spec.rb
@@ -17,6 +17,11 @@ RSpec.describe Flipper::Expressions::LessThanOrEqualTo do
       expect(described_class.call(1, nil)).to be(false)
     end
 
+    it "returns false when operands are not type-compatible" do
+      expect(described_class.call("25", 21)).to be(false)
+      expect(described_class.call(21, "25")).to be(false)
+    end
+
     it "raises ArgumentError with no arguments" do
       expect { described_class.call }.to raise_error(ArgumentError)
     end

--- a/spec/flipper/expressions/less_than_spec.rb
+++ b/spec/flipper/expressions/less_than_spec.rb
@@ -21,6 +21,11 @@ RSpec.describe Flipper::Expressions::LessThan do
       expect(described_class.call(1, nil)).to be(false)
     end
 
+    it "returns false when operands are not type-compatible" do
+      expect(described_class.call("25", 21)).to be(false)
+      expect(described_class.call(21, "25")).to be(false)
+    end
+
     it "raises ArgumentError with no arguments" do
       expect { described_class.call }.to raise_error(ArgumentError)
     end


### PR DESCRIPTION
Comparison expressions (`greater_than`, `less_than`, and their `_or_equal_to` variants) only guarded operands with `respond_to?(operator)`, which confirms both sides respond to `>`/`<` but not that they're type-compatible. Because property values commonly arrive as strings from JSON, comparing something like `"25" >= 21` raised `ArgumentError` out of `Feature#enabled?`, crashing the entire flag check instead of returning false. This rescues `ArgumentError` in `Comparable.call` and treats a failed comparison as `false`, consistent with how missing/`nil` properties already behave. Added specs covering type-mismatched operands (both orderings) for all four comparison expressions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)