### PR TITLE
Normalize Flipper UI feature names to ASCII on create

### DIFF
--- a/lib/flipper/ui/actions/features.rb
+++ b/lib/flipper/ui/actions/features.rb
@@ -41,7 +41,7 @@ module Flipper
             halt view_response(:feature_creation_disabled)
           end
 
-          value = params['value'].to_s.strip
+          value = Util.normalize_feature_name(params['value'])
 
           if Util.blank?(value)
             error = "#{value.inspect} is not a valid feature name."

--- a/lib/flipper/ui/util.rb
+++ b/lib/flipper/ui/util.rb
@@ -14,6 +14,16 @@ module Flipper
         Rack::Utils.unescape(str)
       end
 
+      # NFKD decomposes accented/compatibility characters so their base
+      # characters survive the ASCII conversion; anything unmappable
+      # (including invisible characters like zero-width spaces) is dropped.
+      def self.normalize_feature_name(str)
+        str.to_s
+           .unicode_normalize(:nfkd)
+           .encode(Encoding::US_ASCII, invalid: :replace, undef: :replace, replace: '')
+           .strip
+      end
+
       def self.blank?(str)
         str.to_s !~ NON_WHITESPACE_REGEXP
       end

--- a/spec/flipper/ui/actions/features_spec.rb
+++ b/spec/flipper/ui/actions/features_spec.rb
@@ -224,9 +224,35 @@ RSpec.describe Flipper::UI::Actions::Features do
         end
       end
 
+      context 'feature name contains accented and invisible characters' do
+        let(:feature_name) { "f\u200Beá\u2060ture" }
+
+        it 'adds feature normalized to ascii' do
+          expect(flipper.features.map(&:key)).to include('feature')
+        end
+
+        it 'redirects to normalized feature' do
+          expect(last_response.status).to be(302)
+          expect(last_response.headers['location']).to eq('/features/feature')
+        end
+      end
+
       context 'for an invalid feature name' do
         context 'empty feature name' do
           let(:feature_name) { '' }
+
+          it 'does not add feature' do
+            expect(flipper.features.map(&:key)).to eq([])
+          end
+
+          it 'redirects back to feature' do
+            expect(last_response.status).to be(302)
+            expect(last_response.headers['location']).to eq('/features/new?error=%22%22+is+not+a+valid+feature+name.')
+          end
+        end
+
+        context 'feature name that normalizes to empty' do
+          let(:feature_name) { "\u200B\u2060" }
 
           it 'does not add feature' do
             expect(flipper.features.map(&:key)).to eq([])

--- a/spec/flipper/ui/util_spec.rb
+++ b/spec/flipper/ui/util_spec.rb
@@ -14,4 +14,22 @@ RSpec.describe Flipper::UI::Util do
       end
     end
   end
+
+  describe '#normalize_feature_name' do
+    it 'transliterates accented characters to ascii' do
+      expect(described_class.normalize_feature_name('café')).to eq('cafe')
+    end
+
+    it 'removes invisible characters' do
+      expect(described_class.normalize_feature_name("f\u200Beá\u2060ture")).to eq('feature')
+    end
+
+    it 'strips surrounding whitespace' do
+      expect(described_class.normalize_feature_name('  notifications_next  ')).to eq('notifications_next')
+    end
+
+    it 'returns empty string for nil' do
+      expect(described_class.normalize_feature_name(nil)).to eq('')
+    end
+  end
 end


### PR DESCRIPTION
I had a issue where I copied a flipper feature name from somewhere that included a invisible character. This resulted in two flags that essentially read as the same string in the Flipper UI. 

This change means that feature names submitted through the UI are now NFKD-normalized and encoded to US-ASCII, transliterating accented characters (café -> cafe) and dropping invisible/unmappable characters like zero-width spaces. Names that normalize to empty fall through to the existing invalid name error.