### PR TITLE
Build ActiveRecord gate results in a single pass

### DIFF
--- a/lib/flipper/adapters/active_record.rb
+++ b/lib/flipper/adapters/active_record.rb
@@ -239,21 +239,28 @@ module Flipper
       end
 
       def result_for_gates(feature, gates)
+        # Bucket rows by gate key in one pass instead of re-scanning all rows
+        # for each of the feature's gates. Features with many enabled actors
+        # can have thousands of rows. Rows with a nil key come from the outer
+        # join in get_all for features with no gate values.
+        values_by_key = nil
+        gates&.each do |key, value|
+          next if key.nil?
+          values_by_key ||= {}
+          (values_by_key[key.to_sym] ||= []) << value
+        end
+
         result = {}
-        gates ||= []
         feature.gates.each do |gate|
+          values = values_by_key && values_by_key[gate.key]
           result[gate.key] =
             case gate.data_type
             when :boolean, :integer
-              if row = gates.detect { |key, value| !key.nil? && key.to_sym == gate.key }
-                row.last
-              end
+              values&.first
             when :json
-              if row = gates.detect { |key, value| !key.nil? && key.to_sym == gate.key }
-                Typecast.from_json(row.last)
-              end
+              Typecast.from_json(values.first) if values
             when :set
-              gates.select { |key, value| !key.nil? && key.to_sym == gate.key }.map(&:last).to_set
+              values ? values.to_set : Set.new
             else
               unsupported_data_type gate.data_type
             end

--- a/spec/flipper/adapters/active_record_spec.rb
+++ b/spec/flipper/adapters/active_record_spec.rb
@@ -78,6 +78,23 @@ RSpec.describe Flipper::Adapters::ActiveRecord do
           flipper.preload([:foo])
         end
 
+        it "ignores gate rows with unknown keys" do
+          flipper = Flipper.new(subject)
+          flipper.enable_actor(:foo, Flipper::Actor.new("User;1"))
+
+          Flipper::Adapters::ActiveRecord::Gate.create!(
+            feature_key: "foo",
+            key: "not_a_real_gate",
+            value: "junk",
+          )
+
+          expected = subject.default_config.merge(actors: Set["User;1"])
+          feature = flipper[:foo]
+          expect(subject.get(feature)).to eq(expected)
+          expect(subject.get_multi([feature])).to eq("foo" => expected)
+          expect(subject.get_all).to eq("foo" => expected)
+        end
+
         it 'should not poison wrapping transactions' do
           flipper = Flipper.new(subject)
 


### PR DESCRIPTION
AI Disclosure: This was generated using Claude Code, w/ Fable 5. It has been reviewed and tested by me, and I have validated the findings and confirmed their correctness, including by having Claude run a battery of tests to protect against regressions. The PR description was written mostly by Claude (excluding this intro).

`result_for_gates` re-scanned the full list of gate rows once per gate (up to 6 passes), calling `to_sym` on every row key each pass. Features with many enabled actors can have thousands of rows (though hopefully no one does this...), making `get`, `get_multi`, and `get_all` `O(rows * gates)`.

Bucket rows by gate key in one pass instead: `O(rows + gates)` with one `to_sym` per row.

Benchmarks (sqlite3 in-memory, macOS on an M5 Pro, Ruby 3.4.9, arm64):

  | Scenario | Before (i/s) | After (i/s) | Speedup | Before (allocs/call) | After (allocs/call) |
  |---|---:|---:|---:|---:|---:|
  | enabled? - small feature (1 boolean row) | 26,831 | 27,853 | +4% | 137 | 124 |
  | enabled? - feature with 2000 enabled actors | 543 | 819 | +51% | 12,630 | 12,371 |
  | preload_all - 10x200-actor features + the 2000-actor one | 335 | 539 | +61% | 20,570 | 20,409 |

Allocation counts barely move on the big scenarios because they are dominated by `pluck` materializing rows, but the CPU savings from eliminating the repeated scans are the main thing that helps here.