### PR TITLE
Return shared frozen default config from Memory adapter reads

### DIFF
--- a/lib/flipper/adapters/memory.rb
+++ b/lib/flipper/adapters/memory.rb
@@ -8,6 +8,10 @@ module Flipper
     class Memory
       include ::Flipper::Adapter
 
+      # Private: Shared frozen config for unknown features. Gate values
+      # returned by get are treated as read-only.
+      DEFAULT_CONFIG = default_config.each_value(&:freeze).freeze
+
       # Public
       def initialize(source = nil, threadsafe: true)
         @source = Typecast.features_hash(source)
@@ -41,14 +45,14 @@ module Flipper
 
       # Public
       def get(feature)
-        synchronize { @source[feature.key] } || default_config
+        synchronize { @source[feature.key] } || DEFAULT_CONFIG
       end
 
       def get_multi(features)
         synchronize do
           result = {}
           features.each do |feature|
-            result[feature.key] = @source[feature.key] || default_config
+            result[feature.key] = @source[feature.key] || DEFAULT_CONFIG
           end
           result
         end


### PR DESCRIPTION
AI Disclosure: This was generated using Claude Code w/ Fable 5. It was reviewed and tested by me for correctness. It does have one caveat, which is that gate values coming from `get` _must_ be treated as read-only. But that's how flipper does it everywhere already, and it'd be a bit silly to treat it otherwise, so I think that's a safe change? This only applies to the memory adapter regardless, it's mainly an optimization for test suites. This PR description was written partially by Claude (excluding this intro).

`get` and `get_multi` allocated a fresh `default_config` hash plus two sets on every read of a feature that was never `add`ed. Return a shared frozen config instead: 5 fewer allocations per check (22 -> 17 with an actor, 18 -> 13 without) and +18-24% ips for unknown-feature checks.

Gate values returned by `get` are read-only by contract; `add` and `clear` still build fresh hashes via `default_config` for mutation.

| Scenario (Memory adapter) | main | with change | Δ |
|---|---:|---:|---:|
| Unknown feature, with actor | 22 allocs / 434k i/s | 17 allocs / 514k i/s | +18% |
| Unknown feature, no actor | 18 allocs / 533k i/s | 13 allocs / 661k i/s | +24% |
| Known features | 16 allocs | 16 allocs | unchanged |