### PR TITLE
Add "I deploy on Fridays" merch callout to UI and README

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,6 +37,10 @@ Or install it yourself with:
 
 [💌 &nbsp;Subscribe](https://blog.flippercloud.io/#/portal/signup) - we'll send you short and sweet emails when we release new versions ([examples](https://blog.flippercloud.io/tag/releases/)).
 
+## Merch
+
+Do you deploy on Fridays? [👕 Get the tee](https://shop.verygoodsoftware.company/product/i-deploy-on-fridays-tee?utm_source=oss&utm_medium=readme&utm_campaign=merch).
+
 ## Getting Started
 
 Use `Flipper#enabled?` in your app to check if a feature is enabled.

--- a/lib/flipper/ui/views/layout.erb
+++ b/lib/flipper/ui/views/layout.erb
@@ -80,6 +80,12 @@
           </div>
         </div>
       <% end %>
+
+      <% if Flipper::UI.configuration.fun %>
+        <div class="text-center text-muted small mt-4">
+          👕 Do you deploy on Fridays? <a href="https://shop.verygoodsoftware.company/product/i-deploy-on-fridays-tee?utm_source=oss&utm_medium=ui&utm_campaign=merch">Get&nbsp;the&nbsp;tee</a>.
+        </div>
+      <% end %>
     </div>
 
     <script src="<%= script_name + popper_js[:src] %>" integrity="<%= popper_js[:hash] %>" crossorigin="anonymous"></script>

--- a/lib/flipper/ui/views/layout.erb
+++ b/lib/flipper/ui/views/layout.erb
@@ -57,6 +57,10 @@
           <li class="nav-item ms-auto text-muted small">
             <a href="https://www.flippercloud.io/docs/ui?utm_source=oss&utm_medium=ui&utm_campaign=docs">Docs</a>
             &bull;
+            <% if Flipper::UI.configuration.fun %>
+              <a href="https://shop.verygoodsoftware.company/product/i-deploy-on-fridays-tee?utm_source=oss&utm_medium=ui&utm_campaign=merch" title="Do you deploy on Fridays?">Shirt</a>
+              &bull;
+            <% end %>
             Version: <%= Flipper::VERSION %>
           </li>
         </ul>
@@ -78,12 +82,6 @@
               <small>For audit history, rollback, finer-grained permissions, and multi-environment sync check out <a href="https://www.flippercloud.io/?utm_source=oss&utm_medium=ui&utm_campaign=spread_the_love">Flipper&nbsp;Cloud</a>. We even have a free tier!</small>
             </div>
           </div>
-        </div>
-      <% end %>
-
-      <% if Flipper::UI.configuration.fun %>
-        <div class="text-center text-muted small mt-4">
-          👕 Do you deploy on Fridays? <a href="https://shop.verygoodsoftware.company/product/i-deploy-on-fridays-tee?utm_source=oss&utm_medium=ui&utm_campaign=merch">Get&nbsp;the&nbsp;tee</a>.
         </div>
       <% end %>
     </div>

--- a/spec/flipper/ui/actions/features_spec.rb
+++ b/spec/flipper/ui/actions/features_spec.rb
@@ -91,8 +91,8 @@ RSpec.describe Flipper::UI::Actions::Features do
       context "when fun mode is enabled" do
         let(:fun_mode) { true }
 
-        it 'renders the tee link' do
-          expect(last_response.body).to include('Do you deploy on Fridays?')
+        it 'renders the shirt link' do
+          expect(last_response.body).to include('>Shirt</a>')
           expect(last_response.body).to include('i-deploy-on-fridays-tee')
         end
       end
@@ -100,8 +100,8 @@ RSpec.describe Flipper::UI::Actions::Features do
       context "when fun mode is disabled" do
         let(:fun_mode) { false }
 
-        it 'does not render the tee link' do
-          expect(last_response.body).not_to include('Do you deploy on Fridays?')
+        it 'does not render the shirt link' do
+          expect(last_response.body).not_to include('>Shirt</a>')
           expect(last_response.body).not_to include('i-deploy-on-fridays-tee')
         end
       end

--- a/spec/flipper/ui/actions/features_spec.rb
+++ b/spec/flipper/ui/actions/features_spec.rb
@@ -77,6 +77,36 @@ RSpec.describe Flipper::UI::Actions::Features do
       end
     end
 
+    context "merch callout" do
+      before do
+        @original_fun_enabled = Flipper::UI.configuration.fun
+        Flipper::UI.configuration.fun = fun_mode
+        get '/features'
+      end
+
+      after do
+        Flipper::UI.configuration.fun = @original_fun_enabled
+      end
+
+      context "when fun mode is enabled" do
+        let(:fun_mode) { true }
+
+        it 'renders the tee link' do
+          expect(last_response.body).to include('Do you deploy on Fridays?')
+          expect(last_response.body).to include('i-deploy-on-fridays-tee')
+        end
+      end
+
+      context "when fun mode is disabled" do
+        let(:fun_mode) { false }
+
+        it 'does not render the tee link' do
+          expect(last_response.body).not_to include('Do you deploy on Fridays?')
+          expect(last_response.body).not_to include('i-deploy-on-fridays-tee')
+        end
+      end
+    end
+
     context "when in read-only mode" do
       before { allow(flipper).to receive(:read_only?) { true } }
 


### PR DESCRIPTION
Features the [I deploy on Fridays tee](https://shop.verygoodsoftware.company/product/i-deploy-on-fridays-tee) in two low-key spots. Adds a small, muted callout to the Flipper UI footer (on every page, gated behind the existing `fun` config so buttoned-up installs can opt out) and a short `## Merch` section in the README. Both links carry `utm_*` params (`ui` vs `readme`) so we can see which surface drives sales. Specs cover the fun-mode toggle in both directions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)