### PR TITLE
perf: short-circuit gate checks so `enabled?` can return faster

### DIFF
--- a/lib/flipper/gates/actor.rb
+++ b/lib/flipper/gates/actor.rb
@@ -25,8 +25,11 @@ module Flipper
       def open?(context)
         return false unless context.actors?
 
+        enabled_actors = context.values.actors
+        return false if enabled_actors.empty?
+
         context.actors.any? do |actor|
-          context.values.actors.include?(actor.value)
+          enabled_actors.include?(actor.value)
         end
       end
 

--- a/lib/flipper/gates/percentage_of_actors.rb
+++ b/lib/flipper/gates/percentage_of_actors.rb
@@ -31,7 +31,17 @@ module Flipper
       # Returns true if gate open for any actors, false if not.
       def open?(context)
         return false unless context.actors?
-        id = "#{context.feature_name}#{context.actors.map(&:value).sort.join}"
+
+        percentage = context.values.percentage_of_actors
+        return false if percentage <= 0
+        return true if percentage >= 100
+
+        actors = context.actors
+        id = if actors.size == 1
+          "#{context.feature_name}#{actors.first.value}"
+        else
+          "#{context.feature_name}#{actors.map(&:value).sort.join}"
+        end
         # NOTE: `crc32 % 100_000` has a tiny modulo bias (2**32 is not a
         # multiple of 100_000, so buckets 0..67_295 are ~0.0023% over-
         # represented). This is intentionally left as-is: the bias is
@@ -39,7 +49,7 @@ module Flipper
         # which would re-bucket essentially every actor on upgrade and
         # silently flip who is enabled. Stable, deterministic bucketing
         # matters far more here than perfect uniformity. Do not change.
-        Zlib.crc32(id) % (100 * SCALING_FACTOR) < context.values.percentage_of_actors * SCALING_FACTOR
+        Zlib.crc32(id) % (100 * SCALING_FACTOR) < percentage * SCALING_FACTOR
       end
 
       def protects?(thing)

--- a/lib/flipper/gates/percentage_of_time.rb
+++ b/lib/flipper/gates/percentage_of_time.rb
@@ -23,7 +23,10 @@ module Flipper
       #
       # Returns true if gate open for thing, false if not.
       def open?(context)
-        rand < (context.values.percentage_of_time / 100.0)
+        percentage = context.values.percentage_of_time
+        return false if percentage <= 0
+        return true if percentage >= 100
+        rand < (percentage / 100.0)
       end
 
       def protects?(thing)


### PR DESCRIPTION
AI Disclosure: This was generated with Claude Code w/ Fable 5.

I've reviewed the changes to make sure they make sense and will not cause regressions, re-run Claude over them to additionally review the changes and confirm the changes were safe, run the tests on this branch locally on my Mac, and written this PR description by hand except the benchmark section.

TL;DR we can bail out earlier in various places to avoid extra work/memory allocations in many cases.

Every time `Flipper.enabled?(:flag, user)` was called previously on a boolean flag set to `off`, extra work was done checking every gate type. If we can bail earlier in each gate check, things can get faster in many cases.

- In the main actor gate, we can bail early if there are no actors configured.
- In the `percentage_of_actors` gate, we can bail early if the percentage is set to 100% or 0%, and also avoid sort/map/join if there's only one actor.
- In the `percentage_of_time` gate, we can bail early if the percentage is set to 100% or 0% and avoid a `rand` call.

---

Benchmarking by Claude, **iterations-per-second** so higher is better:

| Scenario | main | gate-shortcuts | Change |
|---|---|---|---|
| `enabled?`, no actor, off feature | 596,401 | 596,103 | within noise, no change |
| `enabled?`, no actor, fully-on feature | 971,738 | 967,336 | within noise |
| `enabled?`, 1 actor, off feature | 430,253 | 475,867 | **+11%** |
| `enabled?`, 8 actors, off feature | 224,266 | 281,032 | **+25%** |
| `enabled?`, 1 actor, percentage_of_actors=25 | 497,538 | 525,569 | **+6%** |
| `enabled?`, 1 actor, actor gate match | 672,020 | 669,894 | within noise |

**Allocations per call (measured via `GC.stat(:total_allocated_objects)` over 10k calls)**

| Scenario | main | gate-shortcuts |
|---|---|---|
| No actor, off feature | 16 | 16 |
| No actor, fully-on feature | 12 | 12 |
| 1 actor, off feature | 24 | **20** |
| 8 actors, off feature | 39 | **34** |
| 1 actor, percentage_of_actors=25 | 20 | **17** |
| 1 actor, actor gate match | 14 | 14 |

ruby 3.4.9 on macOS and an M5 Pro, Memory adapter, benchmark-ips. Both gate implementations were loaded into a single process and swapped in place between measurements, alternating which ran first each round, so machine drift affects both equally. 1.5s measurement + 0.5s warmup per report, median of 5 rounds.