### PR TITLE
Stop opening cloud migrate URLs automatically

### DIFF
--- a/lib/flipper/cli.rb
+++ b/lib/flipper/cli.rb
@@ -103,7 +103,6 @@ module Flipper
             if result.url
               ui.info "Migrating to Flipper Cloud..."
               ui.info result.url
-              system("open", result.url)
             else
               message = "Migration failed (HTTP #{result.code})"
               message << ": #{result.message}" if result.message

--- a/lib/flipper/cli.rb
+++ b/lib/flipper/cli.rb
@@ -102,6 +102,7 @@ module Flipper
             result = Flipper::Cloud.migrate(Flipper)
             if result.url
               ui.info "Migrating to Flipper Cloud..."
+              ui.info "Open this URL in your browser to finish migrating your features:"
               ui.info result.url
             else
               message = "Migration failed (HTTP #{result.code})"

--- a/spec/flipper/cli_spec.rb
+++ b/spec/flipper/cli_spec.rb
@@ -176,11 +176,21 @@ RSpec.describe Flipper::CLI do
       allow(Flipper::Cloud).to receive(:migrate).and_return(
         Flipper::Cloud::MigrateResult.new(code: 200, url: "https://www.flippercloud.io/cloud/setup/abc123")
       )
-      allow(cli).to receive(:system)
     end
 
     it "prints the cloud URL" do
+      expect(cli).not_to receive(:system)
+
       expect(subject).to have_attributes(status: 0, stdout: /flippercloud\.io/)
+    end
+
+    it "does not open URLs returned by the migration API" do
+      allow(Flipper::Cloud).to receive(:migrate).and_return(
+        Flipper::Cloud::MigrateResult.new(code: 200, url: "file:///Applications/Calculator.app")
+      )
+      expect(cli).not_to receive(:system)
+
+      expect(subject).to have_attributes(status: 0, stdout: %r{file:///Applications/Calculator.app})
     end
   end
 

--- a/spec/flipper/cli_spec.rb
+++ b/spec/flipper/cli_spec.rb
@@ -178,10 +178,13 @@ RSpec.describe Flipper::CLI do
       )
     end
 
-    it "prints the cloud URL" do
+    it "prints instructions and the cloud URL" do
       expect(cli).not_to receive(:system)
 
-      expect(subject).to have_attributes(status: 0, stdout: /flippercloud\.io/)
+      expect(subject).to have_attributes(
+        status: 0,
+        stdout: /Open this URL in your browser to finish migrating your features:\nhttps:\/\/www\.flippercloud\.io/
+      )
     end
 
     it "does not open URLs returned by the migration API" do


### PR DESCRIPTION
## Summary
`flipper cloud migrate` now leaves the returned migration link in the terminal instead of launching it through macOS, so a compromised or overridden Cloud endpoint cannot trigger an automatic local URI open.

The CLI still prints legitimate migration links, and coverage now asserts both trusted HTTPS links and attacker-controlled `file://` responses avoid `system`.

## Validation
`bundle exec rspec spec/flipper/cli_spec.rb:172`

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
![GPT-5](https://img.shields.io/badge/GPT--5-000000)
