### PR TITLE
Enforce webhook signature timestamp tolerance

### DIFF
--- a/lib/flipper/cloud.rb
+++ b/lib/flipper/cloud.rb
@@ -24,13 +24,15 @@ module Flipper
     def self.app(flipper = nil, options = {})
       env_key = options.fetch(:env_key, 'flipper')
       memoizer_options = options.fetch(:memoizer_options, {})
+      middleware_options = {env_key: env_key}
+      middleware_options[:signature_tolerance] = options[:signature_tolerance] if options.key?(:signature_tolerance)
 
       app = ->(_) { [404, { Rack::CONTENT_TYPE => 'application/json'.freeze }, ['{}'.freeze]] }
       builder = Rack::Builder.new
       yield builder if block_given?
       builder.use Flipper::Middleware::SetupEnv, flipper, env_key: env_key
       builder.use Flipper::Middleware::Memoizer, memoizer_options.merge(env_key: env_key)
-      builder.use Flipper::Cloud::Middleware, env_key: env_key
+      builder.use Flipper::Cloud::Middleware, middleware_options
       builder.run app
       klass = self
       app = builder.to_app

--- a/lib/flipper/cloud/middleware.rb
+++ b/lib/flipper/cloud/middleware.rb
@@ -9,10 +9,15 @@ module Flipper
       WEBHOOK_PATH = %r{\A/webhooks\/?\Z}
       # Internal: The root path to match for requests.
       ROOT_PATH = %r{\A/\Z}
+      # Internal: Number of seconds a signed webhook remains valid. Bounds the
+      # window in which a captured, validly-signed request can be replayed,
+      # while staying loose enough to tolerate delivery retries and clock skew.
+      DEFAULT_SIGNATURE_TOLERANCE = 60 * 5
 
       def initialize(app, options = {})
         @app = app
         @env_key = options.fetch(:env_key, 'flipper')
+        @signature_tolerance = options.fetch(:signature_tolerance, DEFAULT_SIGNATURE_TOLERANCE)
       end
 
       def call(env)
@@ -33,7 +38,7 @@ module Flipper
 
           begin
             message_verifier = MessageVerifier.new(secret: flipper.sync_secret)
-            if message_verifier.verify(payload, signature)
+            if message_verifier.verify(payload, signature, tolerance: @signature_tolerance)
               begin
                 flipper.sync(cache_bust: true)
                 body = JSON.generate({

--- a/spec/flipper/cloud/middleware_spec.rb
+++ b/spec/flipper/cloud/middleware_spec.rb
@@ -84,6 +84,38 @@ RSpec.describe Flipper::Cloud::Middleware do
     end
   end
 
+  context 'when signature timestamp is outside the tolerance' do
+    let(:app) { Flipper::Cloud.app(flipper) }
+    let(:timestamp) { Time.now - (60 * 60) }
+
+    it 'rejects the replayed webhook without syncing' do
+      stub = stub_request_for_token('regular')
+      env = {
+        "HTTP_FLIPPER_CLOUD_SIGNATURE" => signature_header_value,
+      }
+      post '/', request_body, env
+
+      expect(last_response.status).to eq(400)
+      expect(stub).not_to have_been_requested
+    end
+  end
+
+  context 'when initialized with a custom signature tolerance' do
+    let(:app) { Flipper::Cloud.app(flipper, signature_tolerance: 60 * 60 * 2) }
+    let(:timestamp) { Time.now - (60 * 60) }
+
+    it 'uses the provided tolerance when verifying the webhook' do
+      stub = stub_request_for_token('regular')
+      env = {
+        "HTTP_FLIPPER_CLOUD_SIGNATURE" => signature_header_value,
+      }
+      post '/', request_body, env
+
+      expect(last_response.status).to eq(200)
+      expect(stub).to have_been_requested
+    end
+  end
+
   context "when flipper cloud responds with 402" do
     let(:app) { Flipper::Cloud.app(flipper) }
 


### PR DESCRIPTION
`Flipper::Cloud::Middleware` verified the webhook HMAC signature but never passed a `tolerance`, so the freshness check in `MessageVerifier#verify` was skipped — a captured, validly-signed webhook could be replayed by an unauthenticated caller indefinitely, each replay forcing `flipper.sync(cache_bust: true)` (a bounded amplification-DoS, not an integrity break). This passes a default 5-minute tolerance (overridable via the `:signature_tolerance` option to `Flipper::Cloud.app`) and rejects stale webhooks with a 400. The 5-minute window absorbs clock skew, and since Flipper Cloud re-signs every delivery retry with a fresh timestamp, legitimate retries are never rejected. Follows Stripe's convention of rejecting only too-old timestamps (not future ones).

🤖 Generated with [Claude Code](https://claude.com/claude-code)