### PR TITLE
Fix race_condition_ttl being a silent no-op in ActiveSupportCacheStore

### DIFF
--- a/lib/flipper/adapters/active_support_cache_store.rb
+++ b/lib/flipper/adapters/active_support_cache_store.rb
@@ -80,7 +80,7 @@ module Flipper
       def write_options
         write_options = {}
         write_options[:expires_in] = @ttl if @ttl
-        write_options[:race_condition_ttl] if @race_condition_ttl
+        write_options[:race_condition_ttl] = @race_condition_ttl if @race_condition_ttl
         write_options
       end
     end

--- a/spec/flipper/adapters/active_support_cache_store_spec.rb
+++ b/spec/flipper/adapters/active_support_cache_store_spec.rb
@@ -52,6 +52,21 @@ RSpec.describe Flipper::Adapters::ActiveSupportCacheStore do
     expect(adapter.race_condition_ttl).to be(nil)
   end
 
+  it "passes race_condition_ttl to the cache when writing" do
+    expect(cache).to receive(:fetch)
+      .with(anything, hash_including(race_condition_ttl: race_condition_ttl))
+      .and_call_original
+    adapter.get(flipper[:stats])
+  end
+
+  it "does not pass race_condition_ttl to the cache when not configured" do
+    adapter = described_class.new(memory_adapter, cache, 10)
+    expect(cache).to receive(:fetch)
+      .with(anything, hash_excluding(:race_condition_ttl))
+      .and_call_original
+    adapter.get(flipper[:stats])
+  end
+
   it "knows features_cache_key" do
     expect(adapter.features_cache_key).to eq("flipper/v1/features")
   end


### PR DESCRIPTION
`write_options` read the `:race_condition_ttl` key as a bare expression instead of assigning to it, so a configured `race_condition_ttl:` was never passed to the underlying cache. Users setting it to guard against cache stampedes got no protection, with no error or warning. This one-line fix assigns the value, and adds specs asserting the option is passed to the cache when configured and omitted when not.

🤖 Generated with [Claude Code](https://claude.com/claude-code)