### PR TITLE
Wrap `enabled?` actors in a single pass

### DIFF
--- a/lib/flipper/feature.rb
+++ b/lib/flipper/feature.rb
@@ -100,15 +100,7 @@ module Flipper
     #
     # Returns true if enabled, false if not.
     def enabled?(*actors)
-      actors = Array(actors).
-        # Avoids to_ary warning that happens when passing DelegateClass of an 
-        # ActiveRecord object and using flatten here. This is tested in 
-        # spec/flipper/model/active_record_spec.rb.
-        flat_map { |actor| actor.is_a?(Array) ? actor : [actor] }. 
-        # Allows null object pattern. See PR for more. https://github.com/flippercloud/flipper/pull/887
-        reject(&:nil?). 
-        map { |actor| Types::Actor.wrap(actor) }
-      actors = nil if actors.empty?
+      actors = wrap_actors(actors)
 
       # thing is left for backwards compatibility
       instrument(:enabled?, thing: actors&.first, actors: actors) do |payload|
@@ -434,6 +426,31 @@ module Flipper
     end
 
     private
+
+    # Private: Wrap the actors passed to enabled? in a single pass to avoid
+    # intermediate array allocations on the hot path. Arrays are flattened one
+    # level; the explicit is_a?(Array) check (instead of flatten) avoids the
+    # to_ary warning that happens when passing a DelegateClass of an
+    # ActiveRecord object. This is tested in
+    # spec/flipper/model/active_record_spec.rb. Nils are dropped to allow the
+    # null object pattern. See https://github.com/flippercloud/flipper/pull/887
+    #
+    # Returns an Array of Types::Actor instances or nil if no actors.
+    def wrap_actors(actors)
+      return nil if actors.empty?
+
+      wrapped = []
+      actors.each do |actor|
+        if actor.is_a?(Array)
+          actor.each do |nested_actor|
+            wrapped << Types::Actor.wrap(nested_actor) unless nested_actor.nil?
+          end
+        elsif !actor.nil?
+          wrapped << Types::Actor.wrap(actor)
+        end
+      end
+      wrapped.empty? ? nil : wrapped
+    end
 
     # Private: Instrument a feature operation.
     def instrument(operation, initial_payload = {})

--- a/spec/flipper/feature_spec.rb
+++ b/spec/flipper/feature_spec.rb
@@ -75,6 +75,12 @@ RSpec.describe Flipper::Feature do
         subject.disable
         expect(subject.enabled?(actors)).to be(false)
       end
+
+      it 'ignores nil actors in the array' do
+        subject.enable_actor actors.first
+        expect(subject.enabled?([actors.first, nil])).to be(true)
+        expect(subject.enabled?([nil])).to be(false)
+      end
     end
 
     context "for an object that implements .nil? == true" do


### PR DESCRIPTION
AI Disclosure: This was generated using Claude Code, w/ Fable 5. It was reviewed manually and tested by me to ensure correctness. This PR body was written by Claude (other than this initial intro).

`Feature#enabled?` normalized its actors with an `Array().flat_map.reject.map` chain, allocating 3–4 intermediate arrays on every feature check before any gate ran. This replaces the chain with a private `wrap_actors` method that flattens one level, drops nils, and wraps actors in a single loop. The empty case returns early, so actor-less checks — the most common call shape — skip the chain entirely.

## Behavior is unchanged

- The explicit `is_a?(Array)` check (instead of `flatten`) still avoids the `to_ary` warning for `DelegateClass`-wrapped ActiveRecord objects, covered by `spec/flipper/model/active_record_spec.rb`.
- Nils are still dropped to support the null object pattern (#887).
- One-level-only flattening is preserved: deeply nested arrays (`[actor, [actor]]`) raise the same `ArgumentError` as before.
- The instrumentation payload still gets `actors: nil` (not `[]`) when no actors are passed.

Verified by diffing the observable behavior of both revisions (result, instrumentation payload, and emitted warnings) across edge-case inputs — no actors, bare `nil`, arrays containing nils, mixed splat/array args, empty arrays, and `DelegateClass`-wrapped actors — with byte-identical output.

## Benchmarks

Ruby 3.4.9, arm64-darwin25, macOS with M5 Pro, Memory adapter, `benchmark-ips`:

| Scenario | Allocations per call | Throughput |
|---|---|---|
| no actor | 18 → 14 objects | 544k → 566k i/s (+4.1%) |
| 1 actor | 26 → 22 objects | 399k → 413k i/s (+3.6%) |
| 8 actors (array) | 33 → 30 objects | 238k → 243k i/s (+2.0%) |

Run-to-run variance was ±0.3–2%; an interleaved before/after rerun of the 1-actor case held the gap steady (~380k vs ~396k i/s).

Realistically this is a micro-optimization and only shows up as a significant perf improvement for the memory adapter, other adapter types won't have any noticeable difference.

## New spec

Nils passed directly to `enabled?` were already covered, but nils nested inside an actor array were not — removing the nested nil guard left the entire suite green. This adds a spec pinning that `enabled?([actor, nil])` ignores the nil and `enabled?([nil])` behaves like no actors, verified to fail if the guard regresses.
