### PR TITLE
Add non-blocking Rails main entry to CI matrix

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,6 +6,8 @@ jobs:
     name: Test on ruby ${{ matrix.ruby }} and rails ${{ matrix.rails }}
     runs-on: ubuntu-latest
     timeout-minutes: 20
+    # rails main is an early-warning canary; failures don't block the build
+    continue-on-error: ${{ matrix.rails == 'main' }}
     services:
       redis:
         image: redis
@@ -74,8 +76,11 @@ jobs:
             rails: "6.0.0"
           - ruby: "3.3"
             rails: "6.1.0"
+        include:
+          - ruby: "3.3"
+            rails: "main"
     env:
-      SQLITE3_VERSION: ${{ matrix.rails == '8.0.0' && '2.1.0' || '1.4.1' }}
+      SQLITE3_VERSION: ${{ (matrix.rails == '8.0.0' || matrix.rails == 'main') && '2.1.0' || '1.4.1' }}
       REDIS_URL: redis://localhost:6379/0
       CI: true
       RAILS_VERSION: ${{ matrix.rails }}

--- a/Gemfile
+++ b/Gemfile
@@ -15,7 +15,11 @@ gem 'rspec', '~> 3.0'
 gem 'rack-test'
 gem 'rackup', '= 1.0.0'
 gem 'sqlite3', "~> #{ENV['SQLITE3_VERSION'] || '2.1.0'}"
-gem 'rails', "~> #{ENV['RAILS_VERSION'] || '8.0'}"
+if ENV['RAILS_VERSION'] == 'main'
+  gem 'rails', github: 'rails/rails', branch: 'main'
+else
+  gem 'rails', "~> #{ENV['RAILS_VERSION'] || '8.0'}"
+end
 gem 'minitest', '~> 5.18'
 gem 'minitest-documentation'
 gem 'pstore'


### PR DESCRIPTION
## Why

Rails main went keyword-only for `Arel::Table.new` (rails/rails#57021), which broke `get_all` in the ActiveRecord adapter. The fix landed in #1003, but CI had no way to catch the regression because the matrix only covers released Rails versions.

## What

- Adds a `ruby 3.3 / rails main` entry to the CI matrix via `include`, installing Rails from `rails/rails@main` (currently resolves to 8.2.0.alpha)
- `continue-on-error: ${{ matrix.rails == 'main' }}` makes it a non-blocking canary — edge Rails breakage annotates the run but doesn't fail the build
- Gemfile installs Rails from git when `RAILS_VERSION=main`, otherwise behaves exactly as before
- `SQLITE3_VERSION` uses 2.1.0 for main (same as 8.0.0)

Verified locally that `RAILS_VERSION=main bundle lock` resolves cleanly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)